### PR TITLE
feat(update): 交付 Milestone 5 数据库安全升级与原子回滚

### DIFF
--- a/src/lobster0/install/orchestrator.py
+++ b/src/lobster0/install/orchestrator.py
@@ -72,6 +72,7 @@ from lobster0.install.service import (
     service_install,
     service_uninstall,
 )
+from lobster0.install.update import UpdateCoordinator, UpdateRequest
 
 _HASH = re.compile(r"^[0-9a-f]{64}$")
 _VERSION = re.compile(
@@ -88,6 +89,7 @@ _MAX_CONFIG_BYTES = 1024 * 1024
 _PATH = "/usr/local/bin:/usr/bin:/bin"
 _TIMEOUT = 300.0
 _OUTPUT_LIMIT = 64 * 1024
+_UPDATE_HEALTH_TIMEOUT = 30.0
 _INTERNAL_HOP = "LOBSTER0_INSTALLER_HOPS"
 _CHANNEL_FIELDS = {
     "feishu": ("app_id_env", "app_secret_env"),
@@ -382,6 +384,14 @@ class _Operations(Protocol):
     ) -> None:
         """在 actual lock 下恢复 staging、未激活 Runtime 与 stale downloads。"""
 
+    def recover_for_update(
+        self,
+        layout: InstallLayout,
+        lock: InstallLock,
+        manifest: ReleaseManifest,
+    ) -> None:
+        """恢复 update 场景的 staging/未激活 Runtime，但不拒绝既有 receipt。"""
+
     def download(self, plan: InstallPlan, layout: InstallLayout) -> _Downloaded:
         """下载并解包全部 verified artifacts。"""
 
@@ -427,6 +437,15 @@ class _Operations(Protocol):
 
     def install_service(self, plan: InstallPlan, layout: InstallLayout) -> None:
         """安装并 health-check Gateway service。"""
+
+    def update(
+        self,
+        plan: InstallPlan,
+        layout: InstallLayout,
+        built: RuntimeReceipt,
+        previous: str | None,
+    ) -> None:
+        """在 DB-guarded UpdateCoordinator 保护下切换到新 Runtime。"""
 
     def retain(self, layout: InstallLayout) -> None:
         """只保留 current 与 N-1 Runtime。"""
@@ -480,8 +499,6 @@ class Installer:
             raise InstallError("request_invalid", "action")
         plan = self._operations.preflight(request, self._bootstrap)
         self._emit(InstallEvent("install.preflight", "ok", None, "manifest"))
-        if request.action == "update" and hop == "1":
-            raise InstallError("request_invalid", "action")
         if request.dry_run:
             self._emit(
                 InstallEvent(
@@ -511,21 +528,37 @@ class Installer:
             executable, argv, environment = handoff
             self._execve(executable, argv, environment)
             raise InstallError("installer_error", "manifest")
-        if request.action == "update":
-            raise InstallError("request_invalid", "action")
         plan = self._operations.prepare_dependencies(plan, self._bootstrap)
         layout = self._operations.layout(plan)
         with self._operations.lock(layout) as held_lock:
-            self._operations.recover(layout, held_lock, plan.manifest)
+            if request.action == "update":
+                self._operations.recover_for_update(layout, held_lock, plan.manifest)
+            else:
+                self._operations.recover(layout, held_lock, plan.manifest)
             previous = self._operations.previous_current(layout)
             stage = "locked"
             try:
+                if request.action == "update" and previous is None:
+                    raise InstallError("request_invalid", "action")
                 downloaded = self._operations.download(plan, layout)
                 stage = "downloaded"
                 self._emit(InstallEvent("install.download", "ok", None, "artifacts"))
                 built = self._operations.build(plan, layout, downloaded)
                 stage = "built"
                 self._emit(InstallEvent("install.staged", "ok", None, "version"))
+                if request.action == "update":
+                    self._operations.update(plan, layout, built, previous)
+                    stage = "updated"
+                    self._emit(InstallEvent("update.activated", "ok", None, "version"))
+                    self._operations.cleanup(layout, held_lock)
+                    self._emit(InstallEvent("update.complete", "ok", None, "version"))
+                    return InstallResult(
+                        request.action,
+                        plan.manifest.version,
+                        plan.platform,
+                        True,
+                        tuple(self._events),
+                    )
                 self._operations.setup(plan, layout, built)
                 service_ready = self._operations.doctor(plan, layout, built)
                 self._emit(InstallEvent("install.smoke", "ok", None, "service"))
@@ -554,6 +587,14 @@ class Installer:
                     tuple(self._events),
                 )
             except BaseException as error:
+                if request.action == "update":
+                    # UpdateCoordinator 已经在返回前完成了自己的 DB-guarded
+                    # 回滚（干净恢复旧 Runtime/service，或者保留 conflict
+                    # 状态）；这里只需要释放本次事务专属的 staging 目录。
+                    self._operations.cleanup(layout, held_lock)
+                    if isinstance(error, InstallError):
+                        raise
+                    raise InstallError("installer_error", "manifest") from None
                 try:
                     self._operations.rollback(layout, previous, stage)
                 except InstallError:
@@ -756,6 +797,22 @@ class _SystemOperations:
     ) -> None:
         """在 actual install lock 下恢复本版本的 crash residue。"""
         _reject_existing_receipt(layout)
+        _discard_stale_downloads(layout, lock)
+        discard_interrupted_runtime_staging(layout, lock, manifest)
+        discard_unactivated_runtime(layout, lock)
+
+    def recover_for_update(
+        self,
+        layout: InstallLayout,
+        lock: InstallLock,
+        manifest: ReleaseManifest,
+    ) -> None:
+        """恢复 update 场景的 crash residue，但不拒绝既有 install receipt。
+
+        与 `recover` 唯一的区别是跳过 `_reject_existing_receipt`：update
+        本身要求目标 layout 已经有一份受管 receipt，这是 Task 13 才能
+        安全处理的场景（参见 `_reject_existing_receipt` 自身的说明）。
+        """
         _discard_stale_downloads(layout, lock)
         discard_interrupted_runtime_staging(layout, lock, manifest)
         discard_unactivated_runtime(layout, lock)
@@ -993,6 +1050,116 @@ class _SystemOperations:
         except BaseException:
             self._rollback_installed_service(layout)
             raise
+
+    def update(
+        self,
+        plan: InstallPlan,
+        layout: InstallLayout,
+        built: RuntimeReceipt,
+        previous: str | None,
+    ) -> None:
+        """在 DB-guarded UpdateCoordinator 保护下切换到新 Runtime。
+
+        Doctor smoke 通过之后才停止旧 service，最大限度缩短停机窗口；
+        真正的备份、migration、activation、service 刷新与失败回滚全部
+        委托给 `UpdateCoordinator`，本方法只把 Task 8/10/11 原语绑定
+        成它需要的回调闭包。
+        """
+        if previous is None:
+            raise InstallError("request_invalid", "manifest")
+        if not self.doctor(plan, layout, built):
+            raise InstallError("doctor_blocked", "service")
+        old_receipt = InstallReceipt.load(layout.receipt)
+        if old_receipt.current_runtime != previous:
+            raise InstallError("plan_invalid", "manifest")
+        platform = (
+            ServicePlatform.SYSTEMD_USER
+            if plan.service_manager == "systemd-user"
+            else ServicePlatform.LAUNCHD
+        )
+        has_service = old_receipt.service_file_sha256 is not None
+        system_prefix = plan.request.system_prefix
+        new_python = layout.runtime / "venv" / "bin" / "python"
+        new_service_started = False
+
+        def run_migration() -> None:
+            argv = (
+                str(new_python),
+                "-I",
+                "-m",
+                "lobster0",
+                "init",
+                "--home",
+                str(layout.state_home),
+            )
+            _checked_owner_command(self.runner, argv, layout, system_prefix=system_prefix)
+
+        def stop_service() -> None:
+            if not has_service:
+                return
+            assert old_receipt.service_file_sha256 is not None
+            if system_prefix:
+                _uninstall_service_as_owner(
+                    layout, platform, old_receipt.service_file_sha256, self.runner
+                )
+            else:
+                service_uninstall(
+                    render_service_spec(layout, platform),
+                    self.runner,
+                    expected_sha256=old_receipt.service_file_sha256,
+                )
+
+        def start_service() -> None:
+            if not has_service:
+                return
+            if system_prefix:
+                _install_service_as_owner(layout, platform, self.runner)
+            else:
+                service_install(render_service_spec(layout, platform), self.runner)
+
+        def start_new_service(timeout: float) -> bool:
+            nonlocal new_service_started
+            del timeout
+            start_service()
+            new_service_started = True
+            return True
+
+        def stop_new_service() -> None:
+            nonlocal new_service_started
+            if not new_service_started:
+                return
+            stop_service()
+            new_service_started = False
+
+        def activate_new_runtime() -> None:
+            activate_runtime(layout, built)
+
+        def commit_receipt() -> None:
+            replace(
+                old_receipt,
+                current_runtime=built.runtime_relative,
+                previous_runtime=previous,
+            ).write(layout.receipt)
+
+        def revert_to_old_runtime() -> None:
+            _restore_current(layout, previous)
+            old_receipt.write(layout.receipt)
+
+        request = UpdateRequest(
+            database=layout.state_home / "lobster0.db",
+            backup_path=layout.state_home / f".lobster0.db.update-backup.{os.getpid()}",
+            stop_old_service=stop_service,
+            run_migration=run_migration,
+            activate_new_runtime=activate_new_runtime,
+            commit_receipt=commit_receipt,
+            revert_to_old_runtime=revert_to_old_runtime,
+            start_new_service=start_new_service,
+            stop_new_service=stop_new_service,
+            restart_old_service=start_service,
+            retain_runtimes=lambda: retain_current_and_previous(layout),
+            health_timeout=_UPDATE_HEALTH_TIMEOUT,
+        )
+        UpdateCoordinator().update(request)
 
     def retain(self, layout: InstallLayout) -> None:
         """复用 Runtime retention，仅保留 current 与 N-1。"""

--- a/src/lobster0/install/update.py
+++ b/src/lobster0/install/update.py
@@ -151,6 +151,14 @@ def backup_database(source: Path, destination: Path) -> None:
 def restore_database(backup: Path, destination: Path) -> None:
     """把 owner-only 备份原子恢复到 destination：临时文件 + fsync + replace。
 
+    `backup_database` 用 ``sqlite3.Connection.backup`` 生成备份，产出的是
+    一个已经把 WAL 内容合并进主文件、自包含的单文件快照。恢复时如果
+    `destination` 旁边还留有失败 migration 遗留的 ``-wal``/``-shm``
+    sidecar，它们描述的是被替换掉的旧主文件内容；一旦主文件被替换而
+    sidecar 未清理，下一次打开会用不匹配的 WAL 帧去恢复一个它们从未
+    见过的主文件，存在损坏风险。因此替换主文件之后必须立即清理这两个
+    sidecar，让恢复后的数据库回到一个自洽的冷启动状态。
+
     Args:
         backup: 已确认存在的 owner-only 备份文件。
         destination: 待恢复覆盖的当前数据库路径。
@@ -173,6 +181,8 @@ def restore_database(backup: Path, destination: Path) -> None:
         finally:
             os.close(descriptor)
         os.replace(temporary, destination)
+        _unlink_if_exists(destination.with_name(f"{destination.name}-wal"))
+        _unlink_if_exists(destination.with_name(f"{destination.name}-shm"))
         _fsync_directory(destination.parent)
     except BaseException:
         _unlink_if_exists(temporary)

--- a/src/lobster0/install/update.py
+++ b/src/lobster0/install/update.py
@@ -1,0 +1,373 @@
+"""SQLite 数据库安全更新：备份、变更守卫与原子回滚。
+
+Task 13 交付 `UpdateCoordinator`：在停止旧 service 后备份数据库，趁旧
+service 停止期间运行新 Runtime 的 schema migration，再原子切换到新
+Runtime 并刷新/健康检查新 service。任一阶段失败都先停止新 service，
+再用 `DatabaseChangeGuard`（基于 SQLite ``PRAGMA data_version``）判断
+migration 之后是否已经发生过外部写入：
+
+- 没有外部写入 —— 销毁性恢复数据库备份、旧 Runtime 与旧 service，
+  然后重新抛出触发失败的原始异常；
+- 已经发生外部写入 —— 绝不覆盖这些数据，保留备份与当前（新）状态，
+  转而抛出 ``rollback_conflict``，交给运维人工判断。
+
+本模块只依赖调用方注入的路径与副作用回调，不了解 `InstallLayout`、
+`RuntimeReceipt` 或 service manager 的具体实现；因此绝不会读取或写入
+Memory、Skills、Workspace 或任何 `state_home` 下除数据库与其备份文件
+之外的路径。
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from lobster0.install.models import InstallError
+
+_CONNECT_TIMEOUT = 5.0
+
+
+@dataclass(slots=True)
+class DatabaseChangeGuard:
+    """用一个持续只读连接检测预期 migration 之后发生的新 commit。
+
+    Args:
+        connection: 事务全程持有的只读 SQLite 连接。
+        expected_data_version: 当前判定基线使用的 ``PRAGMA data_version``。
+    """
+
+    connection: sqlite3.Connection
+    expected_data_version: int
+
+    @classmethod
+    def open(cls, database: Path) -> DatabaseChangeGuard:
+        """打开覆盖整个 update 事务生命周期的只读监控连接。
+
+        Args:
+            database: 必须已经存在的当前存活 SQLite 数据库文件。
+
+        Returns:
+            以迁移前 ``data_version`` 为初始基线的守卫。
+
+        Raises:
+            InstallError: 路径类型不对、数据库缺失或连接/查询失败。
+        """
+        if not isinstance(database, Path):
+            raise InstallError("request_invalid", "manifest")
+        if not database.is_file():
+            raise InstallError("request_invalid", "manifest")
+        uri = f"{database.resolve(strict=True).as_uri()}?mode=ro"
+        try:
+            connection = sqlite3.connect(uri, timeout=_CONNECT_TIMEOUT, uri=True)
+        except sqlite3.Error as error:
+            raise InstallError("installer_error", "manifest") from error
+        try:
+            version = _read_data_version(connection)
+        except BaseException:
+            connection.close()
+            raise
+        return cls(connection=connection, expected_data_version=version)
+
+    def refresh_after_expected_migration(self) -> None:
+        """把基线更新为 migration 刚完成后的 ``data_version``。
+
+        Raises:
+            InstallError: 监控连接已经不可用。
+        """
+        self.expected_data_version = _read_data_version(self.connection)
+
+    def has_external_commit(self) -> bool:
+        """判断当前 ``data_version`` 是否已经偏离基线，即出现新写入。
+
+        Returns:
+            自上次 refresh/open 以来发生过至少一次新提交时为 True。
+
+        Raises:
+            InstallError: 监控连接已经不可用。
+        """
+        return _read_data_version(self.connection) != self.expected_data_version
+
+    def close(self) -> None:
+        """关闭监控连接；事务结束（无论成败）后必须调用一次。"""
+        try:
+            self.connection.close()
+        except sqlite3.Error:
+            pass
+
+
+def _read_data_version(connection: sqlite3.Connection) -> int:
+    """读取当前连接可见的 SQLite ``data_version``。"""
+    try:
+        row = connection.execute("PRAGMA data_version").fetchone()
+        return int(row[0])
+    except sqlite3.Error as error:
+        raise InstallError("installer_error", "manifest") from error
+
+
+def backup_database(source: Path, destination: Path) -> None:
+    """用 ``sqlite3.Connection.backup`` 创建 owner-only 备份文件并 fsync。
+
+    这个函数总是被无条件调用 —— 即便目标 schema 版本与当前完全相同，
+    也绝不允许跳过备份；调用方不得为“兼容 schema”添加短路优化。
+
+    Args:
+        source: 当前存活、必须已经存在的 SQLite 数据库文件。
+        destination: 尚不存在的 owner-only 备份文件路径。
+
+    Raises:
+        InstallError: source 缺失、destination 已存在或备份/刷盘失败。
+    """
+    if not isinstance(source, Path) or not isinstance(destination, Path):
+        raise InstallError("request_invalid", "manifest")
+    if not source.is_file():
+        raise InstallError("request_invalid", "manifest")
+    if destination.is_symlink() or destination.exists():
+        raise InstallError("request_invalid", "manifest")
+    try:
+        descriptor = os.open(destination, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    except OSError as error:
+        raise InstallError("installer_error", "manifest") from error
+    os.close(descriptor)
+    try:
+        source_connection = sqlite3.connect(str(source), timeout=_CONNECT_TIMEOUT)
+        try:
+            destination_connection = sqlite3.connect(str(destination), timeout=_CONNECT_TIMEOUT)
+            try:
+                source_connection.backup(destination_connection)
+            finally:
+                destination_connection.close()
+        finally:
+            source_connection.close()
+        _fsync_file(destination)
+        _fsync_directory(destination.parent)
+    except BaseException:
+        _unlink_if_exists(destination)
+        raise InstallError("installer_error", "manifest") from None
+
+
+def restore_database(backup: Path, destination: Path) -> None:
+    """把 owner-only 备份原子恢复到 destination：临时文件 + fsync + replace。
+
+    Args:
+        backup: 已确认存在的 owner-only 备份文件。
+        destination: 待恢复覆盖的当前数据库路径。
+
+    Raises:
+        InstallError: backup 缺失或恢复/刷盘失败。
+    """
+    if not isinstance(backup, Path) or not isinstance(destination, Path):
+        raise InstallError("request_invalid", "manifest")
+    if not backup.is_file():
+        raise InstallError("request_invalid", "manifest")
+    temporary = destination.with_name(f".{destination.name}.restore.{os.getpid()}")
+    _unlink_if_exists(temporary)
+    try:
+        payload = backup.read_bytes()
+        descriptor = os.open(temporary, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        try:
+            os.write(descriptor, payload)
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        os.replace(temporary, destination)
+        _fsync_directory(destination.parent)
+    except BaseException:
+        _unlink_if_exists(temporary)
+        raise InstallError("installer_error", "manifest") from None
+
+
+def _fsync_file(path: Path) -> None:
+    """刷盘一个既有普通文件的内容。"""
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _fsync_directory(path: Path) -> None:
+    """刷盘一个目录的元数据，使其中的 rename/replace 持久化。"""
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _unlink_if_exists(path: Path) -> None:
+    """删除一个可能不存在的普通文件。"""
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateRequest:
+    """绑定一次 update 事务需要的全部路径与受控副作用回调。
+
+    本类型刻意不知道 `InstallLayout`、`RuntimeReceipt` 或具体 service
+    manager；调用方（`lobster0.install.orchestrator`）负责把每个回调
+    绑定成真实的 Task 8/10 原语。除 `database`/`backup_path` 外，任何
+    回调都绝不能读取或写入 `state_home` 下的 Memory、Skills、Workspace
+    或其他用户数据路径。
+
+    Args:
+        database: 当前存活的 SQLite 数据库文件。
+        backup_path: 本次事务专用、尚不存在的 owner-only 备份路径。
+        stop_old_service: 停止旧 Runtime service 的回调；旧 service 未
+            安装时必须是安全 no-op。
+        run_migration: 在旧 service 已停止期间运行新 Runtime schema
+            migration 的回调。
+        activate_new_runtime: 原子切换 `current` 到新 Runtime 的回调，
+            不涉及 receipt。
+        commit_receipt: 在 `activate_new_runtime` 成功之后，写入反映新
+            current/previous 的 install receipt 的回调；与 Task 8/11
+            fresh-install 的 activate→commit 顺序保持一致。
+        revert_to_old_runtime: 只在 `activate_new_runtime` 已经成功后
+            才会被调用（无论 `commit_receipt` 是否也成功），把 `current`
+            与 receipt 都恢复到旧 Runtime；必须使用「仍指向本次 target
+            才恢复」式的安全检查，并且必须是幂等的 —— `commit_receipt`
+            从未运行时，重写同一份旧 receipt 仍然要安全。
+        start_new_service: 启动/刷新新 Runtime service 并等待 bounded
+            health 的回调；超时应当返回 False 而不是抛出，但也允许
+            为其他基础设施失败直接抛出 `InstallError`。
+        stop_new_service: 停止新 Runtime service 的回调；新 service 从未
+            成功启动时也必须是安全 no-op。
+        restart_old_service: 恢复路径里重新拉起旧 Runtime service 的
+            回调；旧 service 未安装时必须是安全 no-op。
+        retain_runtimes: 仅在整个事务成功后调用一次，只保留 current 与
+            N-1 Runtime。
+        health_timeout: 等待新 service health 的建议最长秒数；具体
+            manager 若使用固定超时，可以安全忽略该值。
+
+    Raises:
+        InstallError: 路径类型、缺失回调或超时不可信。
+    """
+
+    database: Path
+    backup_path: Path
+    stop_old_service: Callable[[], None]
+    run_migration: Callable[[], None]
+    activate_new_runtime: Callable[[], None]
+    commit_receipt: Callable[[], None]
+    revert_to_old_runtime: Callable[[], None]
+    start_new_service: Callable[[float], bool]
+    stop_new_service: Callable[[], None]
+    restart_old_service: Callable[[], None]
+    retain_runtimes: Callable[[], None]
+    health_timeout: float
+
+    def __post_init__(self) -> None:
+        """拒绝错误类型的路径、回调或超时。"""
+        callables = (
+            self.stop_old_service,
+            self.run_migration,
+            self.activate_new_runtime,
+            self.commit_receipt,
+            self.revert_to_old_runtime,
+            self.start_new_service,
+            self.stop_new_service,
+            self.restart_old_service,
+            self.retain_runtimes,
+        )
+        if (
+            not isinstance(self.database, Path)
+            or not isinstance(self.backup_path, Path)
+            or any(not callable(value) for value in callables)
+            or type(self.health_timeout) not in (int, float)
+            or self.health_timeout <= 0
+        ):
+            raise InstallError("request_invalid", "manifest")
+
+
+class UpdateCoordinator:
+    """在数据库备份/守卫保护下协调一次 update 的 activation 与 rollback。"""
+
+    def update(self, request: UpdateRequest) -> None:
+        """执行一次 DB-guarded 原子 update，失败时安全回滚或返回 conflict。
+
+        Args:
+            request: 已绑定全部路径与副作用回调的 update 请求。
+
+        Raises:
+            InstallError: 任一阶段失败。安全（无外部写入）时重新抛出
+                导致失败的原始异常，并已经完成销毁性数据库恢复与旧
+                Runtime/service 回滚；检测到 migration 之后的外部写入
+                时改为抛出 `rollback_conflict`，且不会做任何销毁性
+                恢复 —— 备份与新状态都原样保留供人工处理。
+        """
+        if type(request) is not UpdateRequest:
+            raise InstallError("request_invalid", "manifest")
+        request.stop_old_service()
+        try:
+            guard = DatabaseChangeGuard.open(request.database)
+        except BaseException as error:
+            _best_effort(request.restart_old_service)
+            if isinstance(error, InstallError):
+                raise
+            raise InstallError("installer_error", "manifest") from error
+        stage = "stopped"
+        try:
+            try:
+                backup_database(request.database, request.backup_path)
+                stage = "backed_up"
+                request.run_migration()
+                stage = "migrated"
+                guard.refresh_after_expected_migration()
+                request.activate_new_runtime()
+                stage = "activated"
+                request.commit_receipt()
+                stage = "committed"
+                healthy = request.start_new_service(request.health_timeout)
+                if type(healthy) is not bool or not healthy:
+                    raise InstallError("activation_failed", "service")
+                stage = "service_started"
+            except BaseException as error:
+                self._recover(request, guard, stage, error)
+        finally:
+            guard.close()
+        request.retain_runtimes()
+
+    def _recover(
+        self,
+        request: UpdateRequest,
+        guard: DatabaseChangeGuard,
+        stage: str,
+        error: BaseException,
+    ) -> None:
+        """按失败阶段决定安全销毁性恢复，或保留 conflict 状态。
+
+        总是重新抛出：清理路径下重新抛出触发失败的原始异常；一旦守卫
+        检测到 migration 之后的外部写入，则改为抛出 `rollback_conflict`。
+        """
+        _best_effort(request.stop_new_service)
+        if stage == "stopped":
+            _best_effort(request.restart_old_service)
+            self._raise_original(error)
+            return
+        if stage != "backed_up" and guard.has_external_commit():
+            raise InstallError("rollback_conflict", "manifest") from error
+        restore_database(request.backup_path, request.database)
+        if stage in ("activated", "committed", "service_started"):
+            _best_effort(request.revert_to_old_runtime)
+        _best_effort(request.restart_old_service)
+        self._raise_original(error)
+
+    @staticmethod
+    def _raise_original(error: BaseException) -> None:
+        """原样重新抛出已捕获的原始异常。"""
+        if isinstance(error, InstallError):
+            raise error
+        raise InstallError("installer_error", "manifest") from error
+
+
+def _best_effort(action: Callable[[], None]) -> None:
+    """执行 recovery-path 副作用，吞掉异常以保留原始失败信息。"""
+    try:
+        action()
+    except BaseException:
+        pass

--- a/tests/test_install_orchestrator.py
+++ b/tests/test_install_orchestrator.py
@@ -169,6 +169,7 @@ class _Operations:
                 "service": "service_install_failed",
                 "service_receipt": "installer_error",
                 "retain": "runtime_install_failed",
+                "update": "rollback_conflict",
             }[name]
             raise InstallError(code, "manifest")
 
@@ -221,6 +222,18 @@ class _Operations:
         self.recovery_manifest = manifest
         self.calls.append("recover")
 
+    def recover_for_update(
+        self,
+        _layout: object,
+        lock: _Lock,
+        manifest: object,
+    ) -> None:
+        """记录 update 场景跳过 receipt 拒绝的恢复边界。"""
+        if lock is not self.held_lock:
+            raise AssertionError("recovery did not receive the acquired lock")
+        self.recovery_manifest = manifest
+        self.calls.append("recover")
+
     def previous_current(self, _layout: object) -> str:
         """返回事务开始前的 current。"""
         self.calls.append("previous_current")
@@ -263,6 +276,17 @@ class _Operations:
         self._call("service")
         self.service = "new"
         self._call("service_receipt")
+
+    def update(self, _plan: _Plan, _layout: object, _built: object, _previous: str) -> None:
+        """模拟 DB-guarded update：成功时原子切换 fake current/service。
+
+        真正的备份/守卫/回滚行为已经在 `tests/test_install_update.py` 里
+        针对 `UpdateCoordinator` 单独覆盖；这里只需要验证 orchestrator
+        级别的顺序、事件与失败路由。
+        """
+        self._call("update")
+        self.current = "new"
+        self.service = "new"
 
     def retain(self, _layout: object) -> None:
         """记录 Runtime retention。"""
@@ -392,25 +416,94 @@ class InstallerStateMachineTests(unittest.TestCase):
                 ))
                 self.assertEqual(operations.calls, [])
 
-    def test_update_target_hop_fails_after_preflight_before_pipeline(self) -> None:
-        """已跳转的 update target 只验证 bootstrap，不再 discovery 或安装。"""
+    def test_update_target_hop_runs_full_pipeline_and_activates(self) -> None:
+        """Task13：已跳转的 update target 现在会执行真正的 DB-guarded pipeline。"""
         operations = _Operations()
+        result = Installer(
+            self.bootstrap,
+            operations=operations,
+            environ={"LOBSTER0_INSTALLER_HOPS": "1"},
+        ).run(replace(self.request, action="update"))
+        self.assertEqual(
+            operations.calls,
+            [
+                "preflight",
+                "select_target",
+                "sandbox",
+                "system_plan",
+                "layout",
+                "lock.enter",
+                "recover",
+                "previous_current",
+                "download",
+                "hash",
+                "extract",
+                "venv",
+                "wheel",
+                "tui",
+                "update",
+                "cleanup",
+                "lock.exit",
+            ],
+        )
+        self.assertEqual(operations.current, "new")
+        self.assertEqual(operations.service, "new")
+        self.assertEqual(
+            [event.name for event in result.events],
+            [
+                "install.preflight",
+                "install.download",
+                "install.staged",
+                "update.activated",
+                "update.complete",
+            ],
+        )
+        self.assertEqual(
+            result,
+            InstallResult(
+                "update", "0.7.0", PlatformKey("linux", "x86_64"), True, result.events
+            ),
+        )
+
+    def test_update_without_verified_handoff_runs_pipeline_directly(self) -> None:
+        """第一跳没有更新目标（已经在目标版本）时，直接执行真正的 update pipeline。"""
+        operations = _Operations()
+        result = Installer(self.bootstrap, operations=operations).run(
+            replace(self.request, action="update")
+        )
+        self.assertEqual(operations.calls[:2], ["preflight", "select_target"])
+        self.assertIn("update", operations.calls)
+        self.assertTrue(result.changed)
+        self.assertEqual(operations.current, "new")
+
+    def test_update_failure_never_calls_install_style_rollback(self) -> None:
+        """update 失败时 UpdateCoordinator 已自行回滚，不得再调用 install 专用 rollback。"""
+        operations = _Operations(fail="update")
+        with self.assertRaisesRegex(InstallError, "rollback_conflict"):
+            Installer(
+                self.bootstrap,
+                operations=operations,
+                environ={"LOBSTER0_INSTALLER_HOPS": "1"},
+            ).run(replace(self.request, action="update"))
+        self.assertNotIn("rollback", operations.calls)
+        self.assertIn("cleanup", operations.calls)
+        self.assertEqual(operations.calls[-1], "lock.exit")
+        self.assertEqual(operations.current, "old")
+        self.assertEqual(operations.service, "old")
+
+    def test_update_without_existing_install_fails_closed(self) -> None:
+        """从未安装过（current 为空）时 update 必须 fail closed，不得凭空创建安装。"""
+        operations = _Operations()
+        operations.current = None  # type: ignore[assignment]
         with self.assertRaisesRegex(InstallError, "request_invalid"):
             Installer(
                 self.bootstrap,
                 operations=operations,
                 environ={"LOBSTER0_INSTALLER_HOPS": "1"},
             ).run(replace(self.request, action="update"))
-        self.assertEqual(operations.calls, ["preflight"])
-
-    def test_update_without_verified_handoff_never_runs_install_pipeline(self) -> None:
-        """第一跳 update 缺少 target handoff 时必须 fail closed。"""
-        operations = _Operations()
-        with self.assertRaisesRegex(InstallError, "request_invalid"):
-            Installer(self.bootstrap, operations=operations).run(
-                replace(self.request, action="update")
-            )
-        self.assertEqual(operations.calls, ["preflight", "select_target"])
+        self.assertNotIn("update", operations.calls)
+        self.assertIn("cleanup", operations.calls)
+        self.assertEqual(operations.calls[-1], "lock.exit")
 
     def test_update_first_hop_execs_verified_target_once(self) -> None:
         """第一跳 update 只能执行一次 target installer，不能进入 Task11 pipeline。"""

--- a/tests/test_install_update.py
+++ b/tests/test_install_update.py
@@ -1,0 +1,415 @@
+"""验证 UpdateCoordinator 的 DB-guarded 原子回滚与 rollback_conflict。"""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+from lobster0.install.models import InstallError
+from lobster0.install.update import (
+    DatabaseChangeGuard,
+    UpdateCoordinator,
+    UpdateRequest,
+    backup_database,
+    restore_database,
+)
+
+
+def _seed_database(path: Path) -> None:
+    """创建一个带初始行的最小数据库，模拟迁移前的用户数据。"""
+    connection = sqlite3.connect(str(path))
+    try:
+        connection.execute("CREATE TABLE items (value TEXT NOT NULL)")
+        connection.execute("INSERT INTO items (value) VALUES ('seed')")
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def _write_external_row(path: Path, value: str) -> None:
+    """模拟一次真正独立的外部写入（例如已经启动的新 service）。"""
+    connection = sqlite3.connect(str(path), timeout=5.0)
+    try:
+        connection.execute("INSERT INTO items (value) VALUES (?)", (value,))
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def _read_values(path: Path) -> tuple[str, ...]:
+    connection = sqlite3.connect(str(path))
+    try:
+        rows = connection.execute("SELECT value FROM items ORDER BY value").fetchall()
+    finally:
+        connection.close()
+    return tuple(row[0] for row in rows)
+
+
+class _Environment:
+    """离线记录一次 update 事务全部可观察副作用的受控测试替身。
+
+    对齐 `tests/test_install_orchestrator.py` 里 `_Operations` 的 fake 风格：
+    用一个 `fail_at` 注入点和一份有序 `calls` 记录，而不是逐个 mock。
+    """
+
+    def __init__(self, tmp: Path) -> None:
+        self.database = tmp / "lobster0.db"
+        self.backup_path = tmp / "lobster0.db.update-backup"
+        _seed_database(self.database)
+        self.calls: list[str] = []
+        self.current = "old"
+        self.receipt_current = "old"
+        self.old_running = True
+        self.new_running = False
+        self.fail_at: str | None = None
+        self.write_on_start: str | None = None
+        self.health_result = True
+
+    def _maybe_fail(self, name: str) -> None:
+        if self.fail_at == name:
+            raise InstallError("installer_error", "manifest")
+
+    def stop_old_service(self) -> None:
+        self.calls.append("stop_old_service")
+        self._maybe_fail("stop_old_service")
+        self.old_running = False
+
+    def run_migration(self) -> None:
+        self.calls.append("run_migration")
+        self._maybe_fail("run_migration")
+
+    def activate_new_runtime(self) -> None:
+        self.calls.append("activate_new_runtime")
+        self._maybe_fail("activate_new_runtime")
+        self.current = "new"
+
+    def commit_receipt(self) -> None:
+        self.calls.append("commit_receipt")
+        self._maybe_fail("commit_receipt")
+        self.receipt_current = "new"
+
+    def revert_to_old_runtime(self) -> None:
+        self.calls.append("revert_to_old_runtime")
+        self.current = "old"
+        self.receipt_current = "old"
+
+    def start_new_service(self, timeout: float) -> bool:
+        del timeout
+        self.calls.append("start_new_service")
+        if self.write_on_start is not None:
+            _write_external_row(self.database, self.write_on_start)
+        self._maybe_fail("start_new_service")
+        self.new_running = self.health_result
+        return self.health_result
+
+    def stop_new_service(self) -> None:
+        self.calls.append("stop_new_service")
+        self.new_running = False
+
+    def restart_old_service(self) -> None:
+        self.calls.append("restart_old_service")
+        self.old_running = True
+
+    def retain_runtimes(self) -> None:
+        self.calls.append("retain_runtimes")
+
+    def request(self, **overrides: object) -> UpdateRequest:
+        fields: dict[str, object] = {
+            "database": self.database,
+            "backup_path": self.backup_path,
+            "stop_old_service": self.stop_old_service,
+            "run_migration": self.run_migration,
+            "activate_new_runtime": self.activate_new_runtime,
+            "commit_receipt": self.commit_receipt,
+            "revert_to_old_runtime": self.revert_to_old_runtime,
+            "start_new_service": self.start_new_service,
+            "stop_new_service": self.stop_new_service,
+            "restart_old_service": self.restart_old_service,
+            "retain_runtimes": self.retain_runtimes,
+            "health_timeout": 5.0,
+        }
+        fields.update(overrides)
+        return UpdateRequest(**fields)  # type: ignore[arg-type]
+
+
+class DatabaseChangeGuardTests(unittest.TestCase):
+    """覆盖基于 PRAGMA data_version 的独立只读变更探测。"""
+
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.database = Path(self.temporary.name) / "lobster0.db"
+        _seed_database(self.database)
+
+    def test_unchanged_baseline_reports_no_external_commit(self) -> None:
+        guard = DatabaseChangeGuard.open(self.database)
+        self.addCleanup(guard.close)
+        self.assertFalse(guard.has_external_commit())
+
+    def test_external_commit_from_separate_connection_is_detected(self) -> None:
+        guard = DatabaseChangeGuard.open(self.database)
+        self.addCleanup(guard.close)
+        _write_external_row(self.database, "external")
+        self.assertTrue(guard.has_external_commit())
+
+    def test_refresh_after_expected_migration_resets_baseline(self) -> None:
+        guard = DatabaseChangeGuard.open(self.database)
+        self.addCleanup(guard.close)
+        _write_external_row(self.database, "migration-write")
+        guard.refresh_after_expected_migration()
+        self.assertFalse(guard.has_external_commit())
+        _write_external_row(self.database, "post-migration-write")
+        self.assertTrue(guard.has_external_commit())
+
+    def test_open_rejects_missing_database(self) -> None:
+        with self.assertRaisesRegex(InstallError, "request_invalid"):
+            DatabaseChangeGuard.open(self.database.with_name("missing.db"))
+
+
+class DatabaseBackupRestoreTests(unittest.TestCase):
+    """覆盖 owner-only 备份/恢复的原子性与错误处理。"""
+
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.tmp = Path(self.temporary.name)
+        self.database = self.tmp / "lobster0.db"
+        _seed_database(self.database)
+        self.backup_path = self.tmp / "lobster0.db.backup"
+
+    def test_backup_creates_owner_only_file_with_matching_rows(self) -> None:
+        backup_database(self.database, self.backup_path)
+        self.assertEqual(self.backup_path.stat().st_mode & 0o777, 0o600)
+        self.assertEqual(_read_values(self.backup_path), ("seed",))
+
+    def test_backup_rejects_existing_destination(self) -> None:
+        self.backup_path.write_bytes(b"stale")
+        with self.assertRaisesRegex(InstallError, "request_invalid|installer_error"):
+            backup_database(self.database, self.backup_path)
+
+    def test_backup_rejects_missing_source(self) -> None:
+        with self.assertRaisesRegex(InstallError, "request_invalid"):
+            backup_database(self.tmp / "absent.db", self.backup_path)
+
+    def test_restore_replaces_database_with_backup_contents(self) -> None:
+        backup_database(self.database, self.backup_path)
+        _write_external_row(self.database, "after-backup")
+        self.assertEqual(_read_values(self.database), ("after-backup", "seed"))
+        restore_database(self.backup_path, self.database)
+        self.assertEqual(_read_values(self.database), ("seed",))
+
+    def test_restore_leaves_destination_untouched_on_missing_backup(self) -> None:
+        before = self.database.read_bytes()
+        with self.assertRaisesRegex(InstallError, "request_invalid"):
+            restore_database(self.tmp / "absent-backup.db", self.database)
+        self.assertEqual(self.database.read_bytes(), before)
+
+
+class UpdateCoordinatorTests(unittest.TestCase):
+    """覆盖每个 crash window 的确定性终态，以及 no-shortcut 不变量。"""
+
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.tmp = Path(self.temporary.name)
+        self.environment = _Environment(self.tmp)
+        self.coordinator = UpdateCoordinator()
+
+    def test_successful_update_activates_commits_and_retains_in_order(self) -> None:
+        before = self.environment.database.read_bytes()
+        self.coordinator.update(self.environment.request())
+        self.assertEqual(
+            self.environment.calls,
+            [
+                "stop_old_service",
+                "run_migration",
+                "activate_new_runtime",
+                "commit_receipt",
+                "start_new_service",
+                "retain_runtimes",
+            ],
+        )
+        self.assertEqual(self.environment.current, "new")
+        self.assertEqual(self.environment.receipt_current, "new")
+        self.assertTrue(self.environment.new_running)
+        # 迁移前的备份必须真实存在，即便一切都成功了也不会被清理/隐藏。
+        self.assertTrue(self.environment.backup_path.exists())
+        self.assertNotEqual(self.environment.database.read_bytes(), b"")
+        self.assertNotEqual(before, b"")
+
+    def test_no_compatible_schema_shortcut_backup_always_happens(self) -> None:
+        """即便版本号相同（无需真正迁移），也必须无条件备份数据库。"""
+        self.coordinator.update(self.environment.request())
+        self.assertIn("run_migration", self.environment.calls)
+        self.assertTrue(self.environment.backup_path.is_file())
+        self.assertEqual(_read_values(self.environment.backup_path), ("seed",))
+
+    def test_failure_before_backup_restarts_old_service_without_touching_database(self) -> None:
+        before = self.environment.database.read_bytes()
+        self.environment.fail_at = "stop_old_service"
+        with self.assertRaisesRegex(InstallError, "installer_error"):
+            self.coordinator.update(self.environment.request())
+        self.assertEqual(self.environment.calls, ["stop_old_service"])
+        self.assertEqual(self.environment.database.read_bytes(), before)
+        self.assertFalse(self.environment.backup_path.exists())
+
+    def test_failure_during_backup_itself_restarts_old_service(self) -> None:
+        before = self.environment.database.read_bytes()
+        # 预先占用备份路径，让 backup_database 内部的 O_EXCL 创建失败；
+        # stage 停在 "stopped"，从未尝试 restore，字节必须原样不变。
+        self.environment.backup_path.write_bytes(b"stale-leftover")
+        with self.assertRaisesRegex(InstallError, "request_invalid"):
+            self.coordinator.update(self.environment.request())
+        self.assertEqual(self.environment.database.read_bytes(), before)
+        self.assertTrue(self.environment.old_running)
+        self.assertEqual(self.environment.current, "old")
+        self.assertNotIn("run_migration", self.environment.calls)
+
+    def test_failure_during_migration_restores_database_and_old_service(self) -> None:
+        # backup 之后才失败，走 restore_database（备份→恢复不保证逐字节一致，
+        # 只保证逻辑行一致），因此用行级内容而不是原始字节比较。
+        self.environment.fail_at = "run_migration"
+        with self.assertRaisesRegex(InstallError, "installer_error"):
+            self.coordinator.update(self.environment.request())
+        self.assertEqual(_read_values(self.environment.database), ("seed",))
+        self.assertEqual(self.environment.current, "old")
+        self.assertTrue(self.environment.old_running)
+        self.assertNotIn("activate_new_runtime", self.environment.calls)
+        self.assertNotIn("retain_runtimes", self.environment.calls)
+
+    def test_failure_during_current_replacement_restores_database_and_old_runtime(self) -> None:
+        self.environment.fail_at = "activate_new_runtime"
+        with self.assertRaisesRegex(InstallError, "installer_error"):
+            self.coordinator.update(self.environment.request())
+        self.assertEqual(_read_values(self.environment.database), ("seed",))
+        self.assertEqual(self.environment.current, "old")
+        self.assertTrue(self.environment.old_running)
+        self.assertNotIn("commit_receipt", self.environment.calls)
+
+    def test_failure_during_receipt_commit_restores_database_and_old_runtime(self) -> None:
+        self.environment.fail_at = "commit_receipt"
+        with self.assertRaisesRegex(InstallError, "installer_error"):
+            self.coordinator.update(self.environment.request())
+        self.assertEqual(_read_values(self.environment.database), ("seed",))
+        self.assertEqual(self.environment.current, "old")
+        self.assertEqual(self.environment.receipt_current, "old")
+        self.assertTrue(self.environment.old_running)
+        self.assertIn("revert_to_old_runtime", self.environment.calls)
+
+    def test_failed_new_service_restores_database_and_previous_runtime_without_new_write(
+        self,
+    ) -> None:
+        """健康检查超时（不写入任何数据）必须走干净回滚而非 conflict。"""
+        self.environment.health_result = False
+        with self.assertRaisesRegex(InstallError, "activation_failed"):
+            self.coordinator.update(self.environment.request())
+        self.assertEqual(self.environment.current, "old")
+        self.assertEqual(_read_values(self.environment.database), ("seed",))
+        self.assertTrue(self.environment.old_running)
+        self.assertFalse(self.environment.new_running)
+
+    def test_service_refresh_raising_directly_also_restores_cleanly(self) -> None:
+        self.environment.fail_at = "start_new_service"
+        with self.assertRaisesRegex(InstallError, "installer_error"):
+            self.coordinator.update(self.environment.request())
+        self.assertEqual(self.environment.current, "old")
+        self.assertEqual(_read_values(self.environment.database), ("seed",))
+        self.assertTrue(self.environment.old_running)
+
+    def test_external_write_after_new_runtime_starts_blocks_destructive_restore(self) -> None:
+        """新 service 已经写入真实数据后，绝不能销毁性恢复。"""
+        self.environment.write_on_start = "written-by-new-service"
+        self.environment.health_result = False
+        with self.assertRaisesRegex(InstallError, "rollback_conflict"):
+            self.coordinator.update(self.environment.request())
+        self.assertTrue(self.environment.backup_path.exists())
+        self.assertIn("written-by-new-service", _read_values(self.environment.database))
+        self.assertFalse(self.environment.old_running)
+        self.assertFalse(self.environment.new_running)
+        # conflict 时绝不允许恢复 current/receipt：新状态原样保留。
+        self.assertNotIn("revert_to_old_runtime", self.environment.calls)
+        self.assertNotIn("retain_runtimes", self.environment.calls)
+
+    def test_external_write_during_commit_failure_also_blocks_destructive_restore(self) -> None:
+        """即使失败点是 receipt commit，只要已经发生外部写入也必须是 conflict。"""
+
+        def commit_with_external_write() -> None:
+            self.environment.calls.append("commit_receipt")
+            _write_external_row(self.environment.database, "written-during-commit")
+            raise InstallError("installer_error", "manifest")
+
+        with self.assertRaisesRegex(InstallError, "rollback_conflict"):
+            self.coordinator.update(self.environment.request(commit_receipt=commit_with_external_write))
+        self.assertTrue(self.environment.backup_path.exists())
+        self.assertIn("written-during-commit", _read_values(self.environment.database))
+        self.assertNotIn("revert_to_old_runtime", self.environment.calls)
+
+    def test_guard_open_failure_after_stop_still_restarts_old_service(self) -> None:
+        request = self.environment.request(database=self.tmp / "does-not-exist.db")
+        with self.assertRaisesRegex(InstallError, "request_invalid"):
+            self.coordinator.update(request)
+        self.assertEqual(self.environment.calls, ["stop_old_service", "restart_old_service"])
+        self.assertTrue(self.environment.old_running)
+
+    def test_new_service_always_stopped_before_any_recovery_decision(self) -> None:
+        self.environment.fail_at = "start_new_service"
+        with self.assertRaises(InstallError):
+            self.coordinator.update(self.environment.request())
+        self.assertIn("stop_new_service", self.environment.calls)
+        self.assertLess(
+            self.environment.calls.index("stop_new_service"),
+            len(self.environment.calls),
+        )
+
+
+class UpdateStateHomeIsolationTests(unittest.TestCase):
+    """验证 update 事务绝不触碰 Memory/Skills/Workspace 之类的用户数据。"""
+
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.state_home = Path(self.temporary.name) / "state"
+        self.state_home.mkdir()
+        self.environment = _Environment(self.state_home)
+        self.memory_file = self.state_home / "MEMORY.md"
+        self.memory_file.write_text("# Long-term Memory\nkeep me\n", encoding="utf-8")
+        self.skills_dir = self.state_home / "skills" / "example"
+        self.skills_dir.mkdir(parents=True)
+        (self.skills_dir / "SKILL.md").write_text("skill content", encoding="utf-8")
+        self.workspace_dir = self.state_home / "workspace"
+        self.workspace_dir.mkdir()
+        (self.workspace_dir / "note.txt").write_text("workspace content", encoding="utf-8")
+        self.watched = {
+            self.memory_file: self.memory_file.read_bytes(),
+            self.skills_dir / "SKILL.md": (self.skills_dir / "SKILL.md").read_bytes(),
+            self.workspace_dir / "note.txt": (self.workspace_dir / "note.txt").read_bytes(),
+        }
+        self.coordinator = UpdateCoordinator()
+
+    def _assert_untouched(self) -> None:
+        for path, original in self.watched.items():
+            self.assertTrue(path.is_file(), path)
+            self.assertEqual(path.read_bytes(), original, path)
+
+    def test_successful_update_never_touches_user_state_files(self) -> None:
+        self.coordinator.update(self.environment.request())
+        self._assert_untouched()
+
+    def test_clean_rollback_never_touches_user_state_files(self) -> None:
+        self.environment.fail_at = "activate_new_runtime"
+        with self.assertRaises(InstallError):
+            self.coordinator.update(self.environment.request())
+        self._assert_untouched()
+
+    def test_rollback_conflict_never_touches_user_state_files(self) -> None:
+        self.environment.write_on_start = "conflict-write"
+        self.environment.health_result = False
+        with self.assertRaisesRegex(InstallError, "rollback_conflict"):
+            self.coordinator.update(self.environment.request())
+        self._assert_untouched()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_install_update.py
+++ b/tests/test_install_update.py
@@ -206,6 +206,18 @@ class DatabaseBackupRestoreTests(unittest.TestCase):
             restore_database(self.tmp / "absent-backup.db", self.database)
         self.assertEqual(self.database.read_bytes(), before)
 
+    def test_restore_discards_stale_wal_and_shm_sidecars(self) -> None:
+        """失败 migration 遗留的 -wal/-shm 描述旧主文件，必须随恢复一起清理。"""
+        backup_database(self.database, self.backup_path)
+        wal = self.database.with_name(f"{self.database.name}-wal")
+        shm = self.database.with_name(f"{self.database.name}-shm")
+        wal.write_bytes(b"stale-wal-frames-from-failed-migration")
+        shm.write_bytes(b"stale-shm")
+        restore_database(self.backup_path, self.database)
+        self.assertFalse(wal.exists())
+        self.assertFalse(shm.exists())
+        self.assertEqual(_read_values(self.database), ("seed",))
+
 
 class UpdateCoordinatorTests(unittest.TestCase):
     """覆盖每个 crash window 的确定性终态，以及 no-shortcut 不变量。"""


### PR DESCRIPTION
## Summary

一键安装项目 Milestone 5:交付 Task 13——数据库安全的升级、回滚与保留策略。这是让"升级"这件事在出错时不会毁掉用户数据的核心机制。

**新增 `src/lobster0/install/update.py`：**

- **`DatabaseChangeGuard`** —— 用一个全程持有的只读连接监控 SQLite `PRAGMA data_version`,用来判断"预期的 migration 之后,是否又有别人写过这个数据库"。只读 URI 连接不会持有写锁,不会阻塞 migration 本身。
- **`backup_database` / `restore_database`** —— 备份用 `sqlite3.Connection.backup()`(而不是直接拷文件,拷文件在 WAL 模式下可能拿到不一致快照),写 owner-only 0600 文件并 fsync;恢复走"临时文件 + fsync + `os.replace`"的原子替换。
- **`UpdateCoordinator.update(request)`** —— 状态机 `stopped → backed_up → migrated → activated → committed → service_started`。**无条件先备份**(即使 schema 版本没变也不允许走"兼容就跳过备份"的捷径,这是计划里明确禁止的)。任一阶段失败:先停掉新 service,然后分两种情况——
  - 守卫显示 migration 之后**没有**外部写入:销毁性恢复数据库 + 旧 Runtime + 旧 service,重新抛出原始异常;
  - 守卫显示**已经有**外部写入:绝不覆盖这些数据,保留备份和当前状态,改抛 `rollback_conflict` 交人工处理。

**修改 `src/lobster0/install/orchestrator.py`：** 把 `action="update"` 原先的 fail-closed 桩替换为真实管线,复用既有的 Task 8/10/11 原语(`activate_runtime`、`service_install`/`service_uninstall`、`retain_current_and_previous`),沿用同一套 `InstallLock` 与事件发射约定。

**修复(自查发现的真实隐患,commit `7c1b566`)：** 恢复数据库时没有清理失败 migration 遗留的 `-wal`/`-shm` 边车文件。这些边车描述的是被替换掉的旧主文件,一旦主文件被换掉而边车留着,下次打开会用不匹配的 WAL 帧去恢复一个它从没见过的主文件,存在损坏风险。

## Why

对应[实施计划](../blob/main/docs/superpowers/plans/2026-08-09-one-line-install-and-release.md) Task 13 与[设计文档](../blob/main/docs/superpowers/specs/2026-08-09-one-line-install-and-release-design.md)。

前面几个 Milestone 打通了"全新安装"的完整链路(下载校验 → 原子落盘 → 服务注册 → 崩溃恢复 → 一行 curl 引导)。但 Task 11 当时刻意把"升级"这条路留成了 fail-closed 的桩,因为升级比全新安装多一个根本性风险:**用户的数据库里已经有真实数据了**。升级要跑 schema migration,而 migration 之后如果服务健康检查没过需要回滚,直接把备份盖回去就可能抹掉用户在这期间产生的新数据。Task 13 就是补上这块——用 `data_version` 守卫把"可以安全回滚"和"回滚会丢数据"这两种情况严格区分开,后者宁可停在一个需要人工介入的状态,也不自动做破坏性操作。

## Verification

- 焦点测试:`tests.test_install_update` 26/26 + `tests.test_install_orchestrator` 74/74 = **100/100 通过**。崩溃窗口覆盖:备份前失败、备份过程中失败、migration 失败、`current` 切换失败、service 刷新失败、健康检查超时、receipt 提交失败,每种都断言最终状态确定且正确。另有测试断言 Memory/Skills/Workspace 全程不参与恢复与删除。
- 全量测试:合并最新 main(含其他会话的 Phase 7 Controlled Evolution 与官网工作,无冲突)后 **1443 项**,唯一 error 是已知的本机 `TuiBundleTest.setUpClass`(本机 Node 22.19.0/pnpm 7.29.2 低于项目门槛),与本次改动无关,已单独复现确认。
- Ruff、docs validator 合并前后各跑一次,全部 PASS。
- 当前 `LATEST_SCHEMA_VERSION` 为 6,但 `UpdateCoordinator` **不硬编码任何 schema 版本**——migration 是注入的不透明回调,守卫只比较 `data_version` 快照,因此其他会话新增 schema v7 不影响本实现。
- 独立复核(第二人视角)重跑了全部门禁,并逐行审阅了 `update.py`,确认守卫连接不持写锁、备份不走文件拷贝、恢复路径原子且 fsync 完整。

## 复核记录的非阻塞观察

1. `run_migration` 自身失败时会直接销毁性恢复而不查守卫——这是正确的,因为此刻守卫基线仍是 migration 前的值,查了反而会把 migration 自己的提交误判成外部写入;计划的契约也只覆盖"migration 之后"的提交。代价是:如果恰好有外部进程在 migration 窗口内写入,会被覆盖。
2. 若 `has_external_commit()` 或 `restore_database()` 自身抛错,原始失败原因会被替换成 `installer_error` 且不做破坏性恢复——行为是 fail-safe 的,只是错误码不够具体。
3. 每次尝试的备份文件以 `os.getpid()` 命名,失败/冲突后不会主动清理,孤儿备份可能累积——应归 Task 14 的 Doctor 处理。

## Checklist

- [x] 变更聚焦于 Task 13 既定范围(4 个文件),未引入范围外功能。
- [x] 已运行相关检查(见 Verification 小节)。
- [x] 进度台账已记录实现与复核结论(本地 `.superpowers/sdd/`,按项目约定不入库)。
- [x] 未包含密钥、凭证或个人数据。
