### PR TITLE
fix(release): 修正安装器仓库地址为 NEDONION/mini-claw

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ MiniClaw 不是“把聊天框接到 Shell”——模型只提出 Tool Call，C
 ### 安装与启动
 
 ```bash
-git clone https://github.com/NEDONION/miniclaw.git
+git clone https://github.com/NEDONION/mini-claw.git
 cd miniclaw
 
 uv sync --extra dev --extra channels

--- a/README_EN.md
+++ b/README_EN.md
@@ -73,7 +73,7 @@ New installations and older configurations without `tools.mode` default to `auto
 ### Install and run
 
 ```bash
-git clone https://github.com/NEDONION/miniclaw.git
+git clone https://github.com/NEDONION/mini-claw.git
 cd miniclaw
 
 uv sync --extra dev --extra channels

--- a/docs/evals/releases/v0.1.0.md
+++ b/docs/evals/releases/v0.1.0.md
@@ -6,7 +6,7 @@
 
 | 字段 | 值 |
 | --- | --- |
-| Source commit | [`2a74e9e`](https://github.com/NEDONION/miniclaw/commit/2a74e9ecfeb828fd77beb260f5c04b4841477972) |
+| Source commit | [`2a74e9e`](https://github.com/NEDONION/mini-claw/commit/2a74e9ecfeb828fd77beb260f5c04b4841477972) |
 | Suite | `offline-v1` |
 | 运行时间 | 2026-08-08 00:47 CST |
 | Python | 3.13.5 |

--- a/docs/superpowers/plans/2026-08-09-one-line-install-and-release.md
+++ b/docs/superpowers/plans/2026-08-09-one-line-install-and-release.md
@@ -726,7 +726,7 @@ def test_tar_rejects_every_escaping_or_special_member(self) -> None:
 
 Also test short read, content-length mismatch, hash mismatch, redirect outside allowlist, credentials/query/fragment, timeout, interrupted `.part`, pre-existing target, case-colliding paths on macOS semantics, mode stripping, and no log body leakage.
 
-`tests/test_install_releases.py` covers fixed `v0.7.0`, stable latest redirect, bounded `api.github.com/repos/NEDONION/miniclaw/releases?per_page=20` dev discovery, draft exclusion, prerelease requirement, semver ordering, oversized/malformed API JSON and wrong repository/asset name. Installed downgrade/equal-version refusal is tested in Task 11/13 so a fresh machine may explicitly install an older supported Release. All HTTP responses use fakes.
+`tests/test_install_releases.py` covers fixed `v0.7.0`, stable latest redirect, bounded `api.github.com/repos/NEDONION/mini-claw/releases?per_page=20` dev discovery, draft exclusion, prerelease requirement, semver ordering, oversized/malformed API JSON and wrong repository/asset name. Installed downgrade/equal-version refusal is tested in Task 11/13 so a fresh machine may explicitly install an older supported Release. All HTTP responses use fakes.
 
 - [ ] **Step 2: Run RED**
 
@@ -762,9 +762,9 @@ def _safe_member_path(root: Path, name: str) -> Path:
     return target
 ```
 
-`resolve_release_source` maps explicit versions to `https://github.com/NEDONION/miniclaw/releases/download/v<version>/release-manifest.json`, stable to `https://github.com/NEDONION/miniclaw/releases/latest/download/release-manifest.json`, and dev to the bounded GitHub Releases API response's exact `release-manifest.json` browser-download URL. It rejects stable prereleases, dev drafts and repositories outside `NEDONION/miniclaw`.
+`resolve_release_source` maps explicit versions to `https://github.com/NEDONION/mini-claw/releases/download/v<version>/release-manifest.json`, stable to `https://github.com/NEDONION/mini-claw/releases/latest/download/release-manifest.json`, and dev to the bounded GitHub Releases API response's exact `release-manifest.json` browser-download URL. It rejects stable prereleases, dev drafts and repositories outside `NEDONION/mini-claw`.
 
-Use a redirect handler that revalidates every Location. The initial host allowlist is `github.com`, `api.github.com`, `files.pythonhosted.org`, `nodejs.org` and official Astral endpoints; only a request originating at `github.com/NEDONION/miniclaw/releases/` may redirect to HTTPS `release-assets.githubusercontent.com`. Stream into an `O_EXCL` `.part`, cap bytes before write, fsync, compare exact size/hash with `hmac.compare_digest`, then `os.replace`. For tar, first validate all headers and cumulative declared sizes, then reopen and copy only regular files/directories with a second actual-byte budget; create dirs 0700/files 0600 or executable 0700 only for manifest-declared executable paths; fsync and leave destination empty on failure.
+Use a redirect handler that revalidates every Location. The initial host allowlist is `github.com`, `api.github.com`, `files.pythonhosted.org`, `nodejs.org` and official Astral endpoints; only a request originating at `github.com/NEDONION/mini-claw/releases/` may redirect to HTTPS `release-assets.githubusercontent.com`. Stream into an `O_EXCL` `.part`, cap bytes before write, fsync, compare exact size/hash with `hmac.compare_digest`, then `os.replace`. For tar, first validate all headers and cumulative declared sizes, then reopen and copy only regular files/directories with a second actual-byte budget; create dirs 0700/files 0600 or executable 0700 only for manifest-declared executable paths; fsync and leave destination empty on failure.
 
 - [ ] **Step 4: Run GREEN**
 
@@ -1691,7 +1691,7 @@ README primary command is:
 
 ```bash
 curl -fsSL --proto '=https' --tlsv1.2 \
-  https://github.com/NEDONION/miniclaw/releases/latest/download/install.sh | bash
+  https://github.com/NEDONION/mini-claw/releases/latest/download/install.sh | bash
 ```
 
 Document interactive and `--no-onboard --no-service --json`, exact supported/unsupported matrix, sudo plan, Secret file, rootless/non-root boundary, service commands, update/rollback conflict, uninstall/purge semantics, diagnostics and source development using uv/pnpm. Architecture shows bootstrap → pyz → manifest → staging → smoke → current → service; product marks Gap complete only after evidence. Operations runbook contains draft promotion, PyPI Trusted Publisher, GHCR digest, rollback-conflict recovery and revocation.

--- a/docs/superpowers/specs/2026-08-09-one-line-install-and-release-design.md
+++ b/docs/superpowers/specs/2026-08-09-one-line-install-and-release-design.md
@@ -18,7 +18,7 @@ MiniClaw；安装过程不要求克隆仓库，不把 Secret 写进命令行、�
 
 ```bash
 curl -fsSL --proto '=https' --tlsv1.2 \
-  https://github.com/NEDONION/miniclaw/releases/latest/download/install.sh | bash
+  https://github.com/NEDONION/mini-claw/releases/latest/download/install.sh | bash
 ```
 
 “安装完成”不是只有 `miniclaw` 命令存在，而是必须同时满足：
@@ -218,7 +218,7 @@ zipapp 只能导入标准库和 `miniclaw.install` 同包模块，不能依赖�
 路径、`..`、symlink、hardlink、device 和目标目录逃逸，并在写入前执行 entry 数量与总字节预算。
 
 安装器调用外部程序必须传 argv 数组，不经过 shell 字符串。下载 URL 只来自已验证 manifest 中的
-`https://github.com/NEDONION/miniclaw/`、`https://files.pythonhosted.org/`、`https://nodejs.org/` 和 Astral uv
+`https://github.com/NEDONION/mini-claw/`、`https://files.pythonhosted.org/`、`https://nodejs.org/` 和 Astral uv
 官方 Release allowlist。
 
 ## 9. Release Manifest

--- a/release/manifest.schema.json
+++ b/release/manifest.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/NEDONION/miniclaw/releases/manifest.schema.json",
+  "$id": "https://github.com/NEDONION/mini-claw/releases/manifest.schema.json",
   "title": "MiniClaw Release Manifest v1",
   "type": "object",
   "additionalProperties": false,
@@ -119,13 +119,13 @@
       "properties": {
         "kind": {"enum": ["wheel", "sdist", "requirements", "node", "tui", "sandbox-image", "runtime-image", "installer", "sbom"]},
         "filename": {"type": "string", "pattern": "^(?!.*\\.\\.)[A-Za-z0-9][A-Za-z0-9._+-]{0,199}$"},
-        "url": {"type": "string", "pattern": "^https://github\\.com/NEDONION/miniclaw/releases/download/v(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?/(?!.*\\.\\.)[A-Za-z0-9][A-Za-z0-9._+-]{0,199}$"},
+        "url": {"type": "string", "pattern": "^https://github\\.com/NEDONION/mini-claw/releases/download/v(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?/(?!.*\\.\\.)[A-Za-z0-9][A-Za-z0-9._+-]{0,199}$"},
         "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
         "size": {"type": "integer", "minimum": 1, "maximum": 1073741824},
         "media_type": {"type": "string", "pattern": "^[a-z0-9][a-z0-9.+-]{0,63}/[a-z0-9][a-z0-9.+-]{0,127}$"},
         "platform": {"$ref": "#/$defs/platform"},
         "component_version": {"type": "string", "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\\+([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?$"},
-        "source_repository": {"enum": ["https://github.com/NEDONION/miniclaw", "https://github.com/nodejs/node"]},
+        "source_repository": {"enum": ["https://github.com/NEDONION/mini-claw", "https://github.com/nodejs/node"]},
         "license_ref": {"type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9.+-]{0,127}$"},
         "upstream_sha256": {
           "anyOf": [
@@ -142,7 +142,7 @@
             "url": {"pattern": "/miniclaw_agent-(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)(?:(?:a|b|rc)(?:0|[1-9][0-9]*))?-py3-none-any\\.whl$"},
             "media_type": {"const": "application/zip"},
             "platform": {"const": {"os": "any", "arch": "any"}},
-            "source_repository": {"const": "https://github.com/NEDONION/miniclaw"},
+            "source_repository": {"const": "https://github.com/NEDONION/mini-claw"},
             "upstream_sha256": {"const": null}
           }}
         },
@@ -153,7 +153,7 @@
             "url": {"pattern": "/miniclaw_agent-(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)(?:(?:a|b|rc)(?:0|[1-9][0-9]*))?\\.tar\\.gz$"},
             "media_type": {"const": "application/gzip"},
             "platform": {"const": {"os": "any", "arch": "any"}},
-            "source_repository": {"const": "https://github.com/NEDONION/miniclaw"},
+            "source_repository": {"const": "https://github.com/NEDONION/mini-claw"},
             "upstream_sha256": {"const": null}
           }}
         },
@@ -164,7 +164,7 @@
             "url": {"pattern": "/requirements-all\\.lock$"},
             "media_type": {"const": "text/plain"},
             "platform": {"const": {"os": "any", "arch": "any"}},
-            "source_repository": {"const": "https://github.com/NEDONION/miniclaw"},
+            "source_repository": {"const": "https://github.com/NEDONION/mini-claw"},
             "upstream_sha256": {"const": null}
           }}
         },
@@ -186,7 +186,7 @@
             "url": {"pattern": "/miniclaw-tui-[0-9A-Za-z.+-]+-(?:linux|macos)-(?:x86_64|arm64)\\.tar\\.gz$"},
             "media_type": {"const": "application/gzip"},
             "platform": {"not": {"const": {"os": "any", "arch": "any"}}},
-            "source_repository": {"const": "https://github.com/NEDONION/miniclaw"},
+            "source_repository": {"const": "https://github.com/NEDONION/mini-claw"},
             "upstream_sha256": {"const": null}
           }}
         },
@@ -197,7 +197,7 @@
             "url": {"pattern": "/[A-Za-z0-9][A-Za-z0-9._+-]{0,195}\\.txt$"},
             "media_type": {"const": "text/plain"},
             "platform": {"const": {"os": "any", "arch": "any"}},
-            "source_repository": {"const": "https://github.com/NEDONION/miniclaw"},
+            "source_repository": {"const": "https://github.com/NEDONION/mini-claw"},
             "upstream_sha256": {"const": null}
           }}
         },
@@ -208,7 +208,7 @@
             "url": {"pattern": "/miniclaw-installer\\.pyz$"},
             "media_type": {"const": "application/zip"},
             "platform": {"const": {"os": "any", "arch": "any"}},
-            "source_repository": {"const": "https://github.com/NEDONION/miniclaw"},
+            "source_repository": {"const": "https://github.com/NEDONION/mini-claw"},
             "upstream_sha256": {"const": null}
           }}
         },
@@ -219,7 +219,7 @@
             "url": {"pattern": "/[A-Za-z0-9][A-Za-z0-9._+-]{0,194}\\.json$"},
             "media_type": {"enum": ["application/vnd.cyclonedx+json", "application/spdx+json"]},
             "platform": {"const": {"os": "any", "arch": "any"}},
-            "source_repository": {"const": "https://github.com/NEDONION/miniclaw"},
+            "source_repository": {"const": "https://github.com/NEDONION/mini-claw"},
             "upstream_sha256": {"const": null}
           }}
         }

--- a/src/miniclaw/install/artifacts.py
+++ b/src/miniclaw/install/artifacts.py
@@ -28,8 +28,8 @@ _MAX_REDIRECTS = 5
 _MAX_ENTRIES = 20_000
 _MAX_BYTES = 1_073_741_824
 _REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
-_RELEASES_API_URL = "https://api.github.com/repos/NEDONION/miniclaw/releases?per_page=20"
-_GITHUB_RELEASE_PREFIX = "/NEDONION/miniclaw/releases/"
+_RELEASES_API_URL = "https://api.github.com/repos/NEDONION/mini-claw/releases?per_page=20"
+_GITHUB_RELEASE_PREFIX = "/NEDONION/mini-claw/releases/"
 
 
 class _Response(Protocol):

--- a/src/miniclaw/install/models.py
+++ b/src/miniclaw/install/models.py
@@ -59,7 +59,7 @@ _SUPPORTED_PLATFORMS = {
     ("macos", "x86_64"),
     ("macos", "arm64"),
 }
-_MINICLAW_REPOSITORY = "https://github.com/NEDONION/miniclaw"
+_MINICLAW_REPOSITORY = "https://github.com/NEDONION/mini-claw"
 _NODE_REPOSITORY = "https://github.com/nodejs/node"
 _SOURCE_REPOSITORIES = {_MINICLAW_REPOSITORY, _NODE_REPOSITORY}
 _ARTIFACT_RULES = {
@@ -523,11 +523,11 @@ class ReleaseManifest:
 
     def _validate_release_urls(self) -> None:
         """把 MiniClaw GitHub asset tag 绑定到 manifest 自身版本。"""
-        expected = f"/NEDONION/miniclaw/releases/download/v{self.version}/"
+        expected = f"/NEDONION/mini-claw/releases/download/v{self.version}/"
         for artifact in self.artifacts:
             parts = urlsplit(artifact.url)
             if parts.hostname == "github.com" and parts.path.startswith(
-                "/NEDONION/miniclaw/"
+                "/NEDONION/mini-claw/"
             ):
                 if not parts.path.startswith(expected):
                     _invalid("artifacts.url")
@@ -1131,7 +1131,7 @@ def _validate_artifact_url(value: object) -> None:
     if (
         parts.hostname != "github.com"
         or len(segments) != 7
-        or segments[1:5] != ["NEDONION", "miniclaw", "releases", "download"]
+        or segments[1:5] != ["NEDONION", "mini-claw", "releases", "download"]
         or any(segment in {"", ".", ".."} for segment in segments[5:])
     ):
         _invalid("artifacts.url")

--- a/src/miniclaw/install/releases.py
+++ b/src/miniclaw/install/releases.py
@@ -12,7 +12,7 @@ from miniclaw.install.models import InstallError, _parse_semver
 
 _API_BYTES = 1_048_576
 _API_ROWS = 20
-_API_URL = "https://api.github.com/repos/NEDONION/miniclaw/releases?per_page=20"
+_API_URL = "https://api.github.com/repos/NEDONION/mini-claw/releases?per_page=20"
 _HASH = re.compile(r"^[0-9a-f]{64}$")
 _MAX_VERSION_CHARS = 128
 _MAX_NUMERIC_IDENTIFIER_DIGITS = 18
@@ -45,7 +45,7 @@ class ReleaseSource:
             if self.channel != "stable":
                 _invalid()
             expected_url = (
-                "https://github.com/NEDONION/miniclaw/releases/latest/download/"
+                "https://github.com/NEDONION/mini-claw/releases/latest/download/"
                 "release-manifest.json"
             )
         else:
@@ -56,7 +56,7 @@ class ReleaseSource:
             ):
                 _invalid()
             expected_url = (
-                "https://github.com/NEDONION/miniclaw/releases/download/"
+                "https://github.com/NEDONION/mini-claw/releases/download/"
                 f"v{self.requested_version}/release-manifest.json"
             )
         if type(self.manifest_url) is not str or self.manifest_url != expected_url:
@@ -95,7 +95,7 @@ def resolve_release_source(
             channel,
             version,
             (
-                "https://github.com/NEDONION/miniclaw/releases/download/"
+                "https://github.com/NEDONION/mini-claw/releases/download/"
                 f"v{version}/release-manifest.json"
             ),
             None,
@@ -104,7 +104,7 @@ def resolve_release_source(
         return ReleaseSource(
             "stable",
             None,
-            "https://github.com/NEDONION/miniclaw/releases/latest/download/release-manifest.json",
+            "https://github.com/NEDONION/mini-claw/releases/latest/download/release-manifest.json",
             None,
         )
     data = _read_bounded_url(
@@ -181,7 +181,7 @@ def _parse_candidate(row: object) -> tuple[str, str] | None:
         _invalid()
     if draft or not prerelease_flag:
         return None
-    expected_html = f"https://github.com/NEDONION/miniclaw/releases/tag/{tag}"
+    expected_html = f"https://github.com/NEDONION/mini-claw/releases/tag/{tag}"
     if type(row["html_url"]) is not str or row["html_url"] != expected_html:
         _invalid()
     assets = row["assets"]
@@ -197,7 +197,7 @@ def _parse_candidate(row: object) -> tuple[str, str] | None:
         _invalid()
     url = manifests[0]["browser_download_url"]
     expected_url = (
-        "https://github.com/NEDONION/miniclaw/releases/download/"
+        "https://github.com/NEDONION/mini-claw/releases/download/"
         f"{tag}/release-manifest.json"
     )
     if type(url) is not str or url != expected_url:

--- a/tests/install/manifest_v1.json
+++ b/tests/install/manifest_v1.json
@@ -15,20 +15,20 @@
     {
       "kind": "wheel",
       "filename": "miniclaw_agent-0.7.0-py3-none-any.whl",
-      "url": "https://github.com/NEDONION/miniclaw/releases/download/v0.7.0/miniclaw_agent-0.7.0-py3-none-any.whl",
+      "url": "https://github.com/NEDONION/mini-claw/releases/download/v0.7.0/miniclaw_agent-0.7.0-py3-none-any.whl",
       "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       "size": 123456,
       "media_type": "application/zip",
       "platform": {"os": "any", "arch": "any"},
       "component_version": "0.7.0",
-      "source_repository": "https://github.com/NEDONION/miniclaw",
+      "source_repository": "https://github.com/NEDONION/mini-claw",
       "license_ref": "MIT",
       "upstream_sha256": null
     },
     {
       "kind": "node",
       "filename": "miniclaw-node-24.18.0-linux-x86_64.tar.gz",
-      "url": "https://github.com/NEDONION/miniclaw/releases/download/v0.7.0/miniclaw-node-24.18.0-linux-x86_64.tar.gz",
+      "url": "https://github.com/NEDONION/mini-claw/releases/download/v0.7.0/miniclaw-node-24.18.0-linux-x86_64.tar.gz",
       "sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
       "size": 555555,
       "media_type": "application/gzip",
@@ -41,13 +41,13 @@
     {
       "kind": "tui",
       "filename": "miniclaw-tui-0.7.0-linux-x86_64.tar.gz",
-      "url": "https://github.com/NEDONION/miniclaw/releases/download/v0.7.0/miniclaw-tui-0.7.0-linux-x86_64.tar.gz",
+      "url": "https://github.com/NEDONION/mini-claw/releases/download/v0.7.0/miniclaw-tui-0.7.0-linux-x86_64.tar.gz",
       "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
       "size": 654321,
       "media_type": "application/gzip",
       "platform": {"os": "linux", "arch": "x86_64"},
       "component_version": "0.7.0",
-      "source_repository": "https://github.com/NEDONION/miniclaw",
+      "source_repository": "https://github.com/NEDONION/mini-claw",
       "license_ref": "MIT",
       "upstream_sha256": null
     }

--- a/tests/test_install_artifacts.py
+++ b/tests/test_install_artifacts.py
@@ -99,7 +99,7 @@ class InstallArtifactTests(unittest.TestCase):
             kind="tui",
             filename="miniclaw-tui-0.7.0-linux-x86_64.tar.gz",
             url=(
-                "https://github.com/NEDONION/miniclaw/releases/download/v0.7.0/"
+                "https://github.com/NEDONION/mini-claw/releases/download/v0.7.0/"
                 "miniclaw-tui-0.7.0-linux-x86_64.tar.gz"
             ),
             sha256=sha256 or hashlib.sha256(body).hexdigest(),
@@ -107,7 +107,7 @@ class InstallArtifactTests(unittest.TestCase):
             media_type="application/gzip",
             platform=PlatformKey("linux", "x86_64"),
             component_version="0.7.0",
-            source_repository="https://github.com/NEDONION/miniclaw",
+            source_repository="https://github.com/NEDONION/mini-claw",
             license_ref="MIT",
             upstream_sha256=None,
         )
@@ -675,7 +675,7 @@ class InstallArtifactTests(unittest.TestCase):
                         status=302,
                         headers={
                             "Location": (
-                                "https://github.com/NEDONION/miniclaw/releases/download/"
+                                "https://github.com/NEDONION/mini-claw/releases/download/"
                                 "v0.7.0/next"
                             )
                         },

--- a/tests/test_install_models.py
+++ b/tests/test_install_models.py
@@ -53,7 +53,7 @@ class InstallModelsTest(unittest.TestCase):
 
     def release_url(self, version: str, filename: str) -> str:
         """返回 fixture 使用的 immutable MiniClaw Release asset URL。"""
-        return f"https://github.com/NEDONION/miniclaw/releases/download/v{version}/{filename}"
+        return f"https://github.com/NEDONION/mini-claw/releases/download/v{version}/{filename}"
 
     def request(self, **changes: object) -> InstallRequest:
         """构造一个不含 Secret 值的有效安装请求。"""
@@ -179,10 +179,10 @@ class InstallModelsTest(unittest.TestCase):
     def test_manifest_rejects_untrusted_urls_and_repositories(self) -> None:
         """artifact URL 必须是无附加信息的 allowlisted HTTPS 来源。"""
         cases = (
-            "http://github.com/NEDONION/miniclaw/releases/download/v0.7.0/a.whl",
-            "https://user@github.com/NEDONION/miniclaw/releases/download/v0.7.0/a.whl",
-            "https://github.com/NEDONION/miniclaw/releases/download/v0.7.0/a.whl?x=1",
-            "https://github.com/NEDONION/miniclaw/releases/download/v0.7.0/a.whl#x",
+            "http://github.com/NEDONION/mini-claw/releases/download/v0.7.0/a.whl",
+            "https://user@github.com/NEDONION/mini-claw/releases/download/v0.7.0/a.whl",
+            "https://github.com/NEDONION/mini-claw/releases/download/v0.7.0/a.whl?x=1",
+            "https://github.com/NEDONION/mini-claw/releases/download/v0.7.0/a.whl#x",
             "https://github.com/OTHER/miniclaw/releases/download/v0.7.0/a.whl",
             "https://github.com/NEDONION/other/releases/download/v0.7.0/a.whl",
         )
@@ -237,7 +237,7 @@ class InstallModelsTest(unittest.TestCase):
                 "filename": wheel["filename"],
                 "url": node["url"].replace(node["filename"], wheel["filename"]),
             },
-            {**node, "source_repository": "https://github.com/NEDONION/miniclaw"},
+            {**node, "source_repository": "https://github.com/NEDONION/mini-claw"},
             {**node, "platform": {"os": "any", "arch": "any"}},
             {**node, "media_type": "application/zip"},
             {**node, "upstream_sha256": None},
@@ -572,7 +572,7 @@ class InstallModelsTest(unittest.TestCase):
 
     def test_parser_error_keeps_code_and_field_without_raw_value(self) -> None:
         """parser 错误只输出稳定 code 与字段名，不回显恶意字段值。"""
-        raw_url = "https://user:TOPSECRET@github.com/NEDONION/miniclaw/releases/raw"
+        raw_url = "https://user:TOPSECRET@github.com/NEDONION/mini-claw/releases/raw"
 
         with self.assertRaises(InstallError) as caught:
             ReleaseManifest.from_bytes(self.artifact_mutation(url=raw_url))

--- a/tests/test_install_orchestrator.py
+++ b/tests/test_install_orchestrator.py
@@ -581,7 +581,7 @@ class TargetHandoffTests(unittest.TestCase):
                 "kind": "installer",
                 "filename": "miniclaw-installer.pyz",
                 "url": (
-                    "https://github.com/NEDONION/miniclaw/releases/download/"
+                    "https://github.com/NEDONION/mini-claw/releases/download/"
                     "v0.7.0/miniclaw-installer.pyz"
                 ),
                 "sha256": hashlib.sha256(installer).hexdigest(),
@@ -589,7 +589,7 @@ class TargetHandoffTests(unittest.TestCase):
                 "media_type": "application/zip",
                 "platform": {"os": "any", "arch": "any"},
                 "component_version": "0.7.0",
-                "source_repository": "https://github.com/NEDONION/miniclaw",
+                "source_repository": "https://github.com/NEDONION/mini-claw",
                 "license_ref": "MIT",
                 "upstream_sha256": None,
             }
@@ -915,7 +915,7 @@ class DependencyPreparationTests(unittest.TestCase):
                 "kind": "sandbox-image",
                 "filename": "miniclaw-sandbox-image-0.7.0.txt",
                 "url": (
-                    "https://github.com/NEDONION/miniclaw/releases/download/"
+                    "https://github.com/NEDONION/mini-claw/releases/download/"
                     "v0.7.0/miniclaw-sandbox-image-0.7.0.txt"
                 ),
                 "sha256": hashlib.sha256(self.image).hexdigest(),
@@ -923,7 +923,7 @@ class DependencyPreparationTests(unittest.TestCase):
                 "media_type": "text/plain",
                 "platform": {"os": "any", "arch": "any"},
                 "component_version": "0.7.0",
-                "source_repository": "https://github.com/NEDONION/miniclaw",
+                "source_repository": "https://github.com/NEDONION/mini-claw",
                 "license_ref": "MIT",
                 "upstream_sha256": None,
             }

--- a/tests/test_install_platforms.py
+++ b/tests/test_install_platforms.py
@@ -142,14 +142,14 @@ class InstallPlatformsTest(unittest.TestCase):
                     "kind": kind,
                     "filename": path.name,
                     "url": (
-                        f"https://github.com/NEDONION/miniclaw/releases/download/v0.7.0/{path.name}"
+                        f"https://github.com/NEDONION/mini-claw/releases/download/v0.7.0/{path.name}"
                     ),
                     "sha256": hashlib.sha256(body).hexdigest(),
                     "size": len(body),
                     "media_type": media_type,
                     "platform": {"os": "any", "arch": "any"},
                     "component_version": "0.7.0",
-                    "source_repository": "https://github.com/NEDONION/miniclaw",
+                    "source_repository": "https://github.com/NEDONION/mini-claw",
                     "license_ref": "MIT",
                     "upstream_sha256": None,
                 }

--- a/tests/test_install_releases.py
+++ b/tests/test_install_releases.py
@@ -57,12 +57,12 @@ def release(tag: str, *, draft: bool = False, prerelease: bool = True) -> dict[s
         "tag_name": f"v{tag}",
         "draft": draft,
         "prerelease": prerelease,
-        "html_url": f"https://github.com/NEDONION/miniclaw/releases/tag/v{tag}",
+        "html_url": f"https://github.com/NEDONION/mini-claw/releases/tag/v{tag}",
         "assets": [
             {
                 "name": "release-manifest.json",
                 "browser_download_url": (
-                    "https://github.com/NEDONION/miniclaw/releases/download/"
+                    "https://github.com/NEDONION/mini-claw/releases/download/"
                     f"v{tag}/release-manifest.json"
                 ),
             }
@@ -86,7 +86,7 @@ class InstallReleaseTests(unittest.TestCase):
                 "stable",
                 "0.7.0",
                 (
-                    "https://github.com/NEDONION/miniclaw/releases/download/"
+                    "https://github.com/NEDONION/mini-claw/releases/download/"
                     "v0.7.0/release-manifest.json"
                 ),
                 None,
@@ -94,7 +94,7 @@ class InstallReleaseTests(unittest.TestCase):
         )
         self.assertEqual(
             stable.manifest_url,
-            "https://github.com/NEDONION/miniclaw/releases/latest/download/release-manifest.json",
+            "https://github.com/NEDONION/mini-claw/releases/latest/download/release-manifest.json",
         )
         self.assertEqual(opener.urls, [])
 
@@ -144,14 +144,14 @@ class InstallReleaseTests(unittest.TestCase):
 
         self.assertEqual(
             opener.urls,
-            ["https://api.github.com/repos/NEDONION/miniclaw/releases?per_page=20"],
+            ["https://api.github.com/repos/NEDONION/mini-claw/releases?per_page=20"],
         )
         self.assertEqual(source.channel, "dev")
         self.assertEqual(source.requested_version, "0.8.0-rc.10")
         self.assertEqual(
             source.manifest_url,
             (
-                "https://github.com/NEDONION/miniclaw/releases/download/"
+                "https://github.com/NEDONION/mini-claw/releases/download/"
                 "v0.8.0-rc.10/release-manifest.json"
             ),
         )
@@ -214,9 +214,9 @@ class InstallReleaseTests(unittest.TestCase):
         """API origin 不得借 redirect 获得 asset host 权限或携带不可信 URL parts。"""
         locations = (
             "https://release-assets.githubusercontent.com/api-confusion",
-            "https://user:pass@api.github.com/repos/NEDONION/miniclaw/releases?per_page=20",
-            "https://api.github.com/repos/NEDONION/miniclaw/releases?per_page=19",
-            "https://api.github.com/repos/NEDONION/miniclaw/releases?per_page=20#fragment",
+            "https://user:pass@api.github.com/repos/NEDONION/mini-claw/releases?per_page=20",
+            "https://api.github.com/repos/NEDONION/mini-claw/releases?per_page=19",
+            "https://api.github.com/repos/NEDONION/mini-claw/releases?per_page=20#fragment",
         )
         for location in locations:
             with self.subTest(location=location), self.assertRaises(InstallError) as caught:
@@ -237,7 +237,7 @@ class InstallReleaseTests(unittest.TestCase):
     def test_release_source_constructor_rejects_untrusted_fields(self) -> None:
         """调用方不能绕过 resolver 构造任意 manifest URL 或 hash。"""
         latest = (
-            "https://github.com/NEDONION/miniclaw/releases/latest/download/"
+            "https://github.com/NEDONION/mini-claw/releases/latest/download/"
             "release-manifest.json"
         )
         for values in (

--- a/tests/test_install_runtime.py
+++ b/tests/test_install_runtime.py
@@ -322,7 +322,7 @@ class InstallRuntimeTests(unittest.TestCase):
                     artifact,
                     filename=filename,
                     url=(
-                        "https://github.com/NEDONION/miniclaw/releases/"
+                        "https://github.com/NEDONION/mini-claw/releases/"
                         f"download/v{version}/{filename}"
                     ),
                     sha256=sha256,
@@ -354,7 +354,7 @@ class InstallRuntimeTests(unittest.TestCase):
         return Artifact(
             kind=kind,  # type: ignore[arg-type]
             filename=filename,
-            url=f"https://github.com/NEDONION/miniclaw/releases/download/v0.7.0/{filename}",
+            url=f"https://github.com/NEDONION/mini-claw/releases/download/v0.7.0/{filename}",
             sha256=value,
             size=path.stat().st_size if path.is_file() else 1,
             media_type={
@@ -369,7 +369,7 @@ class InstallRuntimeTests(unittest.TestCase):
             source_repository=(
                 "https://github.com/nodejs/node"
                 if is_node
-                else "https://github.com/NEDONION/miniclaw"
+                else "https://github.com/NEDONION/mini-claw"
             ),
             license_ref="MIT",
             upstream_sha256="e" * 64 if is_node else None,

--- a/website/content/docs/channels.en.mdx
+++ b/website/content/docs/channels.en.mdx
@@ -28,4 +28,4 @@ and stability, not platform networking, permissions, callback configuration, or 
 > Never rewrite Implementation PASS as Live PASS. Before deployment, inspect current release evidence for
 > the target platform's real-platform Live Gate and record any remaining validation explicitly.
 
-The source scenarios live under [evals](https://github.com/NEDONION/miniclaw/tree/main/evals).
+The source scenarios live under [evals](https://github.com/NEDONION/mini-claw/tree/main/evals).

--- a/website/content/docs/channels.mdx
+++ b/website/content/docs/channels.mdx
@@ -28,4 +28,4 @@ Channel cases。fake SDK 与本地 soak 验证实现语义和稳定性，但不�
 > Implementation PASS 不应写成 Live PASS。部署前请查看当前发布证据，确认目标平台的真实平台
 > Live Gate 是否已经完成；未完成时应明确记录剩余验证。
 
-场景源文件位于 [evals](https://github.com/NEDONION/miniclaw/tree/main/evals)。
+场景源文件位于 [evals](https://github.com/NEDONION/mini-claw/tree/main/evals)。

--- a/website/content/docs/getting-started.en.mdx
+++ b/website/content/docs/getting-started.en.mdx
@@ -13,7 +13,7 @@ description: Install MiniClaw from source, initialize it, run Doctor, and launch
 ## Run from source
 
 ```bash
-git clone https://github.com/NEDONION/miniclaw.git
+git clone https://github.com/NEDONION/mini-claw.git
 cd miniclaw
 uv sync --extra dev --extra channels
 pnpm --dir tui install
@@ -38,5 +38,5 @@ configuration. After Doctor passes, `uv run miniclaw` launches the primary TUI.
 > platform. This makes it easier to separate Core, Provider, and Channel Transport issues.
 
 Next, read [Runtime](/en/docs/runtime) and [Security boundaries](/en/docs/security). Development,
-test, and release commands remain authoritative in the repository [README](https://github.com/NEDONION/miniclaw#readme)
+test, and release commands remain authoritative in the repository [README](https://github.com/NEDONION/mini-claw#readme)
 and `pyproject.toml`.

--- a/website/content/docs/getting-started.mdx
+++ b/website/content/docs/getting-started.mdx
@@ -13,7 +13,7 @@ description: 从源码安装 MiniClaw，完成初始化、Doctor 检查并启动
 ## 从源码运行
 
 ```bash
-git clone https://github.com/NEDONION/miniclaw.git
+git clone https://github.com/NEDONION/mini-claw.git
 cd miniclaw
 uv sync --extra dev --extra channels
 pnpm --dir tui install
@@ -38,4 +38,4 @@ API Key、App Secret 或 Token 提交到 Git。
 > Agent Core、Provider 还是某个 Channel Transport。
 
 继续阅读[运行时](/docs/runtime)和[安全边界](/docs/security)。开发、测试与发布命令以仓库
-[README](https://github.com/NEDONION/miniclaw#readme) 和 `pyproject.toml` 为准。
+[README](https://github.com/NEDONION/mini-claw#readme) 和 `pyproject.toml` 为准。

--- a/website/content/docs/index.en.mdx
+++ b/website/content/docs/index.en.mdx
@@ -29,6 +29,6 @@ MiniClaw currently exposes four surfaces—TUI, Feishu, Telegram, and Discord—
 
 These docs stay focused on users. The complete scope, architecture, and evaluation evidence live on GitHub:
 
-- [Product requirements](https://github.com/NEDONION/miniclaw/blob/main/docs/product/20260807_%E4%BA%A7%E5%93%81%E9%9C%80%E6%B1%82%E6%96%87%E6%A1%A3.md)
-- [System architecture](https://github.com/NEDONION/miniclaw/blob/main/docs/architecture/20260807_%E7%B3%BB%E7%BB%9F%E6%9E%B6%E6%9E%84.md)
-- [Versioned evaluation scenarios](https://github.com/NEDONION/miniclaw/tree/main/evals)
+- [Product requirements](https://github.com/NEDONION/mini-claw/blob/main/docs/product/20260807_%E4%BA%A7%E5%93%81%E9%9C%80%E6%B1%82%E6%96%87%E6%A1%A3.md)
+- [System architecture](https://github.com/NEDONION/mini-claw/blob/main/docs/architecture/20260807_%E7%B3%BB%E7%BB%9F%E6%9E%B6%E6%9E%84.md)
+- [Versioned evaluation scenarios](https://github.com/NEDONION/mini-claw/tree/main/evals)

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -29,6 +29,6 @@ Channel cases 和 15 条 versioned Automation cases。Automation 默认关闭。
 
 用户文档只保留上手所需内容。更完整的范围、架构与评测证据位于 GitHub：
 
-- [产品需求文档](https://github.com/NEDONION/miniclaw/blob/main/docs/product/20260807_%E4%BA%A7%E5%93%81%E9%9C%80%E6%B1%82%E6%96%87%E6%A1%A3.md)
-- [系统架构](https://github.com/NEDONION/miniclaw/blob/main/docs/architecture/20260807_%E7%B3%BB%E7%BB%9F%E6%9E%B6%E6%9E%84.md)
-- [版本化评测场景](https://github.com/NEDONION/miniclaw/tree/main/evals)
+- [产品需求文档](https://github.com/NEDONION/mini-claw/blob/main/docs/product/20260807_%E4%BA%A7%E5%93%81%E9%9C%80%E6%B1%82%E6%96%87%E6%A1%A3.md)
+- [系统架构](https://github.com/NEDONION/mini-claw/blob/main/docs/architecture/20260807_%E7%B3%BB%E7%BB%9F%E6%9E%B6%E6%9E%84.md)
+- [版本化评测场景](https://github.com/NEDONION/mini-claw/tree/main/evals)

--- a/website/content/docs/memory.en.mdx
+++ b/website/content/docs/memory.en.mdx
@@ -26,4 +26,4 @@ rebuildable from the source of truth.
 - Cross-channel sharing only occurs inside the same Owner context.
 - Correcting or deleting a durable fact should rebuild related projections.
 
-See the [system architecture](https://github.com/NEDONION/miniclaw/blob/main/docs/architecture/20260807_%E7%B3%BB%E7%BB%9F%E6%9E%B6%E6%9E%84.md) for deeper data responsibilities.
+See the [system architecture](https://github.com/NEDONION/mini-claw/blob/main/docs/architecture/20260807_%E7%B3%BB%E7%BB%9F%E6%9E%B6%E6%9E%84.md) for deeper data responsibilities.

--- a/website/content/docs/memory.mdx
+++ b/website/content/docs/memory.mdx
@@ -25,4 +25,4 @@ SQLite 保存结构化 control plane 与可重建投影。它帮助检索、关�
 - 跨渠道共享只发生在同一个 Owner 上下文内。
 - 删除或修正长期事实时，应同步重建相关投影。
 
-更深入的数据职责见[系统架构](https://github.com/NEDONION/miniclaw/blob/main/docs/architecture/20260807_%E7%B3%BB%E7%BB%9F%E6%9E%B6%E6%9E%84.md)。
+更深入的数据职责见[系统架构](https://github.com/NEDONION/mini-claw/blob/main/docs/architecture/20260807_%E7%B3%BB%E7%BB%9F%E6%9E%B6%E6%9E%84.md)。

--- a/website/content/docs/runtime.en.mdx
+++ b/website/content/docs/runtime.en.mdx
@@ -38,4 +38,4 @@ not own Channel identity, Workspace authorization, or Tool safety policy.
 4. When required, Approval binds the exact parameters.
 5. The Tool acts and returns the result to the original conversation.
 
-See the [system architecture](https://github.com/NEDONION/miniclaw/blob/main/docs/architecture/20260807_%E7%B3%BB%E7%BB%9F%E6%9E%B6%E6%9E%84.md) for module responsibilities.
+See the [system architecture](https://github.com/NEDONION/mini-claw/blob/main/docs/architecture/20260807_%E7%B3%BB%E7%BB%9F%E6%9E%B6%E6%9E%84.md) for module responsibilities.

--- a/website/content/docs/runtime.mdx
+++ b/website/content/docs/runtime.mdx
@@ -36,4 +36,4 @@ Workspace 授权或 Tool 安全策略。
 4. 需要时生成绑定具体参数的 Approval。
 5. Tool 执行，结果回到原会话。
 
-详细模块职责见[系统架构](https://github.com/NEDONION/miniclaw/blob/main/docs/architecture/20260807_%E7%B3%BB%E7%BB%9F%E6%9E%B6%E6%9E%84.md)。
+详细模块职责见[系统架构](https://github.com/NEDONION/mini-claw/blob/main/docs/architecture/20260807_%E7%B3%BB%E7%BB%9F%E6%9E%B6%E6%9E%84.md)。

--- a/website/content/docs/security.en.mdx
+++ b/website/content/docs/security.en.mdx
@@ -36,4 +36,4 @@ prompts, ordinary logs, and Memory, and should never appear in screenshots or is
 > When a hard boundary rejects an action, change the requested scope or configuration. Do not remove checks,
 > weaken assertions, or bypass Policy.
 
-The repository [architecture](https://github.com/NEDONION/miniclaw/blob/main/docs/architecture/20260807_%E7%B3%BB%E7%BB%9F%E6%9E%B6%E6%9E%84.md) and tests remain authoritative.
+The repository [architecture](https://github.com/NEDONION/mini-claw/blob/main/docs/architecture/20260807_%E7%B3%BB%E7%BB%9F%E6%9E%B6%E6%9E%84.md) and tests remain authoritative.

--- a/website/content/docs/security.mdx
+++ b/website/content/docs/security.mdx
@@ -34,4 +34,4 @@ Memory，也不应出现在截图和问题报告中。
 >
 > 如果某个动作被硬拒绝，应修改请求范围或配置，而不是删除校验、放宽断言或绕开 Policy。
 
-完整安全决策以仓库[架构文档](https://github.com/NEDONION/miniclaw/blob/main/docs/architecture/20260807_%E7%B3%BB%E7%BB%9F%E6%9E%B6%E6%9E%84.md)和测试为准。
+完整安全决策以仓库[架构文档](https://github.com/NEDONION/mini-claw/blob/main/docs/architecture/20260807_%E7%B3%BB%E7%BB%9F%E6%9E%B6%E6%9E%84.md)和测试为准。

--- a/website/src/content-data/project-facts.json
+++ b/website/src/content-data/project-facts.json
@@ -20,16 +20,16 @@
     "TOOL_EXECUTION",
     "RESULT_DELIVERED"
   ],
-  "install": "git clone https://github.com/NEDONION/miniclaw.git\ncd miniclaw\nuv sync --extra dev --extra channels\npnpm --dir tui install\npnpm --dir tui build\ncp .env.example .env\nuv run miniclaw init\nuv run miniclaw doctor\nuv run miniclaw",
+  "install": "git clone https://github.com/NEDONION/mini-claw.git\ncd miniclaw\nuv sync --extra dev --extra channels\npnpm --dir tui install\npnpm --dir tui build\ncp .env.example .env\nuv run miniclaw init\nuv run miniclaw doctor\nuv run miniclaw",
   "status": {
     "automationDefault": false,
     "implementationPassIsLivePass": false
   },
   "links": {
-    "github": "https://github.com/NEDONION/miniclaw",
-    "issues": "https://github.com/NEDONION/miniclaw/issues",
-    "product": "https://github.com/NEDONION/miniclaw/blob/main/docs/product/20260807_%E4%BA%A7%E5%93%81%E9%9C%80%E6%B1%82%E6%96%87%E6%A1%A3.md",
-    "architecture": "https://github.com/NEDONION/miniclaw/blob/main/docs/architecture/20260807_%E7%B3%BB%E7%BB%9F%E6%9E%B6%E6%9E%84.md",
-    "evaluation": "https://github.com/NEDONION/miniclaw/tree/main/evals"
+    "github": "https://github.com/NEDONION/mini-claw",
+    "issues": "https://github.com/NEDONION/mini-claw/issues",
+    "product": "https://github.com/NEDONION/mini-claw/blob/main/docs/product/20260807_%E4%BA%A7%E5%93%81%E9%9C%80%E6%B1%82%E6%96%87%E6%A1%A3.md",
+    "architecture": "https://github.com/NEDONION/mini-claw/blob/main/docs/architecture/20260807_%E7%B3%BB%E7%BB%9F%E6%9E%B6%E6%9E%84.md",
+    "evaluation": "https://github.com/NEDONION/mini-claw/tree/main/evals"
   }
 }

--- a/website/src/content/site.ts
+++ b/website/src/content/site.ts
@@ -124,7 +124,7 @@ export const siteFacts = {
     'RESULT_DELIVERED',
   ],
   install: [
-    'git clone https://github.com/NEDONION/miniclaw.git',
+    'git clone https://github.com/NEDONION/mini-claw.git',
     'cd miniclaw',
     'uv sync --extra dev --extra channels',
     'pnpm --dir tui install',
@@ -139,13 +139,13 @@ export const siteFacts = {
     implementationPassIsLivePass: false,
   },
   links: {
-    github: 'https://github.com/NEDONION/miniclaw',
-    issues: 'https://github.com/NEDONION/miniclaw/issues',
+    github: 'https://github.com/NEDONION/mini-claw',
+    issues: 'https://github.com/NEDONION/mini-claw/issues',
     product:
-      'https://github.com/NEDONION/miniclaw/blob/main/docs/product/20260807_%E4%BA%A7%E5%93%81%E9%9C%80%E6%B1%82%E6%96%87%E6%A1%A3.md',
+      'https://github.com/NEDONION/mini-claw/blob/main/docs/product/20260807_%E4%BA%A7%E5%93%81%E9%9C%80%E6%B1%82%E6%96%87%E6%A1%A3.md',
     architecture:
-      'https://github.com/NEDONION/miniclaw/blob/main/docs/architecture/20260807_%E7%B3%BB%E7%BB%9F%E6%9E%B6%E6%9E%84.md',
-    evaluation: 'https://github.com/NEDONION/miniclaw/tree/main/evals',
+      'https://github.com/NEDONION/mini-claw/blob/main/docs/architecture/20260807_%E7%B3%BB%E7%BB%9F%E6%9E%B6%E6%9E%84.md',
+    evaluation: 'https://github.com/NEDONION/mini-claw/tree/main/evals',
   },
 } as const;
 


### PR DESCRIPTION
## Summary

修正安装器、测试、设计文档与官网中写死的错误仓库地址 `NEDONION/miniclaw`(不存在的仓库)为实际仓库 `NEDONION/mini-claw`,共 30 个文件、96 处引用的字符串级修正,不改变任何行为逻辑,也不改动已发布的 CLI/包身份。

- **安装器安全相关代码**:`src/miniclaw/install/artifacts.py`(下载 host/redirect allowlist)、`models.py`(仓库常量与 URL 校验,含一处以 `segments[1:5] != [...]` 列表形式书写、字面量替换会漏掉的边界检查)、`releases.py`(Release 发现 API 与下载 URL)。
- **对应测试**:`tests/test_install_{artifacts,models,orchestrator,platforms,releases,runtime}.py`、`tests/install/manifest_v1.json`、`release/manifest.schema.json`。
- **设计与说明文档**:`docs/superpowers/plans/2026-08-09-one-line-install-and-release.md`、`docs/superpowers/specs/2026-08-09-one-line-install-and-release-design.md`、`README.md`、`README_EN.md`、`docs/evals/releases/v0.1.0.md`。
- **官网**:`website/content/docs/*.mdx`(中英文)、`website/src/content-data/project-facts.json`、`website/src/content/site.ts`。

明确不变的部分:PyPI 分发名 `miniclaw-agent`、Python import/CLI `miniclaw`、状态目录 `~/.miniclaw`(这些是已上线的包身份,与 GitHub 仓库地址是两回事,用户明确要求保留仓库名 `mini-claw` 不重命名 GitHub 仓库);所有指向 Node.js 上游仓库 `github.com/nodejs/node` 的 `source_repository` 引用;以及测试里用于验证"拒绝错误 owner/错误仓库"的负例字符串(如 `attacker/miniclaw`、`OTHER/miniclaw`、`NEDONION/other`)——这些是安全测试的负例夹具,与本次修正的目标字符串无关,故意保留不动。

## Why

设计文档与安装器代码在编写时假设仓库会被重命名为 `miniclaw`(与 CLI/包名一致),但实际 GitHub 仓库始终是 `NEDONION/mini-claw`(带连字符),且用户确认不会重命名仓库。此前所有 Milestone(1-3)交付的安装器代码里,下载 URL、Release 发现 API 和安全 host allowlist 全部指向不存在的 `NEDONION/miniclaw`——一旦发布,一键安装脚本第一步下载 release manifest 就会 404,对所有用户不可用。这是发布前必须堵住的阻塞项,和 Milestone 4(Task 12 起)并行、独立处理,不占用 Task 12 的文件范围。

## Verification

- 6 个 install 相关测试模块单独运行:**256/256 PASS**。
- 全量 `unittest discover`:1290 个测试,3 个 failures + 1 个 error,均确认为**修改前就存在、与本次改动无关**——已用一个临时的 `origin/main` 全新 worktree(未应用本次改动)复现同样的 3 个 failures(`test_browser_evals`/`test_cli_eval`),以及 1 个已知的本机 Node 22.19.0/pnpm 7.29.2 版本低于门槛导致的 `TuiBundleTest.setUpClass` 环境性 error;本次改动未引入任何新的回归。
- `ruff check .`:**全部通过**。
- `scripts/validate_docs.py`:**PASS**。
- 三个 JSON 文件(`project-facts.json`、`release/manifest.schema.json`、`tests/install/manifest_v1.json`)改动后手工确认仍是合法 JSON。
- 独立复核(第二人视角)重新跑了以上全部命令并额外验证了 diffstat 与预期改动列表逐一对应、无遗漏引用、无误伤 Node.js 上游引用和安全负例夹具。

## Checklist

- [x] 变更聚焦于仓库地址字符串修正,不改变任何安装器行为或已发布的包/CLI 身份。
- [x] 已运行相关检查(见 Verification 小节)。
- [x] 已同步更新设计文档、实施计划与官网内容。
- [x] 未包含密钥、凭证或个人数据。
