### PR TITLE
feat(cli): 交付 Milestone 6 公开 service/update/uninstall 与安装感知 Doctor

### DIFF
--- a/src/lobster0/cli.py
+++ b/src/lobster0/cli.py
@@ -2,6 +2,8 @@
 
 import argparse
 import asyncio
+import importlib.metadata as importlib_metadata
+import importlib.util
 import json
 import os
 import re
@@ -50,12 +52,22 @@ from lobster0.gateway_service import (
     ServiceError,
     render_launchd_service,
 )
+from lobster0.install.orchestrator import resolve_install_facts, run_install_action
 from lobster0.paths import PathConfigurationError, StatePaths, build_state_paths, resolve_home
 from lobster0.setup import SetupError, run_interactive_setup
 from lobster0.storage.database import Database, DatabaseError
-from lobster0.storage.migrations import MigrationError, apply_migrations
+from lobster0.storage.migrations import (
+    LATEST_SCHEMA_VERSION,
+    MigrationError,
+    apply_migrations,
+)
 from lobster0.storage.repositories import OwnerRepository
-from lobster0.tui_launcher import TuiLaunchError, run_default_tui
+from lobster0.tui_launcher import (
+    TuiLaunchError,
+    inspect_pi_tui,
+    is_supported_node_version,
+    run_default_tui,
+)
 
 _SERVICE_OPTIONAL_CHECKS = frozenset({"pi_tui", "browser"})
 
@@ -145,7 +157,7 @@ def build_parser() -> argparse.ArgumentParser:
     feedback_forget.add_argument("feedback_id", type=_positive_cli_id)
     service_parser = subparsers.add_parser(
         "service",
-        help="manage the owned macOS LaunchAgent",
+        help="manage the owned Lobster0 Gateway user service",
     )
     service_parser.add_argument(
         "--home",
@@ -156,8 +168,66 @@ def build_parser() -> argparse.ArgumentParser:
         dest="service_command",
         required=True,
     )
-    for name in ("install", "status", "restart", "uninstall"):
-        service_subparsers.add_parser(name, help=f"{name} the Lobster0 LaunchAgent")
+    for name in ("install", "status", "logs", "restart", "uninstall"):
+        service_subparsers.add_parser(name, help=f"{name} the Lobster0 Gateway service")
+    update_parser = subparsers.add_parser(
+        "update",
+        help="update a managed Lobster0 install to a newer Release",
+    )
+    update_parser.add_argument(
+        "--home",
+        dest="command_home",
+        help="absolute Lobster0 state directory",
+    )
+    update_parser.add_argument("--version", dest="target_version", help="exact target SemVer")
+    update_parser.add_argument("--channel", choices=("stable", "dev"), default="stable")
+    update_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="emit one redacted machine-readable report",
+    )
+    uninstall_parser = subparsers.add_parser(
+        "uninstall",
+        help="remove the managed Lobster0 install and keep user data by default",
+    )
+    uninstall_parser.add_argument(
+        "--home",
+        dest="command_home",
+        help="absolute Lobster0 state directory",
+    )
+    uninstall_parser.add_argument(
+        "--purge-data",
+        action="store_true",
+        help="also delete the enumerated Lobster0 state; the Workspace is always kept",
+    )
+    uninstall_parser.add_argument(
+        "--yes-i-understand-data-loss",
+        action="store_true",
+        dest="confirm_data_loss",
+        help="required exact confirmation for a noninteractive --purge-data run",
+    )
+    uninstall_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="emit one redacted machine-readable report",
+    )
+    smoke_parser = subparsers.add_parser(
+        "install-smoke",
+        help="internal offline install gate for a freshly built Runtime",
+    )
+    smoke_parser.add_argument(
+        "--home",
+        dest="command_home",
+        help="absolute Lobster0 state directory",
+    )
+    smoke_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="emit one machine-readable smoke document",
+    )
     eval_parser = subparsers.add_parser("eval", help="run deterministic agent regressions")
     eval_subparsers = eval_parser.add_subparsers(dest="eval_command", required=True)
     eval_list = eval_subparsers.add_parser("list", help="list versioned eval cases")
@@ -260,6 +330,27 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if arguments.command == "service":
         return _run_service(paths, arguments)
+
+    if arguments.command == "update":
+        return run_install_action(
+            "update",
+            state_home=paths.home,
+            version=arguments.target_version,
+            channel=arguments.channel,
+            json_output=bool(arguments.json_output),
+        )
+
+    if arguments.command == "uninstall":
+        return run_install_action(
+            "uninstall",
+            state_home=paths.home,
+            purge_data=bool(arguments.purge_data),
+            confirm_data_loss=bool(arguments.confirm_data_loss),
+            json_output=bool(arguments.json_output),
+        )
+
+    if arguments.command == "install-smoke":
+        return _run_install_smoke(paths, json_output=bool(arguments.json_output))
 
     if arguments.command == "gateway":
         try:
@@ -470,18 +561,27 @@ def _run_feedback(paths: StatePaths, arguments: argparse.Namespace) -> int:
 
 
 def _run_service(paths: StatePaths, arguments: argparse.Namespace) -> int:
-    """执行固定的 macOS LaunchAgent lifecycle，不公开 manager 原始输出。
+    """按 install receipt 分流受管 user service 与源码 checkout LaunchAgent。
+
+    受管安装（存在有效 install receipt）走 installer 的 systemd-user/launchd
+    service 层；源码 checkout 保持 Phase 6 的 macOS LaunchAgent 行为、输出与
+    退出码不变。`logs` 只对受管安装有意义，源码模式按既有约定干净失败。
 
     Args:
         paths: 已解析的 Lobster0 状态路径。
-        arguments: argparse 生成且只含四个固定动作的参数。
+        arguments: argparse 生成且只含五个固定动作的参数。
 
     Returns:
         成功为 0、配置/preflight 错误为 2、service lifecycle 错误为 5。
     """
+    command = arguments.service_command
+    if resolve_install_facts(paths.home).managed:
+        return run_install_action(f"service.{command}", state_home=paths.home)
+    if command == "logs":
+        print("error: service_logs_unavailable", file=sys.stderr)
+        return 2
     try:
         service = _launchd_service(paths)
-        command = arguments.service_command
         if command == "install":
             _service_install_preflight(paths)
             service.install()
@@ -508,6 +608,84 @@ def _run_service(paths: StatePaths, arguments: argparse.Namespace) -> int:
     except ServiceError as error:
         print(f"error: {error.code}", file=sys.stderr)
         return 5
+
+
+def _run_install_smoke(paths: StatePaths, *, json_output: bool) -> int:
+    """离线校验一个新建 Runtime 是否可用，不触碰 Provider、Channel 或网络。
+
+    只做 module discovery、包元数据读取、Node/TUI 入口检查和本地数据库
+    schema 只读比对；不实例化任何 SDK Client，也不发起认证或 HTTP。
+
+    Args:
+        paths: 已解析的 Lobster0 状态路径。
+        json_output: 为真时输出唯一 machine-readable 文档。
+
+    Returns:
+        全部检查通过为 0，否则为 2。
+    """
+    find_spec = importlib.util.find_spec
+    checks: dict[str, str] = {}
+    try:
+        distribution = importlib_metadata.version("lobster0-agent")
+    except importlib_metadata.PackageNotFoundError:
+        distribution = None
+    checks["metadata"] = "ok" if distribution == __version__ else "error"
+    console_scripts = {
+        entry.name for entry in importlib_metadata.entry_points(group="console_scripts")
+    }
+    checks["entry_point"] = "ok" if "lobster0" in console_scripts else "error"
+    for channel, module in (
+        ("feishu", "lark_channel"),
+        ("telegram", "telegram"),
+        ("discord", "discord"),
+    ):
+        checks[f"channel_{channel}"] = "ok" if find_spec(module) is not None else "error"
+    for name, module in (
+        ("automation", "lobster0.automation.repository"),
+        ("sandbox", "lobster0.sandbox.base"),
+        ("checkpoint", "lobster0.checkpoints"),
+    ):
+        checks[name] = "ok" if find_spec(module) is not None else "error"
+    inspection = inspect_pi_tui(os.environ)
+    checks["node"] = (
+        "ok"
+        if inspection.node_version is not None
+        and is_supported_node_version(inspection.node_version)
+        else "error"
+    )
+    checks["tui_entry"] = "ok" if inspection.entry is not None else "error"
+    checks["database"] = _install_smoke_database(paths)
+    status = "ok" if all(value == "ok" for value in checks.values()) else "error"
+    if json_output:
+        print(
+            json.dumps(
+                {"checks": checks, "status": status, "version": __version__},
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+            )
+        )
+    else:
+        for name, value in sorted(checks.items()):
+            print(f"[{value.upper()}] {name}")
+        print(f"install-smoke {status} version={__version__}")
+    return 0 if status == "ok" else 2
+
+
+def _install_smoke_database(paths: StatePaths) -> str:
+    """只读比对本地数据库 schema；状态尚未创建时视为无需校验。"""
+    if not paths.database.is_file() or paths.database.is_symlink():
+        return "ok"
+    try:
+        with Database(paths.database).connect_read_only() as connection:
+            version = int(
+                connection.execute(
+                    "SELECT COALESCE(MAX(version), 0) FROM schema_migrations"
+                ).fetchone()[0]
+            )
+    except (DatabaseError, sqlite3.Error, OSError):
+        return "error"
+    return "ok" if version == LATEST_SCHEMA_VERSION else "error"
 
 
 def _launchd_service(paths: StatePaths) -> LaunchdService:

--- a/src/lobster0/doctor.py
+++ b/src/lobster0/doctor.py
@@ -21,6 +21,11 @@ from lobster0.config import (
     load_config,
     resolve_permission_roots,
 )
+from lobster0.install.layout import InstallLayout
+from lobster0.install.models import InstallError
+from lobster0.install.orchestrator import resolve_install_facts
+from lobster0.install.receipt import InstallReceipt, managed_file_sha256
+from lobster0.install.runtime import RuntimeReceipt
 from lobster0.paths import StatePaths
 from lobster0.policy.command import CommandPolicyError, normalize_command
 from lobster0.policy.executables import ExecutableEnvironment, discover_executables
@@ -62,7 +67,7 @@ def run_local_checks(
         environ: 配置覆盖使用的环境变量；默认使用当前进程环境。
 
     Returns:
-        固定二十八项、按依赖顺序排列的安全诊断结果。
+        二十八项本地诊断，外加一项 `install_method`；受管安装再追加五项安装事实。
     """
     state_result = _check_state_home(paths)
     config_result, config = _check_config(paths, environ)
@@ -98,6 +103,144 @@ def run_local_checks(
         _check_channel_runtime(config, "discord", source),
         _check_channel_database(paths),
         _check_channel_workers(config),
+        *_check_install(paths, source),
+    )
+
+
+def _check_install(paths: StatePaths, environ: Mapping[str, str]) -> tuple[CheckResult, ...]:
+    """报告安装方式与受管 Runtime/Node/TUI/service 事实，全程离线只读。
+
+    源码 checkout 只产生一项 `install_method` WARN，绝不因为缺少安装事实而
+    FAIL；受管安装再补齐 receipt、Runtime、Node、TUI 与 service 五项事实。
+    本函数不发起任何网络调用，也不读取任何 Secret 值。
+
+    Args:
+        paths: 需要诊断的 Lobster0 状态路径。
+        environ: 用于发现受管 program prefix 的环境变量。
+
+    Returns:
+        一项或六项安全诊断结果。
+    """
+    facts = resolve_install_facts(paths.home, environ=environ)
+    if not facts.managed or facts.receipt is None or facts.layout is None:
+        return (
+            CheckResult(
+                "install_method",
+                CheckStatus.WARN,
+                f"source checkout; no managed install receipt was found ({facts.detail})",
+            ),
+        )
+    receipt = facts.receipt
+    layout = facts.layout
+    runtime = layout.program_prefix / receipt.current_runtime
+    return (
+        CheckResult(
+            "install_method",
+            CheckStatus.PASS,
+            f"managed install {receipt.version} at {layout.program_prefix}",
+        ),
+        _check_release_receipt(layout, receipt),
+        _check_managed_runtime(layout, receipt, runtime),
+        *_check_managed_components(runtime),
+        _check_managed_service(layout, receipt),
+    )
+
+
+def _check_release_receipt(layout: InstallLayout, receipt: InstallReceipt) -> CheckResult:
+    """确认 launcher 与 PATH command link 仍匹配 install receipt。"""
+    name = "release_receipt"
+    try:
+        if managed_file_sha256(layout.launcher) != receipt.launcher_sha256:
+            return CheckResult(name, CheckStatus.FAIL, "stable launcher no longer matches receipt")
+        link = layout.command_link
+        relative = os.path.relpath(layout.launcher, start=link.parent)
+        if not link.is_symlink() or os.readlink(link) != relative:
+            return CheckResult(name, CheckStatus.FAIL, "PATH command link is not the managed link")
+    except (InstallError, OSError):
+        return CheckResult(name, CheckStatus.FAIL, "managed program files cannot be verified")
+    return CheckResult(
+        name,
+        CheckStatus.PASS,
+        f"receipt {receipt.version} matches the launcher and command link",
+    )
+
+
+def _check_managed_runtime(
+    layout: InstallLayout,
+    receipt: InstallReceipt,
+    runtime: Path,
+) -> CheckResult:
+    """确认 current 指向 receipt 记录的 Runtime，且 Runtime receipt 可读。"""
+    name = "managed_runtime"
+    current = layout.current
+    try:
+        if not current.is_symlink() or os.readlink(current) != receipt.current_runtime:
+            return CheckResult(name, CheckStatus.FAIL, "current does not point at the Runtime")
+        if not (runtime / "venv" / "bin" / "python").is_file():
+            return CheckResult(name, CheckStatus.FAIL, "managed Runtime venv is missing")
+        RuntimeReceipt.load(runtime / "install-receipt.json")
+    except (InstallError, OSError):
+        return CheckResult(name, CheckStatus.FAIL, "managed Runtime cannot be verified")
+    return CheckResult(
+        name,
+        CheckStatus.PASS,
+        f"managed Runtime {receipt.current_runtime} is activated",
+    )
+
+
+def _check_managed_components(runtime: Path) -> tuple[CheckResult, ...]:
+    """从 Runtime receipt 报告受管 Node 与 TUI 事实，不执行任何子进程。"""
+    try:
+        runtime_receipt = RuntimeReceipt.load(runtime / "install-receipt.json")
+    except (InstallError, OSError):
+        return (
+            CheckResult("managed_node", CheckStatus.FAIL, "managed Node cannot be verified"),
+            CheckResult("managed_tui", CheckStatus.FAIL, "managed TUI cannot be verified"),
+        )
+    node = runtime / "node" / "bin" / "node"
+    node_version = tuple(int(part) for part in runtime_receipt.node_version.split("."))
+    if not node.is_file() or node.is_symlink():
+        node_result = CheckResult("managed_node", CheckStatus.FAIL, "managed Node is missing")
+    elif not is_supported_node_version(node_version):
+        node_result = CheckResult(
+            "managed_node",
+            CheckStatus.FAIL,
+            f"managed Node {runtime_receipt.node_version} is outside the supported range",
+        )
+    else:
+        node_result = CheckResult(
+            "managed_node",
+            CheckStatus.PASS,
+            f"managed Node {runtime_receipt.node_version} is installed",
+        )
+    entry = runtime / "tui" / "dist" / "main.js"
+    if not entry.is_file() or entry.is_symlink():
+        tui_result = CheckResult("managed_tui", CheckStatus.FAIL, "managed TUI entry is missing")
+    else:
+        tui_result = CheckResult(
+            "managed_tui",
+            CheckStatus.PASS,
+            f"managed pi-tui {runtime_receipt.tui_version} entry is ready",
+        )
+    return (node_result, tui_result)
+
+
+def _check_managed_service(layout: InstallLayout, receipt: InstallReceipt) -> CheckResult:
+    """只按 receipt 的 label/path/hash 比对 service 文件，不调用 service manager。"""
+    name = "managed_service"
+    digest = receipt.service_file_sha256
+    if digest is None or receipt.service_file is None:
+        return CheckResult(name, CheckStatus.WARN, "no managed Gateway service is installed")
+    service_file = layout.command_link.parents[2] / receipt.service_file
+    try:
+        if managed_file_sha256(service_file) != digest:
+            return CheckResult(name, CheckStatus.FAIL, "service file no longer matches receipt")
+    except (InstallError, OSError):
+        return CheckResult(name, CheckStatus.FAIL, "managed service file cannot be verified")
+    return CheckResult(
+        name,
+        CheckStatus.PASS,
+        f"managed service {receipt.service_label} matches receipt",
     )
 
 

--- a/src/lobster0/install/orchestrator.py
+++ b/src/lobster0/install/orchestrator.py
@@ -31,6 +31,8 @@ from lobster0.install.artifacts import (
     extract_tar_gz,
 )
 from lobster0.install.layout import (
+    _SYSTEM_COMMAND,
+    _SYSTEM_PREFIX,
     InstallLayout,
     InstallLock,
     install_launcher,
@@ -70,6 +72,9 @@ from lobster0.install.service import (
     ServicePlatform,
     render_service_spec,
     service_install,
+    service_logs,
+    service_restart,
+    service_status,
     service_uninstall,
 )
 from lobster0.install.update import UpdateCoordinator, UpdateRequest
@@ -85,12 +90,43 @@ _ENV_NAME = re.compile(r"^[A-Z][A-Z0-9_]{0,127}$")
 _IMAGE = re.compile(r"^[a-z0-9][a-z0-9./_-]{0,255}@sha256:[0-9a-f]{64}$")
 _MAX_MANIFEST_BYTES = 1_048_576
 _MAX_SECRET_BYTES = 64 * 1024
+_MAX_PYZ_BYTES = 32 * 1024 * 1024
 _MAX_CONFIG_BYTES = 1024 * 1024
 _PATH = "/usr/local/bin:/usr/bin:/bin"
 _TIMEOUT = 300.0
 _OUTPUT_LIMIT = 64 * 1024
 _UPDATE_HEALTH_TIMEOUT = 30.0
 _INTERNAL_HOP = "LOBSTER0_INSTALLER_HOPS"
+_PREFIX_ENV = "LOBSTER0_PREFIX"
+_RECEIPT_NAME = "install-receipt.json"
+_INSTALLER_NAME = "lobster0-installer.pyz"
+_MANIFEST_NAME = "release-manifest.json"
+_PURGE_PHRASE = "DELETE ALL LOBSTER0 DATA"
+_UPDATE_BACKUP_PREFIX = ".lobster0.db.update-backup."
+_RUNTIME_RESIDUE = re.compile(r"^\.(?P<version>.+)\.(?:staging|downloads)$")
+_PURGE_FILES = (
+    "config.toml",
+    "secrets.env",
+    "lobster0.db",
+    "lobster0.db-wal",
+    "lobster0.db-shm",
+    "SOUL.md",
+    "USER.md",
+    "MEMORY.md",
+)
+_PURGE_DIRECTORIES = (
+    "memory",
+    "prompts",
+    "skills",
+    "evals",
+    "browser",
+    "artifacts",
+    "downloads",
+    "logs",
+    "run",
+    "checkpoints",
+)
+_SERVICE_ACTIONS = ("install", "status", "logs", "restart", "uninstall")
 _CHANNEL_FIELDS = {
     "feishu": ("app_id_env", "app_secret_env"),
     "telegram": ("bot_token_env",),
@@ -495,7 +531,18 @@ class Installer:
         hop = self._environ.get(_INTERNAL_HOP)
         if hop not in {None, "", "1"}:
             raise InstallError("request_invalid", "manifest")
-        if request.action == "uninstall" or request.action == "update" and request.dry_run:
+        if request.action == "uninstall":
+            # 只有已安装 CLI 发起、且已经带上 one-hop guard 的 uninstall 才
+            # 允许进入受 receipt 约束的删除路径；裸 bootstrap 没有 receipt
+            # 事实可依据，必须继续 fail closed。
+            if request.dry_run or hop != "1":
+                raise InstallError("request_invalid", "action")
+            return run_uninstall_request(
+                request,
+                environ=self._environ,
+                execve=self._execve,
+            )
+        if request.action == "update" and request.dry_run:
             raise InstallError("request_invalid", "action")
         plan = self._operations.preflight(request, self._bootstrap)
         self._emit(InstallEvent("install.preflight", "ok", None, "manifest"))
@@ -2309,3 +2356,782 @@ def _semver_key(value: str) -> tuple[int, int, int, int, tuple[tuple[int, object
 def _installer_error() -> Never:
     """抛出不含底层路径的稳定 installer error。"""
     raise InstallError("installer_error", "manifest")
+
+
+@dataclass(frozen=True, slots=True)
+class InstallFacts:
+    """描述当前进程面对的是受管安装还是源码 checkout。
+
+    Args:
+        managed: 解析到的 program prefix 是否持有有效 install receipt。
+        program_prefix: 已发现的受管程序根；源码模式为 ``None``。
+        state_home: 调用方选择的状态根。
+        receipt: 已通过 strict 校验的 install receipt。
+        layout: 与 receipt 版本绑定的受管 layout。
+        detail: 稳定、不含私有路径的判定原因。
+    """
+
+    managed: bool
+    program_prefix: Path | None
+    state_home: Path
+    receipt: InstallReceipt | None
+    layout: InstallLayout | None
+    detail: str
+
+
+def resolve_install_facts(
+    state_home: Path,
+    *,
+    environ: Mapping[str, str] | None = None,
+    executable: Path | None = None,
+    user_home: Path | None = None,
+) -> InstallFacts:
+    """判定当前状态根对应的是受管安装还是源码 checkout。
+
+    CLI 与 Doctor 共用这一个判定，避免两处各自实现 receipt 发现逻辑。
+
+    Args:
+        state_home: 已解析的绝对状态根。
+        environ: 读取 ``LOBSTER0_PREFIX`` 的环境；省略时使用当前进程环境。
+        executable: 当前解释器路径；省略时使用 ``sys.executable``。
+        user_home: 目标用户 Home；省略时按默认 `<home>/.lobster0` 布局或 passwd 解析。
+
+    Returns:
+        永不抛异常的安装事实；任何不可信 receipt 都降级为非受管并给出原因。
+    """
+    source = dict(os.environ if environ is None else environ)
+    if not _canonical_absolute(state_home):
+        return InstallFacts(False, None, Path(state_home), None, None, "state_home_invalid")
+    uid = os.geteuid()
+    account_home: Path | None = user_home
+    if account_home is None:
+        try:
+            account_home = Path(pwd.getpwuid(uid).pw_dir)
+        except (KeyError, OSError, TypeError):
+            return InstallFacts(False, None, state_home, None, None, "account_unavailable")
+    for prefix in _prefix_candidates(state_home, source, executable):
+        receipt_path = prefix / _RECEIPT_NAME
+        if not _lexists(receipt_path):
+            continue
+        home = (
+            prefix.parent
+            if user_home is None and prefix.name == ".lobster0"
+            else account_home
+        )
+        try:
+            receipt = InstallReceipt.load(receipt_path, expected_uid=uid)
+            layout = _installed_layout(prefix, state_home, receipt.version, uid=uid, user_home=home)
+        except (InstallError, OSError, ValueError):
+            return InstallFacts(False, prefix, state_home, None, None, "receipt_invalid")
+        return InstallFacts(True, prefix, state_home, receipt, layout, "managed")
+    return InstallFacts(False, None, state_home, None, None, "source")
+
+
+def _prefix_candidates(
+    state_home: Path,
+    environ: Mapping[str, str],
+    executable: Path | None,
+) -> tuple[Path, ...]:
+    """按可信度排序返回可能持有 install receipt 的 program prefix。"""
+    ordered: list[Path] = []
+    raw = environ.get(_PREFIX_ENV, "")
+    if type(raw) is str and raw:
+        candidate = Path(raw)
+        if _canonical_absolute(candidate):
+            ordered.append(candidate)
+    derived = _prefix_from_executable(
+        Path(sys.executable) if executable is None else Path(executable)
+    )
+    if derived is not None:
+        ordered.append(derived)
+    ordered.append(state_home)
+    unique: list[Path] = []
+    for item in ordered:
+        if item not in unique:
+            unique.append(item)
+    return tuple(unique)
+
+
+def _prefix_from_executable(executable: Path) -> Path | None:
+    """从受管 Runtime 中的解释器路径反推 program prefix。"""
+    if not _canonical_absolute(executable):
+        return None
+    parents = executable.parents
+    if len(executable.parts) < 6 or executable.parent.name != "bin":
+        return None
+    if parents[1].name != "venv":
+        return None
+    if parents[2].name == "current":
+        return parents[3]
+    if len(executable.parts) >= 7 and parents[3].name == "runtimes":
+        return parents[4]
+    return None
+
+
+def _installed_layout(
+    program_prefix: Path,
+    state_home: Path,
+    version: str,
+    *,
+    uid: int,
+    user_home: Path,
+) -> InstallLayout:
+    """按已安装 receipt 版本重建受管 layout 的全部固定路径。"""
+    command_link = (
+        _SYSTEM_COMMAND
+        if program_prefix == _SYSTEM_PREFIX
+        else user_home / ".local" / "bin" / "lobster0"
+    )
+    return InstallLayout._build(
+        program_prefix,
+        state_home,
+        command_link,
+        version,
+        owner_uid=uid,
+        user_home=user_home,
+    )
+
+
+def _lexists(path: Path) -> bool:
+    """不跟随 symlink 判断路径是否存在。"""
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        return False
+    except OSError:
+        return True
+    return True
+
+
+def _ownership_mismatch() -> Never:
+    """抛出不含私有路径的稳定受管文件所有权错误。"""
+    raise InstallError("uninstall_ownership_mismatch", "manifest")
+
+
+def _validate_purge_root(state_home: object, *, user_home: Path | None) -> None:
+    """拒绝把 `/`、Home 根、Workspace、symlink 或外部目录当作 purge 根。
+
+    Args:
+        state_home: 待删除状态根的候选路径。
+        user_home: 目标用户 Home；``None`` 表示跳过 Home 根比较。
+
+    Raises:
+        InstallError: 路径不是当前用户持有的、非 symlink 的专用状态目录。
+    """
+    if not isinstance(state_home, Path) or not _canonical_absolute(state_home):
+        raise InstallError("request_invalid", "state_home")
+    if state_home == Path("/") or state_home.name == "workspace":
+        raise InstallError("request_invalid", "state_home")
+    if user_home is not None and state_home == user_home:
+        raise InstallError("request_invalid", "state_home")
+    try:
+        metadata = state_home.lstat()
+    except OSError:
+        raise InstallError("request_invalid", "state_home") from None
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or stat.S_IMODE(metadata.st_mode) & 0o022
+    ):
+        raise InstallError("request_invalid", "state_home")
+
+
+def _purge_targets(state_home: Path) -> tuple[Path, ...]:
+    """枚举 purge 允许删除的显式状态路径，绝不做递归通配删除。"""
+    targets: list[Path] = []
+    for name in (*_PURGE_FILES, *_PURGE_DIRECTORIES):
+        candidate = state_home / name
+        if _lexists(candidate):
+            targets.append(candidate)
+    try:
+        with os.scandir(state_home) as entries:
+            for entry in entries:
+                if entry.name.startswith(_UPDATE_BACKUP_PREFIX):
+                    targets.append(state_home / entry.name)
+    except OSError:
+        raise InstallError("request_invalid", "state_home") from None
+    return tuple(sorted(set(targets)))
+
+
+def _managed_runtime_entry(name: str) -> bool:
+    """判断 runtimes/ 条目是否为受管 Runtime 或受管事务残留。"""
+    if _VERSION.fullmatch(name) is not None:
+        return True
+    residue = _RUNTIME_RESIDUE.fullmatch(name)
+    return residue is not None and _VERSION.fullmatch(residue.group("version")) is not None
+
+
+class Uninstaller:
+    """在 install receipt 边界内移除受管程序文件并按显式确认删除状态。"""
+
+    def __init__(
+        self,
+        layout: InstallLayout,
+        *,
+        runner: object | None = None,
+        environ: Mapping[str, str] | None = None,
+        execve: Callable[[str, tuple[str, ...], dict[str, str]], object] = os.execve,
+        executable: Path | None = None,
+        isatty: bool = False,
+        confirm: Callable[[str], str] | None = None,
+        stdout: TextIO | None = None,
+        user_home: Path | None = None,
+    ) -> None:
+        """绑定受管 layout、可注入 runner/execve 与交互确认来源。"""
+        if type(layout) is not InstallLayout or not callable(execve):
+            raise InstallError("request_invalid", "manifest")
+        self._layout = layout
+        self._runner = _SubprocessRunner() if runner is None else runner
+        self._environ = dict(os.environ if environ is None else environ)
+        self._execve = execve
+        self._executable = Path(sys.executable if executable is None else executable)
+        self._isatty = bool(isatty)
+        self._confirm = confirm
+        self._stdout = sys.stdout if stdout is None else stdout
+        self._user_home = user_home
+        self._events: list[InstallEvent] = []
+
+    def run(self, request: InstallRequest) -> InstallResult:
+        """执行一次受 receipt 约束的卸载，默认保留全部用户数据。
+
+        Args:
+            request: 已通过 strict model 校验的 uninstall 请求。
+
+        Returns:
+            仅含脱敏事件的安全终态。
+
+        Raises:
+            InstallError: 请求、确认、受管文件所有权或删除过程失败。
+        """
+        if type(request) is not InstallRequest:
+            raise InstallError("request_invalid", "model")
+        if request.action != "uninstall" or request.dry_run:
+            raise InstallError("request_invalid", "action")
+        self._events = []
+        uid = os.geteuid()
+        layout = self._layout
+        receipt = InstallReceipt.load(layout.receipt, expected_uid=uid)
+        self._emit(InstallEvent("uninstall.preflight", "ok", None, "manifest"))
+        if self._needs_handoff():
+            self._hand_off(request, receipt, uid)
+            _installer_error()
+        with InstallLock.acquire(layout):
+            if request.purge_data:
+                self._authorize_purge(request)
+            receipt = self._remove_service(receipt, uid)
+            self._remove_program_files(receipt, uid)
+            if request.purge_data:
+                self._purge(uid)
+        self._report(request)
+        return InstallResult("uninstall", receipt.version, None, True, tuple(self._events))
+
+    def _needs_handoff(self) -> bool:
+        """判断当前进程是否仍在即将被删除的 Runtime 内运行。"""
+        if self._environ.get(_INTERNAL_HOP) == "1":
+            return False
+        return self._executable.is_relative_to(self._layout.program_prefix)
+
+    def _hand_off(self, request: InstallRequest, receipt: InstallReceipt, uid: int) -> None:
+        """把控制权交给复制到 0700 私有目录并重新校验 hash 的 installer。
+
+        受管 Runtime 会在删除自身之前退出：先把 receipt 匹配的
+        `current/lobster0-installer.pyz` 复制出去、按 Runtime receipt 再校验一次
+        SHA-256，再用同一 Runtime 的 managed Python exec 它，并通过
+        ``LOBSTER0_INSTALLER_HOPS`` 做一次性跳转保护。
+
+        卸载不需要 bootstrap 信任根（Installer 在 preflight 之前就分流），
+        因此四个 internal bootstrap flag 只用于满足 pyz CLI 的结构契约，
+        全部指向本次私有目录；任何真正读取它们的代码路径都会 fail closed。
+        """
+        layout = self._layout
+        runtime = layout.program_prefix / receipt.current_runtime
+        data_mode = 0o644 if request.system_prefix else 0o600
+        runtime_receipt = RuntimeReceipt.load(
+            runtime / _RECEIPT_NAME,
+            expected_uid=uid,
+            expected_mode=data_mode,
+        )
+        source = runtime / _INSTALLER_NAME
+        payload = _read_private_file(source, uid, expected_mode=None, maximum=_MAX_PYZ_BYTES)
+        if not hmac.compare_digest(
+            hashlib.sha256(payload).hexdigest(),
+            runtime_receipt.installer_sha256,
+        ):
+            _ownership_mismatch()
+        manifest = _read_private_file(
+            runtime / _MANIFEST_NAME,
+            uid,
+            expected_mode=data_mode,
+            maximum=_MAX_MANIFEST_BYTES,
+        )
+        python = runtime / "python" / "bin" / "python3.12"
+        _require_private_executable(python, uid)
+        root = Path(tempfile.mkdtemp(prefix="lobster0-uninstall-"))
+        os.chmod(root, 0o700)
+        _require_private_directory(root, uid)
+        installer = root / _INSTALLER_NAME
+        _write_exclusive(installer, payload, 0o700)
+        manifest_file = root / _MANIFEST_NAME
+        _write_exclusive(manifest_file, manifest, 0o600)
+        if not hmac.compare_digest(
+            hashlib.sha256(installer.read_bytes()).hexdigest(),
+            runtime_receipt.installer_sha256,
+        ):
+            _ownership_mismatch()
+        python_root = root / "python"
+        (python_root / "bin").mkdir(mode=0o700, parents=True)
+        argv = (
+            str(python),
+            "-I",
+            str(installer),
+            "uninstall",
+            *_public_uninstall_argv(request),
+            "--manifest-file",
+            str(manifest_file),
+            "--manifest-sha256",
+            hashlib.sha256(manifest).hexdigest(),
+            "--managed-uv",
+            str(root / "uv"),
+            "--managed-python-root",
+            str(python_root),
+            "--managed-python-executable",
+            str(python_root / "bin" / "python3.12"),
+        )
+        environment = {_INTERNAL_HOP: "1", "PATH": _PATH}
+        if self._user_home is not None:
+            environment["HOME"] = str(self._user_home)
+        self._emit(InstallEvent("uninstall.handoff", "ok", None, "program_prefix"))
+        self._execve(str(python), argv, environment)
+
+    def _remove_service(self, receipt: InstallReceipt, uid: int) -> InstallReceipt:
+        """先停止并移除 label/path/hash 都匹配 receipt 的受管服务。"""
+        del uid
+        if receipt.service_file_sha256 is None:
+            return receipt
+        platform = (
+            ServicePlatform.SYSTEMD_USER
+            if receipt.platform.os == "linux"
+            else ServicePlatform.LAUNCHD
+        )
+        service_uninstall(
+            render_service_spec(self._layout, platform),
+            self._runner,
+            expected_sha256=receipt.service_file_sha256,
+        )
+        cleared = replace(
+            receipt,
+            service_label=None,
+            service_file=None,
+            service_file_sha256=None,
+        )
+        cleared.write(self._layout.receipt)
+        self._emit(InstallEvent("service.uninstalled", "ok", None, "service"))
+        return cleared
+
+    def _remove_program_files(self, receipt: InstallReceipt, uid: int) -> None:
+        """先完整验证受管文件，再删除 launcher、link、current 与 Runtime。"""
+        layout = self._layout
+        command_link = _lexists(layout.command_link)
+        if command_link:
+            expected = os.path.relpath(layout.launcher, start=layout.command_link.parent)
+            metadata = layout.command_link.lstat()
+            if (
+                not stat.S_ISLNK(metadata.st_mode)
+                or metadata.st_uid != uid
+                or os.readlink(layout.command_link) != expected
+            ):
+                _ownership_mismatch()
+        launcher = _lexists(layout.launcher)
+        if launcher and managed_file_sha256(
+            layout.launcher,
+            expected_uid=uid,
+        ) != receipt.launcher_sha256:
+            _ownership_mismatch()
+        current = _lexists(layout.current)
+        if current and _read_current(layout) != receipt.current_runtime:
+            _ownership_mismatch()
+        runtimes = self._validated_runtimes(uid)
+        try:
+            if command_link:
+                layout.command_link.unlink()
+                _fsync_directory(layout.command_link.parent)
+            if launcher:
+                layout.launcher.unlink()
+                _fsync_directory(layout.launcher.parent)
+            if current:
+                layout.current.unlink()
+            for runtime in runtimes:
+                shutil.rmtree(runtime)
+            if _lexists(layout.runtimes_dir):
+                layout.runtimes_dir.rmdir()
+            layout.receipt.unlink()
+            _fsync_directory(layout.program_prefix)
+        except OSError:
+            raise InstallError("uninstall_ownership_mismatch", "program_prefix") from None
+        self._prune_empty_directory(layout.bin_dir)
+        self._emit(InstallEvent("uninstall.program.removed", "ok", None, "program_prefix"))
+
+    def _validated_runtimes(self, uid: int) -> tuple[Path, ...]:
+        """只接受受管 Runtime 与受管事务残留，拒绝任何外来条目。"""
+        layout = self._layout
+        if not _lexists(layout.runtimes_dir):
+            return ()
+        metadata = layout.runtimes_dir.lstat()
+        if not stat.S_ISDIR(metadata.st_mode) or metadata.st_uid != uid:
+            _ownership_mismatch()
+        selected: list[Path] = []
+        try:
+            with os.scandir(layout.runtimes_dir) as entries:
+                for entry in entries:
+                    child = entry.stat(follow_symlinks=False)
+                    if (
+                        not _managed_runtime_entry(entry.name)
+                        or not stat.S_ISDIR(child.st_mode)
+                        or child.st_uid != uid
+                    ):
+                        _ownership_mismatch()
+                    selected.append(layout.runtimes_dir / entry.name)
+        except OSError:
+            _ownership_mismatch()
+        return tuple(selected)
+
+    def _prune_empty_directory(self, path: Path) -> None:
+        """只在受管目录已为空时移除它，永不递归删除。"""
+        try:
+            path.rmdir()
+        except OSError:
+            return
+
+    def _authorize_purge(self, request: InstallRequest) -> None:
+        """在任何破坏性动作之前完成 purge 的确认闭合。"""
+        root = self._layout.state_home
+        _validate_purge_root(root, user_home=self._user_home)
+        targets = _purge_targets(root)
+        if not self._isatty:
+            if not request.confirm_data_loss:
+                raise InstallError("request_invalid", "confirm_data_loss")
+            return
+        if self._confirm is None:
+            raise InstallError("request_invalid", "confirm_data_loss")
+        print("These exact paths will be permanently deleted:", file=self._stdout)
+        for target in targets:
+            print(f"  {target}", file=self._stdout)
+        first = self._confirm(f"Type the exact state directory to confirm [{root}]: ")
+        if type(first) is not str or first.strip() != str(root):
+            raise InstallError("request_invalid", "confirm_data_loss")
+        second = self._confirm(f"Type {_PURGE_PHRASE} to confirm: ")
+        if type(second) is not str or second.strip() != _PURGE_PHRASE:
+            raise InstallError("request_invalid", "confirm_data_loss")
+
+    def _purge(self, uid: int) -> None:
+        """删除显式枚举的状态路径，保留 Workspace 与任何未知用户文件。"""
+        root = self._layout.state_home
+        _validate_purge_root(root, user_home=self._user_home)
+        workspace = root / "workspace"
+        targets = _purge_targets(root)
+        for target in targets:
+            metadata = target.lstat()
+            if (
+                target == workspace
+                or target.parent != root
+                or stat.S_ISLNK(metadata.st_mode)
+                or metadata.st_uid != uid
+            ):
+                _ownership_mismatch()
+        try:
+            for target in targets:
+                if target.is_dir():
+                    shutil.rmtree(target)
+                else:
+                    target.unlink()
+            _fsync_directory(root)
+        except OSError:
+            raise InstallError("uninstall_ownership_mismatch", "state_home") from None
+        self._emit(InstallEvent("uninstall.data.purged", "warn", None, "state_home"))
+
+    def _report(self, request: InstallRequest) -> None:
+        """输出精确的保留目录与重新安装提示，不回显任何 Secret 内容。"""
+        layout = self._layout
+        print(
+            f"Removed the managed Lobster0 install at {layout.program_prefix}.",
+            file=self._stdout,
+        )
+        if request.purge_data:
+            print(
+                f"Purged the enumerated Lobster0 state under {layout.state_home}.",
+                file=self._stdout,
+            )
+            print(
+                f"Retained the Workspace at {layout.state_home / 'workspace'}.",
+                file=self._stdout,
+            )
+            return
+        print(f"Retained all user data at {layout.state_home}.", file=self._stdout)
+        print(
+            "Re-run the pinned Lobster0 installer to reinstall against the same data.",
+            file=self._stdout,
+        )
+
+    def _emit(self, event: InstallEvent) -> None:
+        """把一个已脱敏事件追加到当前卸载事务。"""
+        self._events.append(event)
+
+
+def _public_uninstall_argv(request: InstallRequest) -> tuple[str, ...]:
+    """构造 handoff 需要透传、且不含任何 Secret 的 public installer flags。"""
+    argv: list[str] = ["--home", str(request.state_home)]
+    if request.system_prefix:
+        argv.append("--system-prefix")
+    elif request.prefix is not None:
+        argv.extend(("--prefix", str(request.prefix)))
+    if request.purge_data:
+        argv.append("--purge-data")
+    if request.confirm_data_loss:
+        argv.append("--confirm-data-loss")
+    if request.json_output:
+        argv.append("--json")
+    if request.verbose:
+        argv.append("--verbose")
+    return tuple(argv)
+
+
+def run_uninstall_request(
+    request: InstallRequest,
+    *,
+    environ: Mapping[str, str],
+    execve: Callable[[str, tuple[str, ...], dict[str, str]], object] = os.execve,
+) -> InstallResult:
+    """从 installer pyz 的 uninstall 跳转还原受管 layout 并执行删除。"""
+    facts = resolve_install_facts(request.state_home, environ=environ)
+    if not facts.managed or facts.layout is None:
+        raise InstallError("uninstall_ownership_mismatch", "program_prefix")
+    return Uninstaller(
+        facts.layout,
+        environ=environ,
+        execve=execve,
+        isatty=sys.stdin.isatty(),
+        confirm=_tty_confirm,
+        user_home=_user_home(),
+    ).run(request)
+
+
+def _tty_confirm(prompt: str) -> str:
+    """只从 controlling TTY 读取一行破坏性确认，不读取 stdin 管道。"""
+    with open("/dev/tty", "r+", encoding="utf-8") as tty:
+        tty.write(prompt)
+        tty.flush()
+        return tty.readline()
+
+
+def _user_home() -> Path | None:
+    """best-effort 解析当前用户 Home，失败时返回 None。"""
+    try:
+        return Path(pwd.getpwuid(os.geteuid()).pw_dir)
+    except (KeyError, OSError, TypeError):
+        return None
+
+
+def run_install_action(
+    action: str,
+    *,
+    state_home: Path,
+    version: str | None = None,
+    channel: Literal["stable", "dev"] = "stable",
+    purge_data: bool = False,
+    confirm_data_loss: bool = False,
+    json_output: bool = False,
+    verbose: bool = False,
+    environ: Mapping[str, str] | None = None,
+    executable: Path | None = None,
+    user_home: Path | None = None,
+    stdout: TextIO | None = None,
+    stderr: TextIO | None = None,
+    confirm: Callable[[str], str] | None = None,
+    isatty: bool | None = None,
+    runner: object | None = None,
+) -> int:
+    """执行受管安装的 service/update/uninstall 动作并返回稳定退出码。
+
+    Args:
+        action: `service.install|status|logs|restart|uninstall`、`update` 或 `uninstall`。
+        state_home: 已解析的绝对状态根。
+        version: update 的显式目标版本。
+        channel: update 的发布通道。
+        purge_data: 是否请求破坏性 purge。
+        confirm_data_loss: 非交互 purge 的精确长 flag。
+        json_output: 是否请求机器可读输出。
+        verbose: 是否请求更多脱敏诊断。
+        environ: 判定受管模式使用的环境。
+        executable: 当前解释器路径。
+        user_home: 目标用户 Home。
+        stdout: 可替换标准输出。
+        stderr: 可替换标准错误。
+        confirm: 破坏性确认读取器。
+        isatty: stdin 是否为 TTY。
+        runner: 可注入的 bounded exact runner。
+
+    Returns:
+        成功为 0、请求/确认错误为 2、lifecycle 错误为 5。
+    """
+    out = sys.stdout if stdout is None else stdout
+    error_stream = sys.stderr if stderr is None else stderr
+    facts = resolve_install_facts(
+        state_home,
+        environ=environ,
+        executable=executable,
+        user_home=user_home,
+    )
+    if not facts.managed or facts.layout is None or facts.receipt is None:
+        print(f"error: install_not_managed ({facts.detail})", file=error_stream)
+        return 2
+    tty = sys.stdin.isatty() if isatty is None else bool(isatty)
+    try:
+        if action.startswith("service."):
+            return _run_managed_service(
+                action.split(".", 1)[1],
+                facts.layout,
+                facts.receipt,
+                runner=runner,
+                stdout=out,
+            )
+        if action == "update":
+            return _run_managed_update(
+                facts.layout,
+                facts.receipt,
+                version=version,
+                channel=channel,
+                json_output=json_output,
+                verbose=verbose,
+                stderr=error_stream,
+            )
+        if action != "uninstall":
+            print("error: request_invalid", file=error_stream)
+            return 2
+        system_prefix = facts.program_prefix == _SYSTEM_PREFIX
+        custom_prefix = (
+            None
+            if system_prefix or facts.program_prefix == state_home
+            else facts.program_prefix
+        )
+        request = InstallRequest(
+            action="uninstall",
+            version=None,
+            channel="stable",
+            prefix=custom_prefix,
+            state_home=state_home,
+            system_prefix=system_prefix,
+            onboard=False,
+            config_file=None,
+            secrets_file=None,
+            service=None,
+            allow_system_packages=False,
+            dry_run=False,
+            json_output=json_output,
+            verbose=verbose,
+            purge_data=purge_data,
+            confirm_data_loss=confirm_data_loss,
+        )
+        Uninstaller(
+            facts.layout,
+            runner=runner,
+            environ=environ,
+            executable=executable,
+            isatty=tty,
+            confirm=_tty_confirm if confirm is None else confirm,
+            stdout=out,
+            user_home=user_home if user_home is not None else _user_home(),
+        ).run(request)
+    except InstallError as failure:
+        print(f"error: {failure.code}", file=error_stream)
+        return 2 if failure.code == "request_invalid" else 5
+    except OSError:
+        print("error: installer_error", file=error_stream)
+        return 5
+    return 0
+
+
+def _run_managed_service(
+    command: str,
+    layout: InstallLayout,
+    receipt: InstallReceipt,
+    *,
+    runner: object | None,
+    stdout: TextIO,
+) -> int:
+    """驱动受 receipt 绑定的 systemd-user/launchd 用户服务生命周期。"""
+    if command not in _SERVICE_ACTIONS:
+        raise InstallError("request_invalid", "action")
+    platform = (
+        ServicePlatform.SYSTEMD_USER
+        if receipt.platform.os == "linux"
+        else ServicePlatform.LAUNCHD
+    )
+    spec = render_service_spec(layout, platform)
+    if command == "install":
+        digest = service_install(spec, runner, expected_sha256=receipt.service_file_sha256)
+        relative = _service_relative(spec.path, _invoking_account())
+        replace(
+            receipt,
+            service_label=spec.label,
+            service_file=relative,
+            service_file_sha256=digest,
+        ).write(layout.receipt)
+        print("service installed", file=stdout)
+        return 0
+    if command == "status":
+        running = service_status(spec, runner)
+        installed = receipt.service_file_sha256 is not None
+        print(
+            f"service installed={'true' if installed else 'false'} "
+            f"running={'true' if running else 'false'}",
+            file=stdout,
+        )
+        return 0
+    if command == "logs":
+        result = service_logs(spec, runner)
+        print(result.stdout.decode("utf-8", errors="replace"), end="", file=stdout)
+        return 0
+    if command == "restart":
+        service_restart(spec, runner)
+        print("service restarted", file=stdout)
+        return 0
+    if receipt.service_file_sha256 is None:
+        print("service uninstalled", file=stdout)
+        return 0
+    service_uninstall(spec, runner, expected_sha256=receipt.service_file_sha256)
+    replace(
+        receipt,
+        service_label=None,
+        service_file=None,
+        service_file_sha256=None,
+    ).write(layout.receipt)
+    print("service uninstalled", file=stdout)
+    return 0
+
+
+def _run_managed_update(
+    layout: InstallLayout,
+    receipt: InstallReceipt,
+    *,
+    version: str | None,
+    channel: Literal["stable", "dev"],
+    json_output: bool,
+    verbose: bool,
+    stderr: TextIO,
+) -> int:
+    """把 update 交回 pinned bootstrap，绝不在本地退化出第二条升级路径。
+
+    Task 13 的 DB-guarded update pipeline 由 installer zipapp 驱动，而它需要
+    bootstrap 建立的信任根（pinned uv 与 managed Python）。受管 Runtime 在
+    激活时按设计删除 `.inputs`，因此已安装 CLI 手里没有可信 uv；这里 fail
+    closed 并给出精确指引，而不是退化到 PATH 上的不可信 uv 或第二套下载逻辑。
+    """
+    del layout, receipt, version, channel, json_output, verbose
+    print("error: update_requires_bootstrap", file=stderr)
+    print(
+        "Re-run the pinned Lobster0 installer to update; the installed Runtime "
+        "intentionally keeps no bootstrap trust root.",
+        file=stderr,
+    )
+    return 2

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 import argparse
 import contextlib
 import io
+import json
 import sys
 import tempfile
 import unittest
@@ -13,6 +14,7 @@ from unittest import mock
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PROJECT_ROOT / "src"))
 
+from lobster0 import __version__  # noqa: E402
 from lobster0.automation.models import (  # noqa: E402
     DeliveryTarget,
     ScheduleKind,
@@ -449,6 +451,151 @@ class CliTest(unittest.TestCase):
             ):
                 exit_code, output, error = run_cli(["gateway", "--home", directory])
         self.assertEqual((exit_code, output, error), (0, "", ""))
+
+    def test_service_update_and_uninstall_dispatch_outside_agent_runtime(self) -> None:
+        """公共 lifecycle 命令只把 typed action 交给安装模块，不加载 Agent runtime。"""
+        with tempfile.TemporaryDirectory() as directory:
+            for argv, action in (
+                (["service", "--home", directory, "status"], "service.status"),
+                (["service", "--home", directory, "logs"], "service.logs"),
+                (["update", "--home", directory], "update"),
+                (["uninstall", "--home", directory], "uninstall"),
+            ):
+                with (
+                    self.subTest(argv=argv),
+                    mock.patch("lobster0.cli.run_install_action", return_value=0) as run,
+                    mock.patch(
+                        "lobster0.cli.resolve_install_facts",
+                        return_value=mock.Mock(managed=True),
+                    ),
+                    mock.patch(
+                        "lobster0.runtime.create_runtime",
+                        side_effect=AssertionError("Agent runtime must not load"),
+                    ),
+                ):
+                    self.assertEqual(main(argv), 0)
+                    self.assertEqual(run.call_args.args[0], action)
+
+    def test_service_falls_back_to_source_checkout_launchagent(self) -> None:
+        """没有 receipt 的源码 checkout 必须保持 Phase 6 LaunchAgent 行为。"""
+        service = mock.Mock()
+        service.restart = mock.Mock(return_value=None)
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            mock.patch("lobster0.cli.run_install_action") as managed,
+            mock.patch("lobster0.cli._launchd_service", return_value=service),
+        ):
+            exit_code, output, error = run_cli(["service", "--home", directory, "restart"])
+
+        self.assertEqual((exit_code, error), (0, ""))
+        self.assertIn("service restarted", output)
+        managed.assert_not_called()
+
+    def test_service_logs_is_unavailable_in_source_checkout(self) -> None:
+        """logs 只对受管安装有意义，源码模式必须干净失败。"""
+        with tempfile.TemporaryDirectory() as directory:
+            exit_code, output, error = run_cli(["service", "--home", directory, "logs"])
+
+        self.assertEqual(exit_code, 2)
+        self.assertEqual(output, "")
+        self.assertIn("service_logs_unavailable", error)
+
+    def test_lifecycle_help_exposes_no_secret_bearing_flags(self) -> None:
+        """service/update/uninstall 帮助不得出现任何 Secret 值参数。"""
+        parser = build_parser()
+        commands = next(
+            action.choices
+            for action in parser._actions
+            if hasattr(action, "choices") and isinstance(action.choices, dict)
+        )
+        for name in ("service", "update", "uninstall", "install-smoke"):
+            with self.subTest(command=name):
+                options = {
+                    option
+                    for action in commands[name]._actions
+                    for option in action.option_strings
+                }
+                self.assertTrue(
+                    {
+                        "--api-key",
+                        "--token",
+                        "--app-secret",
+                        "--secret",
+                        "--secrets-file",
+                        "--password",
+                    }.isdisjoint(options)
+                )
+        uninstall_options = {
+            option
+            for action in commands["uninstall"]._actions
+            for option in action.option_strings
+        }
+        self.assertIn("--purge-data", uninstall_options)
+        self.assertIn("--yes-i-understand-data-loss", uninstall_options)
+
+    def test_uninstall_maps_the_exact_long_confirmation_flag(self) -> None:
+        """`--yes-i-understand-data-loss` 必须是唯一的非交互破坏性确认。"""
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            mock.patch("lobster0.cli.run_install_action", return_value=0) as run,
+            mock.patch(
+                "lobster0.cli.resolve_install_facts",
+                return_value=mock.Mock(managed=True),
+            ),
+        ):
+            exit_code, _output, _error = run_cli(
+                [
+                    "uninstall",
+                    "--home",
+                    directory,
+                    "--purge-data",
+                    "--yes-i-understand-data-loss",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        self.assertTrue(run.call_args.kwargs["purge_data"])
+        self.assertTrue(run.call_args.kwargs["confirm_data_loss"])
+
+    def test_install_smoke_emits_one_json_document_without_network(self) -> None:
+        """install-smoke 必须输出 status/version 且不触碰 Provider、Channel 或网络。"""
+        with tempfile.TemporaryDirectory() as directory:
+            run_cli(["init", "--home", directory])
+            node = Path(directory) / "test-node"
+            node.write_text("#!/bin/sh\nprintf 'v22.22.3\\n'\n", encoding="utf-8")
+            node.chmod(0o700)
+            entry = Path(directory) / "main.js"
+            entry.write_text("// test entry\n", encoding="utf-8")
+            with (
+                mock.patch.dict(
+                    "os.environ",
+                    {
+                        "LOBSTER0_NODE": str(node),
+                        "LOBSTER0_TUI_ENTRY": str(entry),
+                    },
+                    clear=False,
+                ),
+                mock.patch(
+                    "lobster0.runtime.create_runtime",
+                    side_effect=AssertionError("Provider runtime must not load"),
+                ),
+                mock.patch(
+                    "socket.socket",
+                    side_effect=AssertionError("install-smoke must not open sockets"),
+                ),
+                mock.patch(
+                    "lobster0.cli.importlib.util.find_spec",
+                    return_value=object(),
+                ),
+            ):
+                exit_code, output, error = run_cli(
+                    ["install-smoke", "--home", directory, "--json"]
+                )
+
+        self.assertEqual((exit_code, error), (0, ""))
+        document = json.loads(output)
+        self.assertEqual(document["status"], "ok")
+        self.assertEqual(document["version"], __version__)
 
     def test_gateway_preloads_channel_sdk_before_starting_asyncio(self) -> None:
         """飞书 SDK 必须在主循环启动前加载，避免捕获正在运行的 loop。"""

--- a/tests/test_cli_service.py
+++ b/tests/test_cli_service.py
@@ -78,7 +78,10 @@ class ServiceCliTest(unittest.TestCase):
             for action in service._actions
             if hasattr(action, "choices") and isinstance(action.choices, dict)
         )
-        self.assertEqual(set(choices), {"install", "status", "restart", "uninstall"})
+        self.assertEqual(
+            set(choices),
+            {"install", "status", "logs", "restart", "uninstall"},
+        )
 
     def test_each_action_dispatches_once_and_status_is_structured(self) -> None:
         """CLI 只调用选定动作，status 不转发 launchctl 原始输出。"""

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,5 +1,6 @@
 """Lobster0 离线本地诊断的行为测试。"""
 
+import os
 import tempfile
 import unittest
 from datetime import UTC, datetime
@@ -8,6 +9,10 @@ from unittest import mock
 
 from lobster0.bootstrap import initialize_state
 from lobster0.doctor import CheckStatus, run_local_checks
+from lobster0.install.layout import InstallLayout, render_launcher
+from lobster0.install.models import PlatformKey
+from lobster0.install.receipt import InstallReceipt, managed_file_sha256
+from lobster0.install.runtime import RuntimeReceipt
 from lobster0.memory.markdown_store import MemoryMarkdownStore
 from lobster0.memory.models import DisclosureContext, SourceRef
 from lobster0.memory.repository import (
@@ -93,10 +98,18 @@ class DoctorTest(unittest.TestCase):
                 "channel_database",
                 "channel_workers",
                 "memory",
+                "install_method",
             },
         )
-        self.assertTrue(all(result.status is CheckStatus.PASS for result in results))
         by_name = {result.name: result for result in results}
+        self.assertTrue(
+            all(
+                result.status is CheckStatus.PASS
+                for result in results
+                if result.name != "install_method"
+            )
+        )
+        self.assertIs(by_name["install_method"].status, CheckStatus.WARN)
         self.assertIn("profile personal", by_name["personal_permissions"].message)
         self.assertIn("lark-cli available", by_name["executables"].message)
         self.assertNotIn(str(owner_home), by_name["executables"].message)
@@ -496,6 +509,153 @@ class DoctorTest(unittest.TestCase):
                 "LOBSTER0_TUI_ENTRY",
             }:
                 self.assertNotIn(value, repr(results))
+
+
+class InstallFactsDoctorTest(unittest.TestCase):
+    """验证安装事实检查在源码与受管两种模式下的安全行为。"""
+
+    def setUp(self) -> None:
+        """创建一个真实的受管安装树与已初始化状态。"""
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.home = Path(self.temporary.name).resolve()
+        self.home.chmod(0o700)
+        self.layout = InstallLayout.user(self.home, version="0.7.0")
+        self.paths = build_state_paths(self.layout.state_home)
+        initialize_state(self.paths)
+        self.node = self.home / "test-node"
+        self.node.write_text("#!/bin/sh\nprintf 'v22.22.3\\n'\n", encoding="utf-8")
+        self.node.chmod(0o700)
+        self.tui_entry = self.home / "main.js"
+        self.tui_entry.write_text("// test entry\n", encoding="utf-8")
+        self.environ = {
+            "LOBSTER0_NODE": str(self.node),
+            "LOBSTER0_TUI_ENTRY": str(self.tui_entry),
+        }
+
+    def _install_managed_tree(self) -> None:
+        """写入 launcher、command link、Runtime 与 install receipt。"""
+        self.layout.bin_dir.mkdir(mode=0o700, parents=True)
+        self.layout.runtimes_dir.mkdir(mode=0o700)
+        runtime = self.layout.runtime
+        runtime.mkdir(mode=0o700)
+        for relative in (
+            "venv/bin/python",
+            "node/bin/node",
+            "tui/dist/main.js",
+            "python/bin/python3.12",
+            "lobster0-installer.pyz",
+        ):
+            path = runtime / relative
+            path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+            path.write_text("#!/bin/sh\n", encoding="utf-8")
+            path.chmod(0o700)
+        runtime_receipt = RuntimeReceipt(
+            version="0.7.0",
+            git_commit="a" * 40,
+            runtime_relative="runtimes/0.7.0",
+            python_version="3.12.11",
+            node_version="24.18.0",
+            tui_version="0.7.0",
+            wheel_sha256="1" * 64,
+            requirements_sha256="2" * 64,
+            node_sha256="3" * 64,
+            tui_sha256="4" * 64,
+            installer_sha256="5" * 64,
+            executables_sha256=None,
+        )
+        metadata = runtime / "install-receipt.json"
+        metadata.write_bytes(runtime_receipt.to_bytes())
+        metadata.chmod(0o600)
+        self.layout.current.symlink_to("runtimes/0.7.0")
+        self.layout.launcher.write_bytes(render_launcher(self.layout))
+        self.layout.launcher.chmod(0o700)
+        self.layout.command_link.parent.mkdir(mode=0o755, parents=True)
+        self.layout.command_link.symlink_to(
+            os.path.relpath(self.layout.launcher, start=self.layout.command_link.parent)
+        )
+        InstallReceipt(
+            schema_version=1,
+            version="0.7.0",
+            git_commit="a" * 40,
+            platform=PlatformKey("macos", "arm64"),
+            installed_at="2026-08-10T00:00:00Z",
+            managed_files=(("bin/lobster0", managed_file_sha256(self.layout.launcher)),),
+            current_runtime="runtimes/0.7.0",
+            previous_runtime=None,
+            service_label=None,
+            service_file=None,
+            service_file_sha256=None,
+        ).write(self.layout.receipt)
+
+    def test_source_checkout_only_warns_and_stays_usable(self) -> None:
+        """源码 checkout 不得因缺少安装事实而 FAIL。"""
+        results = run_local_checks(self.paths, self.environ)
+        by_name = {result.name: result for result in results}
+
+        self.assertIn("install_method", by_name)
+        self.assertIs(by_name["install_method"].status, CheckStatus.WARN)
+        self.assertNotIn("managed_runtime", by_name)
+        self.assertNotIn("release_receipt", by_name)
+        self.assertFalse(any(result.status is CheckStatus.FAIL for result in results))
+
+    def test_managed_install_reports_receipt_runtime_node_tui_and_service(self) -> None:
+        """存在 receipt 时必须补齐六项安装事实并保持只读。"""
+        self._install_managed_tree()
+        environ = {**self.environ, "LOBSTER0_PREFIX": str(self.layout.program_prefix)}
+
+        results = run_local_checks(self.paths, environ)
+        by_name = {result.name: result for result in results}
+
+        for name in (
+            "install_method",
+            "release_receipt",
+            "managed_runtime",
+            "managed_node",
+            "managed_tui",
+            "managed_service",
+        ):
+            self.assertIn(name, by_name)
+        self.assertIs(by_name["install_method"].status, CheckStatus.PASS)
+        self.assertIn("0.7.0", by_name["install_method"].message)
+        self.assertIs(by_name["release_receipt"].status, CheckStatus.PASS)
+        self.assertIs(by_name["managed_runtime"].status, CheckStatus.PASS)
+        self.assertIs(by_name["managed_node"].status, CheckStatus.PASS)
+        self.assertIn("24.18.0", by_name["managed_node"].message)
+        self.assertIs(by_name["managed_tui"].status, CheckStatus.PASS)
+        self.assertIs(by_name["managed_service"].status, CheckStatus.WARN)
+        self.assertTrue(self.layout.receipt.is_file())
+
+    def test_install_checks_never_open_sockets_or_read_secret_values(self) -> None:
+        """安装事实检查不得发起网络调用或读取 Secret 值。"""
+        self._install_managed_tree()
+        secret = "install-doctor-secret"
+        secrets_file = self.paths.home / "secrets.env"
+        secrets_file.write_text(
+            f"LOBSTER0_MODEL_API_KEY={secret}\n", encoding="utf-8"
+        )
+        secrets_file.chmod(0o600)
+        environ = {**self.environ, "LOBSTER0_PREFIX": str(self.layout.program_prefix)}
+
+        with mock.patch(
+            "socket.socket",
+            side_effect=AssertionError("doctor must not open sockets"),
+        ):
+            results = run_local_checks(self.paths, environ)
+
+        self.assertNotIn(secret, repr(results))
+
+    def test_drifted_launcher_hash_fails_the_release_receipt_check(self) -> None:
+        """launcher 与 receipt 不一致时必须 FAIL 而不是静默通过。"""
+        self._install_managed_tree()
+        self.layout.launcher.write_bytes(b"#!/bin/sh\nexec /bin/false\n")
+        self.layout.launcher.chmod(0o700)
+        environ = {**self.environ, "LOBSTER0_PREFIX": str(self.layout.program_prefix)}
+
+        results = run_local_checks(self.paths, environ)
+        by_name = {result.name: result for result in results}
+
+        self.assertIs(by_name["release_receipt"].status, CheckStatus.FAIL)
 
 
 if __name__ == "__main__":

--- a/tests/test_install_uninstall.py
+++ b/tests/test_install_uninstall.py
@@ -1,0 +1,543 @@
+"""受管卸载、purge 双确认与 self-uninstall handoff 的离线行为测试。"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+import stat
+import sys
+import tempfile
+import unittest
+from dataclasses import replace
+from pathlib import Path
+from unittest import mock
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from lobster0.install.layout import InstallLayout, render_launcher  # noqa: E402
+from lobster0.install.models import (  # noqa: E402
+    InstallError,
+    InstallRequest,
+    PlatformKey,
+)
+from lobster0.install.orchestrator import (  # noqa: E402
+    Uninstaller,
+    _validate_purge_root,
+    resolve_install_facts,
+)
+from lobster0.install.receipt import InstallReceipt, managed_file_sha256  # noqa: E402
+from lobster0.install.runtime import RuntimeReceipt  # noqa: E402
+
+_INSTALLER_BYTES = b"PK\x03\x04 fake lobster0 installer zipapp\n"
+_MANIFEST_BYTES = b'{"schema_version":1}\n'
+
+
+class _ManagedInstall(unittest.TestCase):
+    """构造一个真实的受管用户安装树与独立用户数据。"""
+
+    version = "0.7.0"
+
+    def setUp(self) -> None:
+        """在临时 Home 下创建 launcher、command link、Runtime、receipt 与用户数据。"""
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.home = Path(self.temporary.name).resolve()
+        self.home.chmod(0o700)
+        self.layout = InstallLayout.user(self.home, version=self.version)
+        self.state_home = self.layout.state_home
+        self.layout.program_prefix.mkdir(mode=0o700, parents=True)
+        self.layout.bin_dir.mkdir(mode=0o700)
+        self.layout.runtimes_dir.mkdir(mode=0o700)
+        self.runtime = self.layout.runtime
+        self.runtime.mkdir(mode=0o700)
+        self.installer_pyz = self.runtime / "lobster0-installer.pyz"
+        self.installer_pyz.write_bytes(_INSTALLER_BYTES)
+        self.installer_pyz.chmod(0o700)
+        self.installer_sha256 = hashlib.sha256(_INSTALLER_BYTES).hexdigest()
+        manifest = self.runtime / "release-manifest.json"
+        manifest.write_bytes(_MANIFEST_BYTES)
+        manifest.chmod(0o600)
+        runtime_receipt = RuntimeReceipt(
+            version=self.version,
+            git_commit="a" * 40,
+            runtime_relative=f"runtimes/{self.version}",
+            python_version="3.12.11",
+            node_version="24.18.0",
+            tui_version=self.version,
+            wheel_sha256="1" * 64,
+            requirements_sha256="2" * 64,
+            node_sha256="3" * 64,
+            tui_sha256="4" * 64,
+            installer_sha256=self.installer_sha256,
+            executables_sha256=None,
+        )
+        runtime_metadata = self.runtime / "install-receipt.json"
+        runtime_metadata.write_bytes(runtime_receipt.to_bytes())
+        runtime_metadata.chmod(0o600)
+        venv_bin = self.runtime / "venv" / "bin"
+        venv_bin.mkdir(mode=0o700, parents=True)
+        (venv_bin / "python").write_text("#!/bin/sh\n", encoding="utf-8")
+        (venv_bin / "python").chmod(0o700)
+        node_bin = self.runtime / "node" / "bin"
+        node_bin.mkdir(mode=0o700, parents=True)
+        (node_bin / "node").write_text("#!/bin/sh\n", encoding="utf-8")
+        (node_bin / "node").chmod(0o700)
+        tui_dist = self.runtime / "tui" / "dist"
+        tui_dist.mkdir(mode=0o700, parents=True)
+        (tui_dist / "main.js").write_text("// tui\n", encoding="utf-8")
+        python_bin = self.runtime / "python" / "bin"
+        python_bin.mkdir(mode=0o700, parents=True)
+        self.managed_python = python_bin / "python3.12"
+        self.managed_python.write_text("#!/bin/sh\n", encoding="utf-8")
+        self.managed_python.chmod(0o700)
+        self.layout.current.symlink_to(f"runtimes/{self.version}")
+        self.layout.launcher.write_bytes(render_launcher(self.layout))
+        self.layout.launcher.chmod(0o700)
+        self.layout.command_link.parent.mkdir(mode=0o755, parents=True)
+        self.layout.command_link.symlink_to(
+            os.path.relpath(self.layout.launcher, start=self.layout.command_link.parent)
+        )
+        self.receipt = InstallReceipt(
+            schema_version=1,
+            version=self.version,
+            git_commit="a" * 40,
+            platform=PlatformKey("macos", "arm64"),
+            installed_at="2026-08-10T00:00:00Z",
+            managed_files=(("bin/lobster0", managed_file_sha256(self.layout.launcher)),),
+            current_runtime=f"runtimes/{self.version}",
+            previous_runtime=None,
+            service_label=None,
+            service_file=None,
+            service_file_sha256=None,
+        )
+        self.receipt.write(self.layout.receipt)
+        self._write_user_data()
+        self.request = InstallRequest(
+            action="uninstall",
+            version=None,
+            channel="stable",
+            prefix=None,
+            state_home=self.state_home,
+            system_prefix=False,
+            onboard=False,
+            config_file=None,
+            secrets_file=None,
+            service=None,
+            allow_system_packages=False,
+            dry_run=False,
+            json_output=False,
+            verbose=False,
+            purge_data=False,
+            confirm_data_loss=False,
+        )
+        self.outside_executable = self.home / "system-python"
+        self.outside_executable.write_text("#!/bin/sh\n", encoding="utf-8")
+        self.outside_executable.chmod(0o700)
+
+    def _write_user_data(self) -> None:
+        """写入 uninstall 必须完整保留的配置、Secret、数据库与个人目录。"""
+        (self.state_home / "config.toml").write_text("[agent]\n", encoding="utf-8")
+        secrets = self.state_home / "secrets.env"
+        secrets.write_text("LOBSTER0_MODEL_API_KEY=user-secret\n", encoding="utf-8")
+        secrets.chmod(0o600)
+        (self.state_home / "lobster0.db").write_bytes(b"SQLite format 3\x00user rows")
+        for name in ("memory", "skills", "prompts", "workspace", "logs", "browser"):
+            directory = self.state_home / name
+            directory.mkdir(mode=0o700)
+            (directory / "personal.txt").write_text(f"{name} data\n", encoding="utf-8")
+
+    def hash_user_data(self) -> str:
+        """返回状态根中全部非受管程序文件的稳定内容指纹。"""
+        managed = {
+            self.layout.bin_dir,
+            self.layout.runtimes_dir,
+            self.layout.current,
+            self.layout.receipt,
+            self.layout.lock,
+        }
+        digest = hashlib.sha256()
+        for path in sorted(self.state_home.rglob("*")):
+            if any(path == item or path.is_relative_to(item) for item in managed):
+                continue
+            digest.update(str(path.relative_to(self.state_home)).encode())
+            if path.is_symlink():
+                digest.update(b"symlink\0" + os.fsencode(os.readlink(path)))
+            elif path.is_file():
+                digest.update(path.read_bytes())
+        return digest.hexdigest()
+
+    def uninstaller(self, **kwargs: object) -> Uninstaller:
+        """构造默认在 Runtime 之外运行、非 TTY 的卸载器。"""
+        options: dict[str, object] = {
+            "environ": {},
+            "execve": self._forbidden_execve,
+            "executable": self.outside_executable,
+            "isatty": False,
+            "stdout": io.StringIO(),
+            "user_home": self.home,
+        }
+        options.update(kwargs)
+        return Uninstaller(self.layout, **options)  # type: ignore[arg-type]
+
+    def _forbidden_execve(self, *_args: object) -> None:
+        """在不应发生 handoff 的用例中失败关闭。"""
+        raise AssertionError("unexpected installer handoff")
+
+
+class DefaultUninstallTests(_ManagedInstall):
+    """验证默认卸载只删除 receipt 内的受管程序文件。"""
+
+    def test_default_uninstall_preserves_all_user_data(self) -> None:
+        """默认卸载必须保留配置、Secret、数据库、Memory、Skills 与 Workspace。"""
+        before = self.hash_user_data()
+
+        result = self.uninstaller().run(replace(self.request, purge_data=False))
+
+        self.assertEqual(self.hash_user_data(), before)
+        self.assertEqual(result.action, "uninstall")
+        self.assertFalse(self.layout.runtimes_dir.exists())
+        self.assertFalse(self.layout.launcher.exists())
+        self.assertFalse(self.layout.command_link.is_symlink())
+        self.assertFalse(self.layout.current.is_symlink())
+        self.assertFalse(self.layout.receipt.exists())
+        self.assertTrue((self.state_home / "lobster0.db").is_file())
+        self.assertTrue((self.state_home / "secrets.env").is_file())
+        self.assertTrue((self.state_home / "workspace" / "personal.txt").is_file())
+
+    def test_uninstall_prints_exact_retained_root(self) -> None:
+        """卸载输出必须给出精确保留目录，且不泄露 Secret 内容。"""
+        stream = io.StringIO()
+        self.uninstaller(stdout=stream).run(self.request)
+
+        self.assertIn(str(self.state_home), stream.getvalue())
+        self.assertNotIn("user-secret", stream.getvalue())
+
+    def test_removes_managed_service_before_program_files(self) -> None:
+        """必须先停止并移除受管服务，再删除 launcher 与 Runtime。"""
+        replace(
+            self.receipt,
+            service_label="io.lobster0.gateway",
+            service_file="Library/LaunchAgents/io.lobster0.gateway.plist",
+            service_file_sha256="c" * 64,
+        ).write(self.layout.receipt)
+        order: list[str] = []
+
+        def fake_uninstall(_spec: object, _runner: object, *, expected_sha256: str) -> None:
+            order.append(f"service:{expected_sha256}")
+
+        original_unlink = Path.unlink
+
+        def recording_unlink(path: Path, missing_ok: bool = False) -> None:
+            order.append(f"unlink:{path.name}")
+            original_unlink(path, missing_ok=missing_ok)
+
+        with (
+            mock.patch("lobster0.install.orchestrator.render_service_spec"),
+            mock.patch(
+                "lobster0.install.orchestrator.service_uninstall",
+                side_effect=fake_uninstall,
+            ),
+            mock.patch.object(Path, "unlink", recording_unlink),
+        ):
+            self.uninstaller().run(self.request)
+
+        self.assertEqual(order[0], "service:" + "c" * 64)
+        self.assertFalse(self.layout.launcher.exists())
+
+    def test_foreign_runtime_entry_blocks_deletion_and_preserves_everything(self) -> None:
+        """runtimes/ 下的非受管条目必须让卸载失败关闭而不是被递归删除。"""
+        foreign = self.layout.runtimes_dir / "not-a-runtime"
+        foreign.mkdir(mode=0o700)
+        (foreign / "keep.txt").write_text("foreign\n", encoding="utf-8")
+        before = self.hash_user_data()
+
+        with self.assertRaises(InstallError) as raised:
+            self.uninstaller().run(self.request)
+
+        self.assertEqual(raised.exception.code, "uninstall_ownership_mismatch")
+        self.assertTrue((foreign / "keep.txt").is_file())
+        self.assertTrue(self.layout.launcher.is_file())
+        self.assertTrue(self.layout.receipt.is_file())
+        self.assertEqual(self.hash_user_data(), before)
+
+    def test_launcher_hash_drift_blocks_deletion(self) -> None:
+        """launcher 与 receipt hash 漂移时必须保留而不是删除。"""
+        self.layout.launcher.write_bytes(b"#!/bin/sh\nexec /bin/false\n")
+        self.layout.launcher.chmod(0o700)
+
+        with self.assertRaises(InstallError) as raised:
+            self.uninstaller().run(self.request)
+
+        self.assertEqual(raised.exception.code, "uninstall_ownership_mismatch")
+        self.assertTrue(self.layout.launcher.is_file())
+        self.assertTrue(self.layout.runtime.is_dir())
+        self.assertTrue(self.layout.receipt.is_file())
+
+    def test_foreign_command_link_target_is_never_removed(self) -> None:
+        """PATH 上的同名非受管命令必须保留。"""
+        self.layout.command_link.unlink()
+        self.layout.command_link.symlink_to("/usr/bin/true")
+
+        with self.assertRaises(InstallError) as raised:
+            self.uninstaller().run(self.request)
+
+        self.assertEqual(raised.exception.code, "uninstall_ownership_mismatch")
+        self.assertTrue(self.layout.command_link.is_symlink())
+        self.assertTrue(self.layout.receipt.is_file())
+
+    def test_partial_failure_preserves_receipt_and_user_data(self) -> None:
+        """Runtime 删除失败时必须保留 receipt 与全部用户数据。"""
+        before = self.hash_user_data()
+
+        with (
+            mock.patch(
+                "lobster0.install.orchestrator.shutil.rmtree",
+                side_effect=OSError("simulated removal failure"),
+            ),
+            self.assertRaises(InstallError),
+        ):
+            self.uninstaller().run(self.request)
+
+        self.assertTrue(self.layout.receipt.is_file())
+        self.assertTrue(self.layout.runtime.is_dir())
+        self.assertEqual(self.hash_user_data(), before)
+
+    def test_missing_receipt_fails_closed_without_touching_anything(self) -> None:
+        """没有 receipt 时不得猜测受管文件。"""
+        self.layout.receipt.unlink()
+        before = self.hash_user_data()
+
+        with self.assertRaises(InstallError):
+            self.uninstaller().run(self.request)
+
+        self.assertTrue(self.layout.launcher.is_file())
+        self.assertEqual(self.hash_user_data(), before)
+
+
+class SelfUninstallHandoffTests(_ManagedInstall):
+    """验证删除 Runtime 前把控制权交给 receipt-matching installer pyz。"""
+
+    def test_hands_off_to_verified_installer_copy_before_deleting_runtime(self) -> None:
+        """必须复制、重新校验 hash 并 exec 私有 0700 目录中的 installer。"""
+        calls: list[tuple[str, tuple[str, ...], dict[str, str]]] = []
+
+        def capture(executable: str, argv: tuple[str, ...], env: dict[str, str]) -> None:
+            calls.append((executable, tuple(argv), dict(env)))
+
+        uninstaller = self.uninstaller(
+            execve=capture,
+            executable=self.runtime / "venv" / "bin" / "python",
+        )
+        with self.assertRaises(InstallError):
+            uninstaller.run(self.request)
+
+        self.assertEqual(len(calls), 1)
+        executable, argv, environment = calls[0]
+        self.assertEqual(environment.get("LOBSTER0_INSTALLER_HOPS"), "1")
+        self.assertIn("uninstall", argv)
+        copied = Path(argv[argv.index("uninstall") - 1])
+        self.assertEqual(copied.name, "lobster0-installer.pyz")
+        self.assertEqual(copied.read_bytes(), _INSTALLER_BYTES)
+        self.assertEqual(stat.S_IMODE(copied.parent.lstat().st_mode), 0o700)
+        self.assertNotEqual(copied.parent, self.runtime)
+        self.assertFalse(copied.is_relative_to(self.layout.program_prefix))
+        self.assertEqual(executable, str(self.managed_python))
+        self.assertTrue(self.layout.runtime.is_dir())
+        self.assertTrue(self.layout.receipt.is_file())
+
+    def test_hop_guard_prevents_a_second_handoff(self) -> None:
+        """已跳转一次的进程必须直接执行删除而不是再次 exec。"""
+        uninstaller = self.uninstaller(
+            environ={"LOBSTER0_INSTALLER_HOPS": "1"},
+            executable=self.runtime / "venv" / "bin" / "python",
+        )
+
+        uninstaller.run(self.request)
+
+        self.assertFalse(self.layout.runtimes_dir.exists())
+
+    def test_installer_hash_mismatch_blocks_handoff_and_deletion(self) -> None:
+        """installer pyz 与 Runtime receipt 不匹配时必须失败关闭。"""
+        self.installer_pyz.write_bytes(b"tampered installer\n")
+        self.installer_pyz.chmod(0o700)
+
+        with self.assertRaises(InstallError) as raised:
+            self.uninstaller(
+                executable=self.runtime / "venv" / "bin" / "python",
+            ).run(self.request)
+
+        self.assertEqual(raised.exception.code, "uninstall_ownership_mismatch")
+        self.assertTrue(self.layout.runtime.is_dir())
+        self.assertTrue(self.layout.receipt.is_file())
+
+
+class PurgeTests(_ManagedInstall):
+    """验证 purge 的双确认、显式枚举与保守拒绝。"""
+
+    def purge_request(self, **kwargs: object) -> InstallRequest:
+        """返回一个 purge 请求。"""
+        return replace(self.request, purge_data=True, **kwargs)  # type: ignore[arg-type]
+
+    def test_noninteractive_purge_requires_the_exact_long_flag(self) -> None:
+        """非交互 purge 缺少确认时必须拒绝并保留全部数据。"""
+        before = self.hash_user_data()
+
+        with self.assertRaises(InstallError) as raised:
+            self.uninstaller(isatty=False).run(self.purge_request())
+
+        self.assertEqual(raised.exception.code, "request_invalid")
+        self.assertEqual(self.hash_user_data(), before)
+
+    def test_interactive_purge_requires_both_confirmation_phrases(self) -> None:
+        """交互 purge 的任一确认短语错误都必须中止且不删除数据。"""
+        before = self.hash_user_data()
+        for answers in (
+            ["wrong", "DELETE ALL LOBSTER0 DATA"],
+            [str(self.state_home), "delete all lobster0 data"],
+            [str(self.state_home), ""],
+        ):
+            with self.subTest(answers=answers):
+                pending = list(answers)
+                with self.assertRaises(InstallError):
+                    self.uninstaller(
+                        isatty=True,
+                        confirm=lambda _prompt, queue=pending: queue.pop(0),
+                    ).run(self.purge_request())
+                self.assertEqual(self.hash_user_data(), before)
+                self.assertTrue(self.layout.receipt.is_file())
+
+    def test_interactive_purge_removes_enumerated_state_and_keeps_workspace(self) -> None:
+        """两个确认短语正确时只删除显式枚举的状态路径。"""
+        answers = [str(self.state_home), "DELETE ALL LOBSTER0 DATA"]
+
+        self.uninstaller(
+            isatty=True,
+            confirm=lambda _prompt, queue=answers: queue.pop(0),
+        ).run(self.purge_request())
+
+        self.assertFalse((self.state_home / "config.toml").exists())
+        self.assertFalse((self.state_home / "secrets.env").exists())
+        self.assertFalse((self.state_home / "lobster0.db").exists())
+        self.assertFalse((self.state_home / "memory").exists())
+        self.assertFalse((self.state_home / "skills").exists())
+        self.assertFalse((self.state_home / "logs").exists())
+        self.assertTrue((self.state_home / "workspace" / "personal.txt").is_file())
+
+    def test_noninteractive_purge_with_exact_flag_removes_state(self) -> None:
+        """显式 confirm flag 可以在无 TTY 时完成 purge。"""
+        self.uninstaller(isatty=False).run(
+            self.purge_request(confirm_data_loss=True)
+        )
+
+        self.assertFalse((self.state_home / "lobster0.db").exists())
+        self.assertTrue((self.state_home / "workspace").is_dir())
+
+    def test_purge_refuses_symlinked_state_entry(self) -> None:
+        """枚举目标是 symlink 时必须整体拒绝，不跟随到外部目录。"""
+        outside = self.home / "outside-memory"
+        outside.mkdir(mode=0o700)
+        (outside / "keep.txt").write_text("outside\n", encoding="utf-8")
+        memory = self.state_home / "memory"
+        (memory / "personal.txt").unlink()
+        memory.rmdir()
+        memory.symlink_to(outside, target_is_directory=True)
+
+        with self.assertRaises(InstallError) as raised:
+            self.uninstaller(isatty=False).run(
+                self.purge_request(confirm_data_loss=True)
+            )
+
+        self.assertEqual(raised.exception.code, "uninstall_ownership_mismatch")
+        self.assertTrue((outside / "keep.txt").is_file())
+        self.assertTrue((self.state_home / "lobster0.db").is_file())
+
+    def test_purge_refuses_foreign_owned_state_home(self) -> None:
+        """状态根不属于当前用户时必须拒绝任何删除。"""
+        before = self.hash_user_data()
+
+        with (
+            mock.patch(
+                "lobster0.install.orchestrator.os.geteuid",
+                return_value=os.geteuid() + 1,
+            ),
+            self.assertRaises(InstallError),
+        ):
+            self.uninstaller(isatty=False).run(
+                self.purge_request(confirm_data_loss=True)
+            )
+
+        self.assertEqual(self.hash_user_data(), before)
+
+    def test_purge_refuses_root_home_root_and_workspace_targets(self) -> None:
+        """`/`、Home 根、Workspace 根与 symlink 都不能成为 purge 根。"""
+        link = self.home / "linked-state"
+        link.symlink_to(self.state_home, target_is_directory=True)
+        for candidate in (
+            Path("/"),
+            self.home,
+            self.state_home / "workspace",
+            link,
+            Path("relative"),
+        ):
+            with self.subTest(candidate=candidate):
+                with self.assertRaises(InstallError):
+                    _validate_purge_root(candidate, user_home=self.home)
+        _validate_purge_root(self.state_home, user_home=self.home)
+        self.assertTrue((self.state_home / "lobster0.db").is_file())
+
+
+class InstallFactsTests(_ManagedInstall):
+    """验证 CLI 与 Doctor 共用的受管/源码模式判定。"""
+
+    def test_reports_managed_mode_for_a_real_receipt(self) -> None:
+        """存在有效 receipt 时必须报告受管安装与精确版本。"""
+        facts = resolve_install_facts(
+            self.state_home,
+            environ={"LOBSTER0_PREFIX": str(self.layout.program_prefix)},
+            executable=self.outside_executable,
+            user_home=self.home,
+        )
+
+        self.assertTrue(facts.managed)
+        self.assertIsNotNone(facts.receipt)
+        assert facts.receipt is not None
+        self.assertEqual(facts.receipt.version, self.version)
+        self.assertEqual(facts.program_prefix, self.layout.program_prefix)
+
+    def test_reports_source_mode_without_a_receipt(self) -> None:
+        """没有 receipt 的源码 checkout 必须报告非受管且不抛异常。"""
+        self.layout.receipt.unlink()
+
+        facts = resolve_install_facts(
+            self.state_home,
+            environ={},
+            executable=self.outside_executable,
+            user_home=self.home,
+        )
+
+        self.assertFalse(facts.managed)
+        self.assertIsNone(facts.receipt)
+
+    def test_reports_managed_runtime_metadata_for_doctor(self) -> None:
+        """Doctor 需要的 Runtime/Node/TUI 事实必须来自 Runtime receipt。"""
+        facts = resolve_install_facts(
+            self.state_home,
+            environ={"LOBSTER0_PREFIX": str(self.layout.program_prefix)},
+            executable=self.outside_executable,
+            user_home=self.home,
+        )
+
+        self.assertIsNotNone(facts.layout)
+        assert facts.layout is not None
+        runtime = facts.layout.program_prefix / "runtimes" / self.version
+        self.assertTrue((runtime / "node" / "bin" / "node").is_file())
+        self.assertTrue((runtime / "tui" / "dist" / "main.js").is_file())
+        document = json.loads((runtime / "install-receipt.json").read_text(encoding="utf-8"))
+        self.assertEqual(document["node_version"], "24.18.0")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Milestone 6 / Task 14:把安装器的能力暴露成公开命令,并让 Doctor 感知安装状态。

- **`lobster0 service install|status|logs|restart|uninstall`** —— 单命令、感知安装状态:检测到安装凭据就走托管服务(Linux systemd-user / macOS launchd),源码检出则完全保持 Phase 6 既有行为与退出码不变。
- **`lobster0 uninstall [--purge-data]`** —— 默认卸载只删托管程序文件,完整保留配置、数据库、`secrets.env`、Memory、Skills、Workspace 和日志。
- **`lobster0 install-smoke --json`** —— 内部门禁(见下方"修复的真实缺陷")。
- **Doctor 新增 6 项安装事实检查**:`install_method`、`release_receipt`、`managed_runtime`、`managed_node`、`managed_tui`、`managed_service`。全部只读凭据与 `lstat`,无子进程、无网络、不读 Secret(均有断言);源码模式一律 WARN 不 FAIL。

### 计划未预料到的冲突及处理

计划成文early于 Phase 6,而 Phase 6 已经上线了同名的 `lobster0 service`(macOS-only、面向源码开发、无安装凭据),四个子命令名完全撞车。处理方式是**做成单个感知安装状态的命令**,而不是加第二个命令或删掉 Phase 6 的。模式判定收敛在唯一的 `resolve_install_facts` 里,Doctor 的 `install_method` 与 CLI 共用,二者不可能产生分歧。

### 修复的真实缺陷

`runtime.py` 早已在调用 `python -I -m lobster0 install-smoke --json` 并要求返回 `{"status":"ok",...}`,但这个子命令从来不存在——意味着**任何真实安装都会在 Runtime 冒烟检查这一步失败**。本次补齐实现。

## Verification

- 焦点测试 65/65;关联模块(service/orchestrator/zipapp/documentation)168/168。
- 全量 1487 项,仅剩已知的本机 `TuiBundleTest`(Node/pnpm 版本低于门槛)+ 1 预期跳过。
- 三个 `--help` 全部 rc=0,且断言参数树中不含任何携带 Secret 的选项。
- Ruff、docs validator 均 PASS。
- 独立复核重跑了焦点测试,并逐条核对了破坏性路径的断言覆盖:数据哈希前后比对、外来 runtime 条目阻断、launcher 哈希漂移阻断、外来命令链接不删、部分失败保留凭据与数据、缺凭据 fail closed、卸载前交接到校验过的 installer 副本、防递归跳转、哈希不符阻断交接;清除数据需双重确认短语 / 非交互需精确长参数、始终保留 Workspace、拒绝符号链接 / 非本人所有 / 根目录 / 家目录 / 工作区。

## 已知缺口(如实记录,不掩盖)

`lobster0 update` 目前 **fail closed**,提示用户重新运行 pinned 安装器。原因:Task 13 的升级流水线由 installer zipapp 驱动,需要 bootstrap 建立的信任根(pinned uv + managed Python),而受管 Runtime 按设计在激活时删除 `.inputs`,已安装的 CLI 手里没有可信 uv。开发者拒绝伪造信任根或退化到 PATH 上的不可信 uv——这个安全判断是正确的,复核认可。用户仍可通过重新运行一行安装命令完成升级。彻底修复需要让 Runtime 保留一份已校验的 uv(属于 Task 8 运行时契约变更),已作为独立待办跟踪。

## Checklist

- [x] 变更聚焦既定范围;唯一改动的既有断言(service 子命令集合加入 `logs`)已说明理由。
- [x] 已运行相关检查。
- [x] 台账已记录冲突裁决与已知缺口。
- [x] 未包含密钥、凭证或个人数据。
