### PR TITLE
build(release): 交付 Milestone 7 可复现发布产物与封闭世界清单

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,10 @@ workspace/
 .lobster0/
 .worktrees/
 .local/
+
+/release-artifacts/
+/release-manifest.json
+/release-inputs.json
+/SHA256SUMS
+/install.sh
+/lobster0-installer.pyz

--- a/release/features.json
+++ b/release/features.json
@@ -1,0 +1,75 @@
+{
+  "schema_version": 1,
+  "features": [
+    {
+      "feature": "agent",
+      "module": "lobster0.agent.runner",
+      "attribute": "AgentRunner"
+    },
+    {
+      "feature": "automation",
+      "module": "lobster0.automation.scheduler",
+      "attribute": "Scheduler"
+    },
+    {
+      "feature": "checkpoint",
+      "module": "lobster0.checkpoints.store",
+      "attribute": "CheckpointStore"
+    },
+    {
+      "feature": "discord",
+      "module": "lobster0.channels.discord",
+      "attribute": "DiscordAdapter"
+    },
+    {
+      "feature": "feishu",
+      "module": "lobster0.channels.feishu",
+      "attribute": "FeishuAdapter"
+    },
+    {
+      "feature": "gateway",
+      "module": "lobster0.gateway",
+      "attribute": "prepare_gateway_sdk_runtime"
+    },
+    {
+      "feature": "heartbeat",
+      "module": "lobster0.automation.heartbeat",
+      "attribute": "HeartbeatReconciler"
+    },
+    {
+      "feature": "memory",
+      "module": "lobster0.memory.service",
+      "attribute": "MemoryService"
+    },
+    {
+      "feature": "rollback",
+      "module": "lobster0.checkpoints.rollback",
+      "attribute": "RollbackService"
+    },
+    {
+      "feature": "sandbox",
+      "module": "lobster0.sandbox.base",
+      "attribute": "ExecutionPlan"
+    },
+    {
+      "feature": "skills",
+      "module": "lobster0.skills.loader",
+      "attribute": "SkillLoader"
+    },
+    {
+      "feature": "telegram",
+      "module": "lobster0.channels.telegram",
+      "attribute": "TelegramAdapter"
+    },
+    {
+      "feature": "tools",
+      "module": "lobster0.tools.registry",
+      "attribute": "ToolRegistry"
+    },
+    {
+      "feature": "tui",
+      "module": "lobster0.tui_launcher",
+      "attribute": "is_supported_node_version"
+    }
+  ]
+}

--- a/release/manifest.schema.json
+++ b/release/manifest.schema.json
@@ -80,8 +80,8 @@
         ]
       }
     },
-    "database_schema": {"const": 5},
-    "minimum_readable_schema": {"type": "integer", "minimum": 1, "maximum": 5}
+    "database_schema": {"const": 7},
+    "minimum_readable_schema": {"type": "integer", "minimum": 1, "maximum": 7}
   },
   "$defs": {
     "platform": {

--- a/scripts/build_release_manifest.py
+++ b/scripts/build_release_manifest.py
@@ -12,6 +12,8 @@ import zipfile
 from dataclasses import dataclass, replace
 from pathlib import Path, PurePosixPath
 
+from lobster0.storage.migrations import LATEST_SCHEMA_VERSION
+
 _SEMVER = re.compile(r"^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$")
 _COMMIT = re.compile(r"^[0-9a-f]{40}$")
 _SHA256 = re.compile(r"^[0-9a-f]{64}$")
@@ -21,7 +23,6 @@ _METADATA_FIELD = re.compile(r"^([A-Za-z][A-Za-z0-9-]*):[ \t]*(.*)$")
 _DISTRIBUTION = "lobster0-agent"
 _PRODUCT = "lobster0"
 _PYTHON_SERIES = "3.12"
-_DATABASE_SCHEMA = 5
 _MINIMUM_READABLE_SCHEMA = 1
 _MANIFEST_FILENAME = "release-manifest.json"
 _INSTALL_SCRIPT_FILENAME = "install.sh"
@@ -116,7 +117,7 @@ class ReleaseInputs:
         if (
             type(self.minimum_readable_schema) is not int
             or isinstance(self.minimum_readable_schema, bool)
-            or not 1 <= self.minimum_readable_schema <= _DATABASE_SCHEMA
+            or not 1 <= self.minimum_readable_schema <= LATEST_SCHEMA_VERSION
         ):
             raise ReleaseBuildError("invalid minimum readable schema")
         if (
@@ -214,7 +215,7 @@ def build_manifest(inputs: ReleaseInputs) -> bytes:
             for platform in _PLATFORMS
         ],
         "features": list(inputs.features),
-        "database_schema": _DATABASE_SCHEMA,
+        "database_schema": LATEST_SCHEMA_VERSION,
         "minimum_readable_schema": inputs.minimum_readable_schema,
     }
     return _canonical_json(document)
@@ -629,13 +630,20 @@ def _validate_requirements(path: Path) -> None:
 
 
 def _validate_installer(path: Path) -> None:
-    """要求 installer pyz 带固定 shebang 且是合法 zip。"""
+    """要求 installer pyz 带固定 shebang、可执行入口且无损坏 entry。"""
     try:
         with path.open("rb") as source:
             header = source.read(23)
         if header != b"#!/usr/bin/env python3\n" or not zipfile.is_zipfile(path):
             raise ReleaseBuildError("installer pyz is invalid")
-    except OSError as error:
+        with zipfile.ZipFile(path) as archive:
+            if "__main__.py" not in set(archive.namelist()):
+                raise ReleaseBuildError("installer pyz is missing its entry point")
+            if archive.testzip() is not None:
+                raise ReleaseBuildError("installer pyz has a corrupt entry")
+    except ReleaseBuildError:
+        raise
+    except (OSError, ValueError, zipfile.BadZipFile) as error:
         raise ReleaseBuildError("installer pyz is invalid") from error
 
 

--- a/scripts/build_release_manifest.py
+++ b/scripts/build_release_manifest.py
@@ -1,0 +1,937 @@
+#!/usr/bin/env python3
+"""从干净 tag commit 与已构建 artifact 生成封闭世界 Release manifest 与 checksums。"""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import tarfile
+import zipfile
+from dataclasses import dataclass, replace
+from pathlib import Path, PurePosixPath
+
+_SEMVER = re.compile(r"^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$")
+_COMMIT = re.compile(r"^[0-9a-f]{40}$")
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_VERSION_CONSTANT = re.compile(r'^__version__:\s*str\s*=\s*"([^"]+)"$', re.MULTILINE)
+_IMAGE_DIGEST = re.compile(r"^(ghcr\.io/nedonion/lobster0(?:-sandbox)?)@sha256:[0-9a-f]{64}$")
+_METADATA_FIELD = re.compile(r"^([A-Za-z][A-Za-z0-9-]*):[ \t]*(.*)$")
+_DISTRIBUTION = "lobster0-agent"
+_PRODUCT = "lobster0"
+_PYTHON_SERIES = "3.12"
+_DATABASE_SCHEMA = 5
+_MINIMUM_READABLE_SCHEMA = 1
+_MANIFEST_FILENAME = "release-manifest.json"
+_INSTALL_SCRIPT_FILENAME = "install.sh"
+_CHECKSUMS_FILENAME = "SHA256SUMS"
+_REPOSITORY = "https://github.com/NEDONION/lobster0"
+_NODE_REPOSITORY = "https://github.com/nodejs/node"
+_DOWNLOAD_BASE = f"{_REPOSITORY}/releases/download"
+_PROJECT_LICENSE = "MIT"
+_PLATFORMS = ("linux-x86_64", "linux-arm64", "macos-x86_64", "macos-arm64")
+_NODE_POLICY = {
+    "default": "24.18.0",
+    "accepted": [
+        {"minimum": "22.22.3", "maximum_exclusive": "23.0.0"},
+        {"minimum": "24.15.0", "maximum_exclusive": "25.0.0"},
+    ],
+}
+_FEATURES = (
+    "agent",
+    "tools",
+    "memory",
+    "skills",
+    "evolution",
+    "tui",
+    "feishu",
+    "telegram",
+    "discord",
+    "gateway",
+    "automation",
+    "heartbeat",
+    "sandbox",
+    "checkpoint",
+    "rollback",
+)
+_MAX_ARTIFACTS = 128
+_MAX_ARTIFACT_BYTES = 1_073_741_824
+_MAX_ARCHIVE_ENTRIES = 65_536
+_MEMBER_LIMIT = 4 * 1024 * 1024
+_GIT_TIMEOUT_SECONDS = 30
+
+
+class ReleaseBuildError(RuntimeError):
+    """表示 Release 事实、artifact 集合或输出不满足严格契约。"""
+
+
+@dataclass(frozen=True, slots=True)
+class ReleaseInputs:
+    """描述装配一个具体 Release 所需的全部已验证事实。
+
+    Args:
+        version: `_version.py` 给出的三段 Release 版本。
+        release_tag: 与版本精确对应的 `v<version>` tag。
+        git_commit: tag 指向的 lowercase 40-hex commit。
+        source_date_epoch: tag commit 时间，作为唯一时间来源。
+        node_version: `runtime-versions.json` 固定的默认 Node 版本。
+        minimum_readable_schema: 当前 Runtime 可读取的最早数据库 schema。
+        features: 已实现且在注册表中登记的能力名。
+        artifacts: 需要进入 manifest 的全部已构建 Release 文件。
+        install_script: 已渲染的 bootstrap 信任根文件。
+        runtime_versions: 固定 uv/Node/pnpm 版本与上游 hash 的 pins JSON。
+
+    Raises:
+        ReleaseBuildError: 任一字段类型、格式、范围或相互关系不可信。
+    """
+
+    version: str
+    release_tag: str
+    git_commit: str
+    source_date_epoch: int
+    node_version: str
+    minimum_readable_schema: int
+    features: tuple[str, ...]
+    artifacts: tuple[Path, ...]
+    install_script: Path
+    runtime_versions: Path
+
+    def __post_init__(self) -> None:
+        """在读取任何 artifact 字节前闭合 Release 身份关系。"""
+        if type(self.version) is not str or _SEMVER.fullmatch(self.version) is None:
+            raise ReleaseBuildError("invalid release version")
+        if self.release_tag != f"v{self.version}":
+            raise ReleaseBuildError("release tag must match the release version")
+        if type(self.git_commit) is not str or _COMMIT.fullmatch(self.git_commit) is None:
+            raise ReleaseBuildError("invalid git commit")
+        if (
+            type(self.source_date_epoch) is not int
+            or isinstance(self.source_date_epoch, bool)
+            or not 0 < self.source_date_epoch < 4_102_444_800
+        ):
+            raise ReleaseBuildError("invalid SOURCE_DATE_EPOCH")
+        if type(self.node_version) is not str or _SEMVER.fullmatch(self.node_version) is None:
+            raise ReleaseBuildError("invalid node version")
+        if (
+            type(self.minimum_readable_schema) is not int
+            or isinstance(self.minimum_readable_schema, bool)
+            or not 1 <= self.minimum_readable_schema <= _DATABASE_SCHEMA
+        ):
+            raise ReleaseBuildError("invalid minimum readable schema")
+        if (
+            type(self.features) is not tuple
+            or not self.features
+            or any(item not in _FEATURES for item in self.features)
+        ):
+            raise ReleaseBuildError("invalid feature registry")
+        if len(self.features) != len(set(self.features)):
+            raise ReleaseBuildError("duplicate feature registry entry")
+        if (
+            type(self.artifacts) is not tuple
+            or not 1 <= len(self.artifacts) <= _MAX_ARTIFACTS
+            or any(not isinstance(item, Path) for item in self.artifacts)
+        ):
+            raise ReleaseBuildError("invalid artifact set")
+        for path in (*self.artifacts, self.install_script, self.runtime_versions):
+            if not isinstance(path, Path) or not path.is_file() or path.is_symlink():
+                raise ReleaseBuildError("release inputs must be regular files")
+
+
+@dataclass(frozen=True, slots=True)
+class ReleaseOutputs:
+    """保存一个候选 Release 的两份 canonical 文本产物。
+
+    Args:
+        manifest: canonical `release-manifest.json` 字节。
+        checksums: 排序后的 `SHA256SUMS` 字节。
+    """
+
+    manifest: bytes
+    checksums: bytes
+
+
+@dataclass(frozen=True, slots=True)
+class _Expected:
+    """描述封闭世界中一个 Release 文件的全部固定属性。"""
+
+    kind: str
+    os: str
+    arch: str
+    media_type: str
+    component_version: str
+    source_repository: str
+    license_ref: str
+
+
+@dataclass(frozen=True, slots=True)
+class _Record:
+    """保存一个已散列并已深度校验的 manifest artifact 记录。"""
+
+    expected: _Expected
+    filename: str
+    sha256: str
+    size: int
+    upstream_sha256: str | None
+
+
+def build_manifest(inputs: ReleaseInputs) -> bytes:
+    """校验完整 Tier 1 组件集合并生成 canonical Release manifest。
+
+    Args:
+        inputs: 已通过身份校验的 Release 输入。
+
+    Returns:
+        键序稳定、以换行结尾的 canonical UTF-8 manifest 字节。
+
+    Raises:
+        ReleaseBuildError: artifact 集合不完整、多余、重复或内容与 Release 不符。
+    """
+    if type(inputs) is not ReleaseInputs:
+        raise ReleaseBuildError("invalid release inputs")
+    expected = _expected_artifacts(inputs.version, inputs.node_version)
+    present = _require_complete_set(inputs, expected)
+    records = _validate_artifacts(inputs, expected, present)
+    ordered = sorted(
+        records,
+        key=lambda record: (
+            record.expected.kind,
+            record.expected.os,
+            record.expected.arch,
+            record.filename,
+        ),
+    )
+    document = {
+        "schema_version": 1,
+        "product": _PRODUCT,
+        "version": inputs.version,
+        "git_commit": inputs.git_commit,
+        "python": _PYTHON_SERIES,
+        "node": _NODE_POLICY,
+        "artifacts": [_artifact_document(record, inputs.release_tag) for record in ordered],
+        "supported_platforms": [
+            {"os": platform.split("-", 1)[0], "arch": platform.split("-", 1)[1]}
+            for platform in _PLATFORMS
+        ],
+        "features": list(inputs.features),
+        "database_schema": _DATABASE_SCHEMA,
+        "minimum_readable_schema": inputs.minimum_readable_schema,
+    }
+    return _canonical_json(document)
+
+
+def build_checksums(manifest: bytes, inputs: ReleaseInputs) -> bytes:
+    """对 manifest、bootstrap 与全部 Release artifact 生成排序 checksums。
+
+    Args:
+        manifest: 已完成的 canonical manifest 字节。
+        inputs: 与 manifest 同源的 Release 输入。
+
+    Returns:
+        按文件名排序、每行 `<sha256>  <filename>` 的 `SHA256SUMS` 字节。
+
+    Raises:
+        ReleaseBuildError: manifest 字节、bootstrap 文件名或文件集合不可信。
+    """
+    if type(manifest) is not bytes or not manifest:
+        raise ReleaseBuildError("invalid manifest bytes")
+    if type(inputs) is not ReleaseInputs:
+        raise ReleaseBuildError("invalid release inputs")
+    if inputs.install_script.name != _INSTALL_SCRIPT_FILENAME:
+        raise ReleaseBuildError("install script must be named install.sh")
+    _require_complete_set(inputs, _expected_artifacts(inputs.version, inputs.node_version))
+    entries = {
+        _MANIFEST_FILENAME: hashlib.sha256(manifest).hexdigest(),
+        _INSTALL_SCRIPT_FILENAME: _sha256(inputs.install_script),
+    }
+    for path in inputs.artifacts:
+        if path.name in entries:
+            raise ReleaseBuildError(f"duplicate artifact filename {path.name}")
+        entries[path.name] = _sha256(path)
+    if _CHECKSUMS_FILENAME in entries:
+        raise ReleaseBuildError("SHA256SUMS must not be a release artifact")
+    lines = [
+        f"{entries[filename]}  {filename}\n"
+        for filename in sorted(entries, key=lambda name: name.encode("utf-8"))
+    ]
+    return "".join(lines).encode()
+
+
+def build_release_outputs(inputs: ReleaseInputs) -> ReleaseOutputs:
+    """一次性生成同一候选 Release 的 manifest 与 checksums。
+
+    Args:
+        inputs: 已通过身份校验的 Release 输入。
+
+    Returns:
+        对相同输入逐字节可复现的两份文本产物。
+
+    Raises:
+        ReleaseBuildError: manifest 或 checksums 任一环节校验失败。
+    """
+    manifest = build_manifest(inputs)
+    return ReleaseOutputs(manifest=manifest, checksums=build_checksums(manifest, inputs))
+
+
+def build_release_inputs_document(manifest: bytes, inputs: ReleaseInputs) -> bytes:
+    """生成 `install.sh` 渲染所需的固定 manifest/installer 事实。
+
+    Args:
+        manifest: 已完成的 canonical manifest 字节。
+        inputs: 与 manifest 同源的 Release 输入。
+
+    Returns:
+        canonical `release-inputs.json` 字节。
+
+    Raises:
+        ReleaseBuildError: manifest 字节或 installer artifact 不可信。
+    """
+    if type(manifest) is not bytes or not manifest:
+        raise ReleaseBuildError("invalid manifest bytes")
+    if type(inputs) is not ReleaseInputs:
+        raise ReleaseBuildError("invalid release inputs")
+    installer = next(
+        (path for path in inputs.artifacts if path.name == "lobster0-installer.pyz"), None
+    )
+    if installer is None:
+        raise ReleaseBuildError("missing installer artifact")
+    return _canonical_json(
+        {
+            "release_tag": inputs.release_tag,
+            "manifest_filename": _MANIFEST_FILENAME,
+            "manifest_sha256": hashlib.sha256(manifest).hexdigest(),
+            "manifest_size": len(manifest),
+            "installer_filename": installer.name,
+            "installer_sha256": _sha256(installer),
+            "installer_size": installer.stat().st_size,
+        }
+    )
+
+
+def load_features(path: Path) -> tuple[str, ...]:
+    """读取 features 注册表并返回排序、唯一、封闭的能力名。
+
+    Args:
+        path: `release/features.json` 的路径。
+
+    Returns:
+        与注册表登记顺序一致的能力名元组。
+
+    Raises:
+        ReleaseBuildError: 注册表结构、能力名或 import 断言不可信。
+    """
+    document = _read_json(path, "feature registry")
+    if type(document) is not dict or document.get("schema_version") != 1:
+        raise ReleaseBuildError("invalid feature registry")
+    entries = document.get("features")
+    if type(entries) is not list or not entries:
+        raise ReleaseBuildError("invalid feature registry")
+    names: list[str] = []
+    for entry in entries:
+        if type(entry) is not dict or set(entry) != {"feature", "module", "attribute"}:
+            raise ReleaseBuildError("invalid feature registry")
+        name = entry["feature"]
+        module = entry["module"]
+        attribute = entry["attribute"]
+        if (
+            type(name) is not str
+            or name not in _FEATURES
+            or type(module) is not str
+            or not module.startswith("lobster0.")
+            or type(attribute) is not str
+            or not attribute.isidentifier()
+        ):
+            raise ReleaseBuildError("invalid feature registry")
+        names.append(name)
+    if names != sorted(names) or len(names) != len(set(names)):
+        raise ReleaseBuildError("duplicate feature registry entry")
+    return tuple(names)
+
+
+def collect_release_inputs(
+    repository: Path,
+    artifact_directory: Path,
+    install_script: Path,
+    environ: dict[str, str],
+) -> ReleaseInputs:
+    """从干净 tag commit 与本地 artifact 目录收集全部 Release 事实。
+
+    Args:
+        repository: 处于 tag commit 且工作区干净的 Git 仓库。
+        artifact_directory: 只包含已构建 Release 文件的目录。
+        install_script: 已渲染的 bootstrap 信任根文件。
+        environ: 必须提供 `SOURCE_DATE_EPOCH` 的进程环境映射。
+
+    Returns:
+        与 tag、commit、版本和固定 pins 精确一致的 Release 输入。
+
+    Raises:
+        ReleaseBuildError: 工作区不干净、tag 不指向 HEAD、时间不一致或目录不合规。
+    """
+    repository_root = Path(repository)
+    if _git(repository_root, "status", "--porcelain").strip():
+        raise ReleaseBuildError("git worktree is not clean")
+    version = _read_version(repository_root)
+    tag = f"v{version}"
+    head = _git(repository_root, "rev-parse", "HEAD").strip()
+    tagged = _git(repository_root, "rev-parse", "--verify", f"{tag}^{{commit}}").strip()
+    if _COMMIT.fullmatch(head) is None or tagged != head:
+        raise ReleaseBuildError("release tag does not point at HEAD")
+    epoch_text = _git(repository_root, "show", "-s", "--format=%ct", f"{tag}^{{commit}}").strip()
+    if not epoch_text.isdigit():
+        raise ReleaseBuildError("could not read the tag commit time")
+    requested = environ.get("SOURCE_DATE_EPOCH") if type(environ) is dict else None
+    if type(requested) is not str or not requested.isdigit() or requested != epoch_text:
+        raise ReleaseBuildError("SOURCE_DATE_EPOCH must equal the tag commit time")
+    directory = Path(artifact_directory)
+    if not directory.is_dir() or directory.is_symlink():
+        raise ReleaseBuildError("artifact directory must be a regular directory")
+    artifacts = tuple(sorted(directory.iterdir()))
+    runtime_versions = repository_root / "release/runtime-versions.json"
+    return ReleaseInputs(
+        version=version,
+        release_tag=tag,
+        git_commit=head,
+        source_date_epoch=int(epoch_text),
+        node_version=_node_pins(runtime_versions)[0],
+        minimum_readable_schema=_MINIMUM_READABLE_SCHEMA,
+        features=load_features(repository_root / "release/features.json"),
+        artifacts=artifacts,
+        install_script=Path(install_script),
+        runtime_versions=runtime_versions,
+    )
+
+
+def _expected_artifacts(version: str, node_version: str) -> dict[str, _Expected]:
+    """枚举一个完整 Release 必须恰好包含的全部文件。"""
+    universal = _Expected(
+        kind="",
+        os="any",
+        arch="any",
+        media_type="",
+        component_version=version,
+        source_repository=_REPOSITORY,
+        license_ref=_PROJECT_LICENSE,
+    )
+    table = {
+        f"lobster0_agent-{version}-py3-none-any.whl": replace(
+            universal, kind="wheel", media_type="application/zip"
+        ),
+        f"lobster0_agent-{version}.tar.gz": replace(
+            universal, kind="sdist", media_type="application/gzip"
+        ),
+        "requirements-all.lock": replace(
+            universal, kind="requirements", media_type="text/plain"
+        ),
+        "lobster0-installer.pyz": replace(
+            universal, kind="installer", media_type="application/zip"
+        ),
+        f"lobster0-{version}-sbom.cyclonedx.json": replace(
+            universal, kind="sbom", media_type="application/vnd.cyclonedx+json"
+        ),
+        f"lobster0-{version}-sbom.spdx.json": replace(
+            universal, kind="sbom", media_type="application/spdx+json"
+        ),
+        f"lobster0-runtime-image-{version}.txt": replace(
+            universal, kind="runtime-image", media_type="text/plain"
+        ),
+        f"lobster0-sandbox-image-{version}.txt": replace(
+            universal, kind="sandbox-image", media_type="text/plain"
+        ),
+    }
+    for platform in _PLATFORMS:
+        os_name, arch = platform.split("-", 1)
+        table[f"lobster0-node-{node_version}-{platform}.tar.gz"] = _Expected(
+            kind="node",
+            os=os_name,
+            arch=arch,
+            media_type="application/gzip",
+            component_version=node_version,
+            source_repository=_NODE_REPOSITORY,
+            license_ref=_PROJECT_LICENSE,
+        )
+        table[f"lobster0-tui-{version}-{platform}.tar.gz"] = _Expected(
+            kind="tui",
+            os=os_name,
+            arch=arch,
+            media_type="application/gzip",
+            component_version=version,
+            source_repository=_REPOSITORY,
+            license_ref=_PROJECT_LICENSE,
+        )
+    return table
+
+
+def _require_complete_set(
+    inputs: ReleaseInputs, expected: dict[str, _Expected]
+) -> dict[str, Path]:
+    """要求输入文件集合与封闭世界期望精确相等。"""
+    present = _index_artifacts(inputs.artifacts, expected)
+    for filename in sorted(expected):
+        if filename not in present:
+            raise ReleaseBuildError(_missing_message(expected[filename]))
+    return present
+
+
+def _missing_message(expected: _Expected) -> str:
+    """为一个缺失组件生成精确、稳定的失败消息。"""
+    if expected.kind == "sbom":
+        fmt = "cyclonedx" if "cyclonedx" in expected.media_type else "spdx"
+        return f"missing sbom artifact for {fmt}"
+    if expected.os != "any":
+        return f"missing {expected.kind} artifact for {expected.os}-{expected.arch}"
+    return f"missing {expected.kind} artifact"
+
+
+def _index_artifacts(
+    artifacts: tuple[Path, ...], expected: dict[str, _Expected]
+) -> dict[str, Path]:
+    """按文件名索引输入文件并拒绝未登记或重复的条目。"""
+    present: dict[str, Path] = {}
+    for path in artifacts:
+        if path.name not in expected:
+            raise ReleaseBuildError(f"unexpected artifact {path.name}")
+        if path.name in present:
+            raise ReleaseBuildError(f"duplicate artifact filename {path.name}")
+        present[path.name] = path
+    return present
+
+
+def _validate_artifacts(
+    inputs: ReleaseInputs,
+    expected: dict[str, _Expected],
+    present: dict[str, Path],
+) -> tuple[_Record, ...]:
+    """散列每个 artifact 并按 kind 执行深度内容校验。"""
+    node_version, node_archives = _node_pins(inputs.runtime_versions)
+    if node_version != inputs.node_version:
+        raise ReleaseBuildError("node version does not match the pinned runtime")
+    digests: dict[str, str] = {}
+    sizes: dict[str, int] = {}
+    for filename in sorted(present):
+        path = present[filename]
+        size = path.stat().st_size
+        if not 1 <= size <= _MAX_ARTIFACT_BYTES:
+            raise ReleaseBuildError(f"artifact size is out of range for {filename}")
+        digests[filename] = _sha256(path)
+        sizes[filename] = size
+    wheel_name = f"lobster0_agent-{inputs.version}-py3-none-any.whl"
+    _validate_wheel(present[wheel_name], inputs.version)
+    _validate_sdist(present[f"lobster0_agent-{inputs.version}.tar.gz"], inputs.version)
+    _validate_requirements(present["requirements-all.lock"])
+    _validate_installer(present["lobster0-installer.pyz"])
+    records: list[_Record] = []
+    for filename in sorted(present):
+        entry = expected[filename]
+        upstream: str | None = None
+        if entry.kind == "node":
+            platform = f"{entry.os}-{entry.arch}"
+            _scan_archive(present[filename])
+            upstream = _validate_node_bundle(
+                present[filename], platform, node_version, node_archives
+            )
+        elif entry.kind == "tui":
+            _scan_archive(present[filename])
+            _validate_tui_bundle(present[filename])
+        elif entry.kind == "sdist":
+            _scan_archive(present[filename])
+        elif entry.kind == "sbom":
+            _validate_sbom(
+                present[filename], entry.media_type, inputs.version, wheel_name,
+                digests[wheel_name],
+            )
+        elif entry.kind in {"runtime-image", "sandbox-image"}:
+            _validate_image_digest(present[filename], entry.kind)
+        records.append(
+            _Record(
+                expected=entry,
+                filename=filename,
+                sha256=digests[filename],
+                size=sizes[filename],
+                upstream_sha256=upstream,
+            )
+        )
+    return tuple(records)
+
+
+def _artifact_document(record: _Record, release_tag: str) -> dict[str, object]:
+    """把一条已校验记录渲染成 manifest artifact 对象。"""
+    return {
+        "kind": record.expected.kind,
+        "filename": record.filename,
+        "url": f"{_DOWNLOAD_BASE}/{release_tag}/{record.filename}",
+        "sha256": record.sha256,
+        "size": record.size,
+        "media_type": record.expected.media_type,
+        "platform": {"os": record.expected.os, "arch": record.expected.arch},
+        "component_version": record.expected.component_version,
+        "source_repository": record.expected.source_repository,
+        "license_ref": record.expected.license_ref,
+        "upstream_sha256": record.upstream_sha256,
+    }
+
+
+def _validate_wheel(path: Path, version: str) -> None:
+    """要求 wheel 的分发名、版本与 console script 与 Release 精确一致。"""
+    dist_info = f"lobster0_agent-{version}.dist-info"
+    try:
+        with zipfile.ZipFile(path) as archive:
+            names = set(archive.namelist())
+            required = {
+                f"{dist_info}/METADATA",
+                f"{dist_info}/RECORD",
+                f"{dist_info}/entry_points.txt",
+            }
+            if not required.issubset(names):
+                raise ReleaseBuildError("wheel metadata mismatch")
+            metadata = _metadata_fields(archive.read(f"{dist_info}/METADATA"))
+            entry_points = archive.read(f"{dist_info}/entry_points.txt").decode("utf-8")
+    except ReleaseBuildError:
+        raise
+    except (OSError, UnicodeDecodeError, ValueError, zipfile.BadZipFile) as error:
+        raise ReleaseBuildError("wheel metadata mismatch") from error
+    if (
+        _normalize(metadata.get("Name", "")) != _DISTRIBUTION
+        or metadata.get("Version") != version
+        or "lobster0 = lobster0.cli:main" not in entry_points
+    ):
+        raise ReleaseBuildError("wheel metadata mismatch")
+
+
+def _validate_sdist(path: Path, version: str) -> None:
+    """要求 sdist 的 PKG-INFO 与 Release 名称版本精确一致。"""
+    metadata = _metadata_fields(
+        _read_tar_member(path, f"lobster0_agent-{version}/PKG-INFO")
+    )
+    if _normalize(metadata.get("Name", "")) != _DISTRIBUTION or metadata.get("Version") != version:
+        raise ReleaseBuildError("sdist metadata mismatch")
+
+
+def _validate_requirements(path: Path) -> None:
+    """要求 lock 中每条 requirement 都固定版本并带 SHA-256。"""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as error:
+        raise ReleaseBuildError("could not read the requirements lock") from error
+    entries = 0
+    for line in text.replace("\\\n", " ").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith(("#", "-")):
+            continue
+        requirement = stripped.split(" ", 1)[0]
+        if requirement.count("==") != 1 or not requirement.split("==", 1)[1]:
+            raise ReleaseBuildError("requirements entry without pinned version")
+        if "--hash=sha256:" not in stripped:
+            raise ReleaseBuildError("requirements entry without hash")
+        entries += 1
+    if entries == 0:
+        raise ReleaseBuildError("requirements lock is empty")
+
+
+def _validate_installer(path: Path) -> None:
+    """要求 installer pyz 带固定 shebang 且是合法 zip。"""
+    try:
+        with path.open("rb") as source:
+            header = source.read(23)
+        if header != b"#!/usr/bin/env python3\n" or not zipfile.is_zipfile(path):
+            raise ReleaseBuildError("installer pyz is invalid")
+    except OSError as error:
+        raise ReleaseBuildError("installer pyz is invalid") from error
+
+
+def _validate_node_bundle(
+    path: Path, platform: str, node_version: str, archives: dict[str, dict[str, str]]
+) -> str:
+    """要求 Node bundle 记录的上游 hash 与固定 pin 精确一致。"""
+    component = _read_json_bytes(
+        _read_tar_member(path, "node/release-component.json"), "node component"
+    )
+    if type(component) is not dict:
+        raise ReleaseBuildError("invalid node component")
+    if component.get("version") != node_version or component.get("platform") != platform:
+        raise ReleaseBuildError(f"node component mismatch for {platform}")
+    upstream = component.get("upstream_sha256")
+    if type(upstream) is not str or _SHA256.fullmatch(upstream) is None:
+        raise ReleaseBuildError("invalid node component")
+    if upstream != archives[platform]["sha256"]:
+        raise ReleaseBuildError(f"node upstream hash mismatch for {platform}")
+    return upstream
+
+
+def _validate_tui_bundle(path: Path) -> None:
+    """要求 TUI bundle 携带 production license 清单与 package 描述。"""
+    for member in ("tui/licenses.json", "tui/package.json"):
+        if not _read_tar_member(path, member):
+            raise ReleaseBuildError("tui bundle is missing a release member")
+
+
+def _validate_sbom(
+    path: Path, media_type: str, version: str, wheel_filename: str, wheel_sha256: str
+) -> None:
+    """要求两种 SBOM 的主体与 wheel hash 与本 Release 精确一致。"""
+    document = _read_json(path, "sbom")
+    if type(document) is not dict:
+        raise ReleaseBuildError("sbom subject mismatch")
+    if media_type == "application/vnd.cyclonedx+json":
+        metadata = document.get("metadata")
+        component = metadata.get("component") if type(metadata) is dict else None
+        if (
+            document.get("specVersion") != "1.5"
+            or type(component) is not dict
+            or component.get("name") != _PRODUCT
+            or component.get("version") != version
+        ):
+            raise ReleaseBuildError("sbom subject mismatch")
+        entries = document.get("components")
+        found = _find_entry(entries, wheel_filename, "name")
+        digest = _first_value(found, "hashes", "content")
+    else:
+        if document.get("spdxVersion") != "SPDX-2.3" or document.get("name") != (
+            f"{_PRODUCT}-{version}"
+        ):
+            raise ReleaseBuildError("sbom subject mismatch")
+        entries = document.get("packages")
+        found = _find_entry(entries, wheel_filename, "name")
+        digest = _first_value(found, "checksums", "checksumValue")
+    if digest != wheel_sha256:
+        raise ReleaseBuildError("sbom subject mismatch")
+
+
+def _validate_image_digest(path: Path, kind: str) -> None:
+    """要求 GHCR digest 文件是精确的单行 immutable 引用。"""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as error:
+        raise ReleaseBuildError("image digest missing") from error
+    matched = _IMAGE_DIGEST.fullmatch(text.strip())
+    if matched is None or text.strip().count("\n") != 0:
+        raise ReleaseBuildError("image digest missing")
+    expected = f"ghcr.io/nedonion/{_PRODUCT}" + ("-sandbox" if kind == "sandbox-image" else "")
+    if matched.group(1) != expected:
+        raise ReleaseBuildError("image digest missing")
+
+
+def _scan_archive(path: Path) -> None:
+    """拒绝含 link、special entry、逃逸路径或重复条目的 Release archive。"""
+    seen: set[str] = set()
+    try:
+        with tarfile.open(path, "r:gz") as archive:
+            for index, member in enumerate(archive):
+                if index >= _MAX_ARCHIVE_ENTRIES:
+                    raise ReleaseBuildError("archive contains too many entries")
+                name = member.name
+                pure = PurePosixPath(name)
+                if (
+                    not (member.isreg() or member.isdir())
+                    or pure.is_absolute()
+                    or ".." in pure.parts
+                    or name in seen
+                ):
+                    raise ReleaseBuildError("archive contains an unsafe entry")
+                seen.add(name)
+    except ReleaseBuildError:
+        raise
+    except (OSError, EOFError, tarfile.TarError) as error:
+        raise ReleaseBuildError("archive contains an unsafe entry") from error
+    if not seen:
+        raise ReleaseBuildError("archive contains an unsafe entry")
+
+
+def _find_entry(entries: object, value: str, key: str) -> dict[str, object]:
+    """在 SBOM 列表中定位唯一匹配指定键值的对象。"""
+    if type(entries) is not list:
+        raise ReleaseBuildError("sbom subject mismatch")
+    matches = [
+        item for item in entries if type(item) is dict and item.get(key) == value
+    ]
+    if len(matches) != 1:
+        raise ReleaseBuildError("sbom subject mismatch")
+    return matches[0]
+
+
+def _first_value(entry: dict[str, object], container: str, key: str) -> str:
+    """读取 SBOM 记录中第一条 hash 结构的字符串值。"""
+    values = entry.get(container)
+    if type(values) is not list or not values or type(values[0]) is not dict:
+        raise ReleaseBuildError("sbom subject mismatch")
+    value = values[0].get(key)
+    if type(value) is not str:
+        raise ReleaseBuildError("sbom subject mismatch")
+    return value
+
+
+def _metadata_fields(payload: bytes) -> dict[str, str]:
+    """解析 core metadata 头部并返回首次出现的字段值。"""
+    fields: dict[str, str] = {}
+    try:
+        text = payload.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise ReleaseBuildError("invalid distribution metadata") from error
+    for line in text.splitlines():
+        if not line.strip():
+            break
+        matched = _METADATA_FIELD.fullmatch(line)
+        if matched is not None and matched.group(1) not in fields:
+            fields[matched.group(1)] = matched.group(2).strip()
+    return fields
+
+
+def _node_pins(path: Path) -> tuple[str, dict[str, dict[str, str]]]:
+    """读取并严格校验四平台 Node 版本与上游 hash。"""
+    document = _read_json(path, "runtime pins")
+    node = document.get("node") if type(document) is dict else None
+    if type(node) is not dict:
+        raise ReleaseBuildError("invalid runtime pins")
+    version = node.get("version")
+    archives = node.get("archives")
+    if (
+        type(version) is not str
+        or _SEMVER.fullmatch(version) is None
+        or type(archives) is not dict
+        or set(archives) != set(_PLATFORMS)
+    ):
+        raise ReleaseBuildError("invalid runtime pins")
+    normalized: dict[str, dict[str, str]] = {}
+    for platform in _PLATFORMS:
+        entry = archives[platform]
+        digest = entry.get("sha256") if type(entry) is dict else None
+        url = entry.get("url") if type(entry) is dict else None
+        if (
+            type(digest) is not str
+            or _SHA256.fullmatch(digest) is None
+            or type(url) is not str
+            or not url.startswith("https://nodejs.org/dist/")
+        ):
+            raise ReleaseBuildError("invalid runtime pins")
+        normalized[platform] = {"sha256": digest, "url": url}
+    return version, normalized
+
+
+def _read_version(repository: Path) -> str:
+    """从版本单一来源常量读取 Release 版本，不导入任何模块。"""
+    try:
+        text = (repository / "src/lobster0/_version.py").read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as error:
+        raise ReleaseBuildError("could not read the release version") from error
+    matched = _VERSION_CONSTANT.search(text)
+    if matched is None or _SEMVER.fullmatch(matched.group(1)) is None:
+        raise ReleaseBuildError("could not read the release version")
+    return matched.group(1)
+
+
+def _git(repository: Path, *arguments: str) -> str:
+    """以 exact argv 运行一个只读 git 子命令。"""
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(repository), *arguments],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_SECONDS,
+            check=False,
+            shell=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise ReleaseBuildError("could not read git release facts") from error
+    if completed.returncode != 0:
+        raise ReleaseBuildError("could not read git release facts")
+    return completed.stdout
+
+
+def _read_json(path: Path, label: str) -> object:
+    """读取一个有字节上限的 UTF-8 JSON 文档。"""
+    try:
+        data = Path(path).read_bytes()
+    except OSError as error:
+        raise ReleaseBuildError(f"could not read {label}") from error
+    return _read_json_bytes(data, label)
+
+
+def _read_json_bytes(data: bytes, label: str) -> object:
+    """解析一个有字节上限的 UTF-8 JSON 字节串。"""
+    if not data or len(data) > _MAX_ARTIFACT_BYTES:
+        raise ReleaseBuildError(f"invalid {label}")
+    try:
+        return json.loads(data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ReleaseBuildError(f"invalid {label}") from error
+
+
+def _read_tar_member(path: Path, name: str) -> bytes:
+    """从 tar.gz bundle 中读取一个有上限的 regular member。"""
+    try:
+        with tarfile.open(path, "r:gz") as archive:
+            member = archive.getmember(name)
+            if not member.isreg() or not 0 < member.size <= _MEMBER_LIMIT:
+                raise ReleaseBuildError(f"invalid bundle member {name}")
+            source = archive.extractfile(member)
+            if source is None:
+                raise ReleaseBuildError(f"invalid bundle member {name}")
+            with source:
+                return source.read(_MEMBER_LIMIT + 1)
+    except ReleaseBuildError:
+        raise
+    except (OSError, EOFError, KeyError, tarfile.TarError) as error:
+        raise ReleaseBuildError(f"invalid bundle member {name}") from error
+
+
+def _sha256(path: Path) -> str:
+    """流式计算一个 regular file 的 SHA-256。"""
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as source:
+            for chunk in iter(lambda: source.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError as error:
+        raise ReleaseBuildError("could not read a release artifact") from error
+    return digest.hexdigest()
+
+
+def _normalize(name: str) -> str:
+    """按 PyPA 规则把分发名规范化为可比较形式。"""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _canonical_json(document: object) -> bytes:
+    """编码带结尾换行、键序稳定的 canonical UTF-8 JSON。"""
+    encoded = json.dumps(document, ensure_ascii=False, indent=2, sort_keys=True)
+    return f"{encoded}\n".encode()
+
+
+def main(argv: list[str] | None = None) -> int:
+    """解析 CLI 子命令并写出 manifest 或 checksums。"""
+    parser = argparse.ArgumentParser(description="Assemble the Lobster0 release manifest")
+    parser.add_argument("--repository", type=Path, default=Path("."))
+    parser.add_argument("--artifact-dir", type=Path, required=True)
+    parser.add_argument("--install-script", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    subcommands = parser.add_subparsers(dest="command", required=True)
+    manifest_parser = subcommands.add_parser("manifest", help="write release-manifest.json")
+    manifest_parser.add_argument("--release-inputs-output", type=Path, default=None)
+    checksums_parser = subcommands.add_parser("checksums", help="write SHA256SUMS")
+    checksums_parser.add_argument("--manifest", type=Path, required=True)
+    arguments = parser.parse_args(argv)
+    try:
+        inputs = collect_release_inputs(
+            arguments.repository,
+            arguments.artifact_dir,
+            arguments.install_script,
+            dict(os.environ),
+        )
+        if arguments.command == "manifest":
+            payload = build_manifest(inputs)
+            if arguments.release_inputs_output is not None:
+                arguments.release_inputs_output.write_bytes(
+                    build_release_inputs_document(payload, inputs)
+                )
+        else:
+            payload = build_checksums(arguments.manifest.read_bytes(), inputs)
+    except ReleaseBuildError as error:
+        parser.error(str(error))
+        return 2
+    arguments.output.parent.mkdir(parents=True, exist_ok=True)
+    arguments.output.write_bytes(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_sbom.py
+++ b/scripts/build_sbom.py
@@ -1,0 +1,621 @@
+#!/usr/bin/env python3
+"""从已构建 Release artifact 生成 canonical CycloneDX 1.5 与 SPDX 2.3 SBOM。"""
+
+import argparse
+import hashlib
+import json
+import re
+import tarfile
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+_SEMVER = re.compile(r"^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$")
+_COMMIT = re.compile(r"^[0-9a-f]{40}$")
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_PACKAGE_NAME = re.compile(r"^[@A-Za-z0-9][A-Za-z0-9._@/+-]{0,127}$")
+_PACKAGE_VERSION = re.compile(r"^[A-Za-z0-9][A-Za-z0-9.+_-]{0,63}$")
+_LICENSE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9.+ ()-]{0,127}$")
+_SPDX_ID = re.compile(r"[^A-Za-z0-9.-]")
+_IMAGE_DIGEST = re.compile(r"^(ghcr\.io/nedonion/lobster0(?:-sandbox)?)@sha256:([0-9a-f]{64})$")
+_REPOSITORY = "https://github.com/NEDONION/lobster0"
+_TOOL = "lobster0-build-sbom"
+_PROJECT_LICENSE = "MIT"
+_MEMBER_LIMIT = 4 * 1024 * 1024
+_DOCUMENT_LIMIT = 8 * 1024 * 1024
+_MAX_COMPONENTS = 4096
+
+
+class SbomBuildError(RuntimeError):
+    """表示 SBOM 输入、依赖清单或输出不满足严格契约。"""
+
+
+@dataclass(frozen=True, slots=True)
+class SbomInputs:
+    """描述生成一份 Release SBOM 所需的全部本地事实。
+
+    Args:
+        version: Release 的三段版本。
+        git_commit: 绑定 Release 的 lowercase 40-hex commit。
+        source_date_epoch: tag commit 时间，用作唯一的文档时间戳来源。
+        python_components: `uv export --format cyclonedx1.5` 的输出 JSON。
+        requirements_lock: 与 export 精确同源的 hash-locked requirements。
+        artifacts: 需要记录 SHA-256 的已构建 Release 文件。
+        image_digests: GHCR runtime/sandbox digest 文本文件。
+
+    Raises:
+        SbomBuildError: 任一字段类型、格式或范围不可信。
+    """
+
+    version: str
+    git_commit: str
+    source_date_epoch: int
+    python_components: Path
+    requirements_lock: Path
+    artifacts: tuple[Path, ...]
+    image_digests: tuple[Path, ...]
+
+    def __post_init__(self) -> None:
+        """执行不读取文件内容的严格结构校验。"""
+        if (
+            type(self.version) is not str
+            or _SEMVER.fullmatch(self.version) is None
+            or type(self.git_commit) is not str
+            or _COMMIT.fullmatch(self.git_commit) is None
+            or type(self.source_date_epoch) is not int
+            or isinstance(self.source_date_epoch, bool)
+            or not 0 < self.source_date_epoch < 4_102_444_800
+            or type(self.artifacts) is not tuple
+            or not self.artifacts
+            or type(self.image_digests) is not tuple
+            or not self.image_digests
+        ):
+            raise SbomBuildError("invalid sbom inputs")
+        paths = (
+            self.python_components,
+            self.requirements_lock,
+            *self.artifacts,
+            *self.image_digests,
+        )
+        for path in paths:
+            if not isinstance(path, Path) or not path.is_file() or path.is_symlink():
+                raise SbomBuildError("invalid sbom inputs")
+
+
+@dataclass(frozen=True, slots=True)
+class SbomDocuments:
+    """保存同一 Release 的两种 canonical SBOM 序列化。
+
+    Args:
+        cyclonedx: CycloneDX 1.5 JSON 字节。
+        spdx: SPDX 2.3 JSON 字节。
+    """
+
+    cyclonedx: bytes
+    spdx: bytes
+
+
+@dataclass(frozen=True, slots=True)
+class _Entry:
+    """描述一个进入两种 SBOM 的规范化组件记录。"""
+
+    category: str
+    name: str
+    version: str
+    license_id: str
+    purl: str | None
+    sha256: str | None
+
+
+def build_sbom(inputs: SbomInputs) -> SbomDocuments:
+    """把 locked Python、production Node、artifact 与镜像事实汇成两份 SBOM。
+
+    Args:
+        inputs: 已通过结构校验的本地 SBOM 输入。
+
+    Returns:
+        字节可复现的 CycloneDX 1.5 与 SPDX 2.3 文档。
+
+    Raises:
+        SbomBuildError: 依赖集合不一致、清单不可解析或组件重复。
+    """
+    if type(inputs) is not SbomInputs:
+        raise SbomBuildError("invalid sbom inputs")
+    entries: list[_Entry] = []
+    entries.extend(_python_entries(inputs.python_components, inputs.requirements_lock))
+    entries.extend(_node_entries(inputs.artifacts))
+    entries.extend(_node_runtime_entries(inputs.artifacts))
+    entries.extend(_file_entries(inputs.artifacts, inputs.version))
+    entries.extend(_image_entries(inputs.image_digests, inputs.version))
+    ordered = tuple(
+        sorted(
+            entries,
+            key=lambda entry: (
+                entry.category,
+                entry.name,
+                entry.version,
+                entry.purl or "",
+            ),
+        )
+    )
+    if not 0 < len(ordered) <= _MAX_COMPONENTS:
+        raise SbomBuildError("sbom component budget exceeded")
+    references = [_reference(entry) for entry in ordered]
+    if len(references) != len(set(references)):
+        raise SbomBuildError("duplicate sbom component")
+    timestamp = datetime.fromtimestamp(inputs.source_date_epoch, tz=UTC).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    return SbomDocuments(
+        cyclonedx=_canonical_json(_cyclonedx(inputs, ordered, references, timestamp)),
+        spdx=_canonical_json(_spdx(inputs, ordered, references, timestamp)),
+    )
+
+
+def locked_packages(path: Path) -> dict[str, str]:
+    """从 hash-locked requirements 读取精确的包名到版本映射。
+
+    Args:
+        path: `requirements-all.lock` 的路径。
+
+    Returns:
+        规范化小写包名到精确版本的映射。
+
+    Raises:
+        SbomBuildError: 文件不可读、条目非固定版本或出现重复包。
+    """
+    try:
+        text = Path(path).read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as error:
+        raise SbomBuildError("could not read locked requirements") from error
+    packages: dict[str, str] = {}
+    for line in text.replace("\\\n", " ").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith(("#", "--")):
+            continue
+        requirement = stripped.split(" ", 1)[0]
+        if requirement.count("==") != 1:
+            raise SbomBuildError("locked requirements entry is not pinned")
+        name, version = requirement.split("==", 1)
+        normalized = _normalize(name)
+        if (
+            _PACKAGE_NAME.fullmatch(normalized) is None
+            or _PACKAGE_VERSION.fullmatch(version) is None
+        ):
+            raise SbomBuildError("locked requirements entry is not pinned")
+        if normalized in packages:
+            raise SbomBuildError("duplicate locked requirements entry")
+        packages[normalized] = version
+    if not packages:
+        raise SbomBuildError("locked requirements are empty")
+    return packages
+
+
+def _python_entries(components: Path, lock: Path) -> tuple[_Entry, ...]:
+    """要求 uv export 与 lock 的包集合精确一致并生成 PyPI 组件。"""
+    locked = locked_packages(lock)
+    document = _read_json(components, "python components")
+    raw = document.get("components") if type(document) is dict else None
+    if type(raw) is not list or not raw:
+        raise SbomBuildError("invalid python components")
+    entries: dict[str, _Entry] = {}
+    for item in raw:
+        if type(item) is not dict:
+            raise SbomBuildError("invalid python components")
+        name = _normalize(str(item.get("name", "")))
+        version = str(item.get("version", ""))
+        if (
+            _PACKAGE_NAME.fullmatch(name) is None
+            or _PACKAGE_VERSION.fullmatch(version) is None
+        ):
+            raise SbomBuildError("invalid python components")
+        if name in entries:
+            raise SbomBuildError("duplicate python component")
+        entries[name] = _Entry(
+            category="library",
+            name=name,
+            version=version,
+            license_id=_license_of(item.get("licenses")),
+            purl=f"pkg:pypi/{name}@{version}",
+            sha256=None,
+        )
+    if {name: entry.version for name, entry in entries.items()} != locked:
+        raise SbomBuildError("python package set mismatch")
+    return tuple(entries[name] for name in sorted(entries))
+
+
+def _node_entries(artifacts: tuple[Path, ...]) -> tuple[_Entry, ...]:
+    """从四个 TUI bundle 的同一 production license 清单生成 npm 组件。"""
+    bundles = tuple(path for path in artifacts if path.name.startswith("lobster0-tui-"))
+    if not bundles:
+        raise SbomBuildError("missing tui bundle for the license inventory")
+    inventories = {
+        _read_tar_member(path, "tui/licenses.json") for path in sorted(bundles)
+    }
+    if len(inventories) != 1:
+        raise SbomBuildError("tui license inventory mismatch")
+    try:
+        document = json.loads(inventories.pop().decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise SbomBuildError("invalid license inventory") from error
+    if type(document) is not dict or not document:
+        raise SbomBuildError("invalid license inventory")
+    entries: dict[str, _Entry] = {}
+    for license_id in sorted(document):
+        group = document[license_id]
+        if type(group) is not list or _LICENSE_ID.fullmatch(str(license_id)) is None:
+            raise SbomBuildError("invalid license inventory")
+        for item in group:
+            if type(item) is not dict:
+                raise SbomBuildError("invalid license inventory")
+            name = str(item.get("name", ""))
+            versions = item.get("versions", [item.get("version", "")])
+            if type(versions) is not list or not versions:
+                raise SbomBuildError("invalid license inventory")
+            for version in versions:
+                entry = _npm_entry(name, str(version), str(license_id))
+                if entry.name in entries:
+                    raise SbomBuildError("duplicate node package")
+                entries[entry.name] = entry
+    if not entries:
+        raise SbomBuildError("invalid license inventory")
+    return tuple(entries[name] for name in sorted(entries))
+
+
+def _npm_entry(name: str, version: str, license_id: str) -> _Entry:
+    """构造一个已校验的 npm production 组件记录。"""
+    if (
+        _PACKAGE_NAME.fullmatch(name) is None
+        or _PACKAGE_VERSION.fullmatch(version) is None
+    ):
+        raise SbomBuildError("invalid license inventory")
+    return _Entry(
+        category="library",
+        name=name,
+        version=version,
+        license_id=license_id,
+        purl=f"pkg:npm/{name}@{version}",
+        sha256=None,
+    )
+
+
+def _node_runtime_entries(artifacts: tuple[Path, ...]) -> tuple[_Entry, ...]:
+    """从每个 Node bundle 的 release-component.json 生成 runtime 组件。"""
+    bundles = tuple(path for path in artifacts if path.name.startswith("lobster0-node-"))
+    if not bundles:
+        raise SbomBuildError("missing node bundle for the runtime component")
+    entries: list[_Entry] = []
+    versions: set[str] = set()
+    for path in sorted(bundles):
+        try:
+            component = json.loads(
+                _read_tar_member(path, "node/release-component.json").decode("utf-8")
+            )
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise SbomBuildError("invalid node component") from error
+        if type(component) is not dict:
+            raise SbomBuildError("invalid node component")
+        version = str(component.get("version", ""))
+        platform = str(component.get("platform", ""))
+        upstream = str(component.get("upstream_sha256", ""))
+        if (
+            _SEMVER.fullmatch(version) is None
+            or _PACKAGE_VERSION.fullmatch(platform) is None
+            or _SHA256.fullmatch(upstream) is None
+        ):
+            raise SbomBuildError("invalid node component")
+        versions.add(version)
+        entries.append(
+            _Entry(
+                category="library",
+                name=f"node ({platform})",
+                version=version,
+                license_id=_PROJECT_LICENSE,
+                purl=f"pkg:generic/node@{version}?platform={platform}",
+                sha256=upstream,
+            )
+        )
+    if len(versions) != 1:
+        raise SbomBuildError("node runtime version mismatch")
+    return tuple(entries)
+
+
+def _file_entries(artifacts: tuple[Path, ...], version: str) -> tuple[_Entry, ...]:
+    """为每个已构建 Release 文件生成带 SHA-256 的 file 组件。"""
+    entries: dict[str, _Entry] = {}
+    for path in sorted(artifacts):
+        if path.name in entries:
+            raise SbomBuildError("duplicate release artifact filename")
+        entries[path.name] = _Entry(
+            category="file",
+            name=path.name,
+            version=version,
+            license_id=_PROJECT_LICENSE,
+            purl=None,
+            sha256=_sha256(path),
+        )
+    return tuple(entries[name] for name in sorted(entries))
+
+
+def _image_entries(image_digests: tuple[Path, ...], version: str) -> tuple[_Entry, ...]:
+    """把每个 GHCR digest 文件解析成 immutable container 组件。"""
+    entries: list[_Entry] = []
+    for path in sorted(image_digests):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as error:
+            raise SbomBuildError("could not read image digest") from error
+        matched = _IMAGE_DIGEST.fullmatch(text.strip())
+        if matched is None or text.strip().count("\n") != 0:
+            raise SbomBuildError("invalid image digest")
+        repository, digest = matched.group(1), matched.group(2)
+        entries.append(
+            _Entry(
+                category="container",
+                name=repository,
+                version=version,
+                license_id=_PROJECT_LICENSE,
+                purl=f"pkg:oci/{repository.rsplit('/', 1)[-1]}@sha256:{digest}",
+                sha256=digest,
+            )
+        )
+    return tuple(entries)
+
+
+def _cyclonedx(
+    inputs: SbomInputs,
+    entries: tuple[_Entry, ...],
+    references: list[str],
+    timestamp: str,
+) -> dict[str, object]:
+    """渲染 CycloneDX 1.5 文档，含 metadata、组件与依赖关系。"""
+    root = f"pkg:github/NEDONION/lobster0@v{inputs.version}"
+    components = []
+    for entry, reference in zip(entries, references, strict=True):
+        component: dict[str, object] = {
+            "bom-ref": reference,
+            "type": entry.category,
+            "name": entry.name,
+            "version": entry.version,
+            "licenses": [{"license": {"name": entry.license_id}}],
+        }
+        if entry.purl is not None:
+            component["purl"] = entry.purl
+        if entry.sha256 is not None:
+            component["hashes"] = [{"alg": "SHA-256", "content": entry.sha256}]
+        components.append(component)
+    return {
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.5",
+        "version": 1,
+        "metadata": {
+            "timestamp": timestamp,
+            "tools": [{"name": _TOOL, "version": inputs.version}],
+            "component": {
+                "bom-ref": root,
+                "type": "application",
+                "name": "lobster0",
+                "version": inputs.version,
+                "purl": root,
+                "licenses": [{"license": {"name": _PROJECT_LICENSE}}],
+                "externalReferences": [{"type": "vcs", "url": _REPOSITORY}],
+            },
+            "properties": [{"name": "lobster0:git_commit", "value": inputs.git_commit}],
+        },
+        "components": components,
+        "dependencies": [
+            {"ref": root, "dependsOn": sorted(references)},
+            *({"ref": reference, "dependsOn": []} for reference in sorted(references)),
+        ],
+    }
+
+
+def _spdx(
+    inputs: SbomInputs,
+    entries: tuple[_Entry, ...],
+    references: list[str],
+    timestamp: str,
+) -> dict[str, object]:
+    """渲染 SPDX 2.3 文档，含 DESCRIBES 与 CONTAINS 关系。"""
+    root_purl = f"pkg:github/NEDONION/lobster0@v{inputs.version}"
+    root_id = f"SPDXRef-lobster0-{inputs.version}".replace(".", "-")
+    packages: list[dict[str, object]] = [
+        {
+            "SPDXID": root_id,
+            "name": "lobster0",
+            "versionInfo": inputs.version,
+            "downloadLocation": f"{_REPOSITORY}/releases/tag/v{inputs.version}",
+            "filesAnalyzed": False,
+            "licenseConcluded": _PROJECT_LICENSE,
+            "licenseDeclared": _PROJECT_LICENSE,
+            "copyrightText": "NOASSERTION",
+            "externalRefs": [
+                {
+                    "referenceCategory": "PACKAGE-MANAGER",
+                    "referenceType": "purl",
+                    "referenceLocator": root_purl,
+                }
+            ],
+        }
+    ]
+    identifiers = {root_id}
+    for entry, reference in zip(entries, references, strict=True):
+        identifier = f"SPDXRef-{_SPDX_ID.sub('-', reference)}"
+        if identifier in identifiers:
+            raise SbomBuildError("duplicate spdx identifier")
+        identifiers.add(identifier)
+        package: dict[str, object] = {
+            "SPDXID": identifier,
+            "name": entry.name,
+            "versionInfo": entry.version,
+            "downloadLocation": "NOASSERTION",
+            "filesAnalyzed": False,
+            "licenseConcluded": entry.license_id,
+            "licenseDeclared": entry.license_id,
+            "copyrightText": "NOASSERTION",
+        }
+        if entry.sha256 is not None:
+            package["checksums"] = [
+                {"algorithm": "SHA256", "checksumValue": entry.sha256}
+            ]
+        if entry.purl is not None:
+            package["externalRefs"] = [
+                {
+                    "referenceCategory": "PACKAGE-MANAGER",
+                    "referenceType": "purl",
+                    "referenceLocator": entry.purl,
+                }
+            ]
+        packages.append(package)
+    relationships = [
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
+            "relationshipType": "DESCRIBES",
+            "relatedSpdxElement": root_id,
+        }
+    ]
+    relationships.extend(
+        {
+            "spdxElementId": root_id,
+            "relationshipType": "CONTAINS",
+            "relatedSpdxElement": str(package["SPDXID"]),
+        }
+        for package in packages[1:]
+    )
+    return {
+        "spdxVersion": "SPDX-2.3",
+        "dataLicense": "CC0-1.0",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "name": f"lobster0-{inputs.version}",
+        "documentNamespace": (
+            f"{_REPOSITORY}/releases/download/v{inputs.version}/"
+            f"lobster0-{inputs.version}-sbom.spdx.json"
+        ),
+        "creationInfo": {
+            "created": timestamp,
+            "creators": [f"Tool: {_TOOL}", "Organization: Lobster0 contributors"],
+            "comment": f"git_commit={inputs.git_commit}",
+        },
+        "packages": packages,
+        "relationships": relationships,
+    }
+
+
+def _reference(entry: _Entry) -> str:
+    """返回一个组件在两种 SBOM 中共用的稳定引用。"""
+    return entry.purl if entry.purl is not None else f"file/{entry.name}"
+
+
+def _license_of(value: object) -> str:
+    """从 CycloneDX licenses 结构提取单一稳定 license 标识。"""
+    if type(value) is not list or not value:
+        return "NOASSERTION"
+    first = value[0]
+    if type(first) is not dict:
+        return "NOASSERTION"
+    expression = first.get("expression")
+    if type(expression) is str and _LICENSE_ID.fullmatch(expression) is not None:
+        return expression
+    license_object = first.get("license")
+    if type(license_object) is dict:
+        for key in ("id", "name"):
+            candidate = license_object.get(key)
+            if type(candidate) is str and _LICENSE_ID.fullmatch(candidate) is not None:
+                return candidate
+    return "NOASSERTION"
+
+
+def _normalize(name: str) -> str:
+    """按 PyPA 规则把分发名规范化为可比较形式。"""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _read_json(path: Path, label: str) -> object:
+    """读取一个有字节上限的 UTF-8 JSON 文档。"""
+    try:
+        data = Path(path).read_bytes()
+    except OSError as error:
+        raise SbomBuildError(f"could not read {label}") from error
+    if not data or len(data) > _DOCUMENT_LIMIT:
+        raise SbomBuildError(f"invalid {label}")
+    try:
+        return json.loads(data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise SbomBuildError(f"invalid {label}") from error
+
+
+def _read_tar_member(path: Path, name: str) -> bytes:
+    """从 tar.gz bundle 中读取一个有上限的 regular member。"""
+    try:
+        with tarfile.open(path, "r:gz") as archive:
+            member = archive.getmember(name)
+            if not member.isreg() or not 0 < member.size <= _MEMBER_LIMIT:
+                raise SbomBuildError("invalid bundle member")
+            source = archive.extractfile(member)
+            if source is None:
+                raise SbomBuildError("invalid bundle member")
+            with source:
+                return source.read(_MEMBER_LIMIT + 1)
+    except SbomBuildError:
+        raise
+    except (OSError, EOFError, KeyError, tarfile.TarError) as error:
+        raise SbomBuildError("invalid bundle member") from error
+
+
+def _sha256(path: Path) -> str:
+    """流式计算一个 regular file 的 SHA-256。"""
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as source:
+            for chunk in iter(lambda: source.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError as error:
+        raise SbomBuildError("could not read release artifact") from error
+    return digest.hexdigest()
+
+
+def _canonical_json(document: object) -> bytes:
+    """编码带结尾换行、键序稳定的 canonical UTF-8 JSON。"""
+    encoded = json.dumps(document, ensure_ascii=False, indent=2, sort_keys=True)
+    return f"{encoded}\n".encode()
+
+
+def main(argv: list[str] | None = None) -> int:
+    """解析 CLI 参数并写出两种格式的 Release SBOM。"""
+    parser = argparse.ArgumentParser(description="Build the Lobster0 release SBOM documents")
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--git-commit", required=True)
+    parser.add_argument("--source-date-epoch", type=int, required=True)
+    parser.add_argument("--python-components", type=Path, required=True)
+    parser.add_argument("--requirements-lock", type=Path, required=True)
+    parser.add_argument("--artifact", type=Path, action="append", required=True)
+    parser.add_argument("--image-digest", type=Path, action="append", required=True)
+    parser.add_argument("--cyclonedx-output", type=Path, required=True)
+    parser.add_argument("--spdx-output", type=Path, required=True)
+    arguments = parser.parse_args(argv)
+    try:
+        documents = build_sbom(
+            SbomInputs(
+                version=arguments.version,
+                git_commit=arguments.git_commit,
+                source_date_epoch=arguments.source_date_epoch,
+                python_components=arguments.python_components,
+                requirements_lock=arguments.requirements_lock,
+                artifacts=tuple(sorted(arguments.artifact)),
+                image_digests=tuple(sorted(arguments.image_digest)),
+            )
+        )
+    except SbomBuildError as error:
+        parser.error(str(error))
+        return 2
+    for output, payload in (
+        (arguments.cyclonedx_output, documents.cyclonedx),
+        (arguments.spdx_output, documents.spdx),
+    ):
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_bytes(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_release_artifacts.py
+++ b/scripts/verify_release_artifacts.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""独立复核候选 Release 的 manifest schema、artifact hash、checksums 与 SBOM。"""
+
+import argparse
+import hashlib
+import json
+import re
+from pathlib import Path
+
+_SHA256_LINE = re.compile(r"^([0-9a-f]{64})  ([A-Za-z0-9][A-Za-z0-9._+-]{0,199})$")
+_MANIFEST_FILENAME = "release-manifest.json"
+_INSTALL_SCRIPT_FILENAME = "install.sh"
+_MAX_DOCUMENT_BYTES = 8 * 1024 * 1024
+_MAX_ARTIFACT_BYTES = 1_073_741_824
+
+
+class ReleaseVerifyError(RuntimeError):
+    """表示候选 Release 未通过独立复核。"""
+
+
+def verify_release(
+    *,
+    manifest: Path,
+    schema: Path,
+    artifact_directory: Path,
+    checksums: Path,
+    install_script: Path,
+) -> tuple[str, ...]:
+    """完全从磁盘重新加载并复核一个候选 Release 的全部事实。
+
+    Args:
+        manifest: 待复核的 `release-manifest.json`。
+        schema: 权威的 `release/manifest.schema.json`。
+        artifact_directory: 只包含 manifest 所列 artifact 的目录。
+        checksums: 覆盖 manifest、bootstrap 与全部 artifact 的 `SHA256SUMS`。
+        install_script: 已渲染的 bootstrap 信任根文件。
+
+    Returns:
+        按固定顺序描述已复核事实的报告行。
+
+    Raises:
+        ReleaseVerifyError: schema、hash、size、覆盖范围或 SBOM 主体不一致。
+    """
+    manifest_bytes = _read_bytes(manifest, "manifest")
+    document = _load_json(manifest_bytes, "manifest")
+    schema_document = _load_json(_read_bytes(schema, "schema"), "schema")
+    if type(document) is not dict or type(schema_document) is not dict:
+        raise ReleaseVerifyError("manifest schema violation at $")
+    _validate(document, schema_document, schema_document, "$")
+    directory = Path(artifact_directory)
+    if not directory.is_dir() or directory.is_symlink():
+        raise ReleaseVerifyError("artifact directory must be a regular directory")
+    artifacts = document["artifacts"]
+    version = document["version"]
+    listed = [str(entry["filename"]) for entry in artifacts]
+    on_disk = sorted(path.name for path in directory.iterdir())
+    if sorted(listed) != on_disk:
+        raise ReleaseVerifyError("artifact directory does not match the manifest")
+    digests: dict[str, str] = {}
+    for entry in artifacts:
+        filename = str(entry["filename"])
+        path = directory / filename
+        if not path.is_file() or path.is_symlink():
+            raise ReleaseVerifyError(f"artifact is not a regular file: {filename}")
+        size = path.stat().st_size
+        digest = _sha256(path)
+        digests[filename] = digest
+        if digest != entry["sha256"]:
+            raise ReleaseVerifyError(f"artifact hash mismatch: {filename}")
+        if size != entry["size"] or not 1 <= size <= _MAX_ARTIFACT_BYTES:
+            raise ReleaseVerifyError(f"artifact size mismatch: {filename}")
+        if not str(entry["url"]).endswith(f"/v{version}/{filename}"):
+            raise ReleaseVerifyError(f"artifact url mismatch: {filename}")
+    _verify_sbom(directory, digests, version)
+    covered = _verify_checksums(
+        checksums, manifest_bytes, install_script, directory, digests
+    )
+    return (
+        f"manifest {version} verified",
+        f"artifacts {len(artifacts)} verified",
+        f"checksums {covered} verified",
+    )
+
+
+def _verify_sbom(directory: Path, digests: dict[str, str], version: str) -> None:
+    """要求两份 SBOM 的主体与 wheel hash 与 manifest 完全一致。"""
+    wheel = f"lobster0_agent-{version}-py3-none-any.whl"
+    if wheel not in digests:
+        raise ReleaseVerifyError("manifest is missing the universal wheel")
+    cyclonedx = _load_json(
+        _read_bytes(directory / f"lobster0-{version}-sbom.cyclonedx.json", "sbom"), "sbom"
+    )
+    spdx = _load_json(
+        _read_bytes(directory / f"lobster0-{version}-sbom.spdx.json", "sbom"), "sbom"
+    )
+    if type(cyclonedx) is not dict or type(spdx) is not dict:
+        raise ReleaseVerifyError("sbom subject mismatch")
+    metadata = cyclonedx.get("metadata")
+    component = metadata.get("component") if type(metadata) is dict else None
+    if (
+        cyclonedx.get("specVersion") != "1.5"
+        or type(component) is not dict
+        or component.get("version") != version
+        or spdx.get("spdxVersion") != "SPDX-2.3"
+        or spdx.get("name") != f"lobster0-{version}"
+    ):
+        raise ReleaseVerifyError("sbom subject mismatch")
+    if _lookup(cyclonedx.get("components"), wheel, "hashes", "content") != digests[wheel]:
+        raise ReleaseVerifyError("sbom subject mismatch")
+    if _lookup(spdx.get("packages"), wheel, "checksums", "checksumValue") != digests[wheel]:
+        raise ReleaseVerifyError("sbom subject mismatch")
+
+
+def _verify_checksums(
+    checksums: Path,
+    manifest_bytes: bytes,
+    install_script: Path,
+    directory: Path,
+    digests: dict[str, str],
+) -> int:
+    """重新计算信任根 hash 并要求 checksums 精确覆盖且排序。"""
+    text = _read_bytes(checksums, "checksums").decode("utf-8", errors="strict")
+    lines = text.splitlines()
+    if not text.endswith("\n") or not lines:
+        raise ReleaseVerifyError("checksums file is not canonical")
+    recorded: dict[str, str] = {}
+    names: list[str] = []
+    for line in lines:
+        matched = _SHA256_LINE.fullmatch(line)
+        if matched is None:
+            raise ReleaseVerifyError("checksums file is not canonical")
+        if matched.group(2) in recorded:
+            raise ReleaseVerifyError("checksums file has a duplicate entry")
+        recorded[matched.group(2)] = matched.group(1)
+        names.append(matched.group(2))
+    if names != sorted(names, key=lambda name: name.encode("utf-8")):
+        raise ReleaseVerifyError("checksums file is not sorted")
+    expected = dict(digests)
+    expected[_MANIFEST_FILENAME] = hashlib.sha256(manifest_bytes).hexdigest()
+    script = Path(install_script)
+    if script.name != _INSTALL_SCRIPT_FILENAME or not script.is_file() or script.is_symlink():
+        raise ReleaseVerifyError("install script is missing")
+    expected[_INSTALL_SCRIPT_FILENAME] = _sha256(script)
+    if recorded != expected:
+        raise ReleaseVerifyError("checksums do not match the release files")
+    if not directory.is_dir():
+        raise ReleaseVerifyError("artifact directory must be a regular directory")
+    return len(recorded)
+
+
+def _lookup(entries: object, name: str, container: str, key: str) -> str:
+    """在 SBOM 列表里取出唯一匹配记录的第一个 hash 值。"""
+    if type(entries) is not list:
+        raise ReleaseVerifyError("sbom subject mismatch")
+    matches = [item for item in entries if type(item) is dict and item.get("name") == name]
+    if len(matches) != 1:
+        raise ReleaseVerifyError("sbom subject mismatch")
+    values = matches[0].get(container)
+    if type(values) is not list or not values or type(values[0]) is not dict:
+        raise ReleaseVerifyError("sbom subject mismatch")
+    value = values[0].get(key)
+    if type(value) is not str:
+        raise ReleaseVerifyError("sbom subject mismatch")
+    return value
+
+
+def _validate(value: object, schema: object, root: dict[str, object], location: str) -> None:
+    """按 manifest schema 使用的 JSON Schema 子集递归校验一个文档。"""
+    if type(schema) is not dict:
+        raise ReleaseVerifyError(f"manifest schema violation at {location}")
+    reference = schema.get("$ref")
+    if type(reference) is str:
+        _validate(value, _resolve(reference, root, location), root, location)
+        return
+    for keyword, expected in schema.items():
+        _check(keyword, expected, value, schema, root, location)
+
+
+def _check(
+    keyword: str,
+    expected: object,
+    value: object,
+    schema: dict[str, object],
+    root: dict[str, object],
+    location: str,
+) -> None:
+    """校验单个 JSON Schema 关键字对当前实例的约束。"""
+    if keyword in {"$schema", "$id", "title", "description", "$defs"}:
+        return
+    if keyword == "type" and not _is_type(value, expected):
+        _fail(location)
+    elif keyword == "const" and value != expected:
+        _fail(location)
+    elif keyword == "enum" and (type(expected) is not list or value not in expected):
+        _fail(location)
+    elif keyword == "pattern":
+        if type(value) is not str or re.compile(str(expected)).search(value) is None:
+            _fail(location)
+    elif keyword == "required" and type(value) is dict:
+        if any(name not in value for name in expected):  # type: ignore[union-attr]
+            _fail(location)
+    elif keyword == "additionalProperties" and expected is False and type(value) is dict:
+        allowed = set(schema.get("properties", {}))  # type: ignore[arg-type]
+        if set(value) - allowed:
+            _fail(location)
+    elif keyword == "properties" and type(value) is dict:
+        for name, subschema in expected.items():  # type: ignore[union-attr]
+            if name in value:
+                _validate(value[name], subschema, root, f"{location}.{name}")
+    elif keyword == "items" and type(value) is list:
+        for index, item in enumerate(value):
+            _validate(item, expected, root, f"{location}[{index}]")
+    elif keyword == "minItems" and type(value) is list and len(value) < int(str(expected)):
+        _fail(location)
+    elif keyword == "maxItems" and type(value) is list and len(value) > int(str(expected)):
+        _fail(location)
+    elif keyword == "uniqueItems" and expected is True and type(value) is list:
+        encoded = [json.dumps(item, sort_keys=True) for item in value]
+        if len(encoded) != len(set(encoded)):
+            _fail(location)
+    elif keyword == "minimum" and type(value) is int and value < int(str(expected)):
+        _fail(location)
+    elif keyword == "maximum" and type(value) is int and value > int(str(expected)):
+        _fail(location)
+    elif keyword == "allOf":
+        for index, subschema in enumerate(expected):  # type: ignore[union-attr]
+            _validate(value, subschema, root, f"{location}/allOf[{index}]")
+    elif keyword == "anyOf":
+        if not any(_matches(value, subschema, root) for subschema in expected):  # type: ignore[union-attr]
+            _fail(location)
+    elif keyword == "oneOf":
+        matched = sum(
+            1 for subschema in expected if _matches(value, subschema, root)  # type: ignore[union-attr]
+        )
+        if matched != 1:
+            _fail(location)
+    elif keyword == "not" and _matches(value, expected, root):
+        _fail(location)
+    elif keyword == "contains" and type(value) is list:
+        if not any(_matches(item, expected, root) for item in value):
+            _fail(location)
+    elif keyword == "if":
+        branch = "then" if _matches(value, expected, root) else "else"
+        if branch in schema:
+            _validate(value, schema[branch], root, f"{location}/{branch}")
+    elif keyword in {"then", "else"} and "if" not in schema:
+        _fail(location)
+
+
+def _matches(value: object, schema: object, root: dict[str, object]) -> bool:
+    """在不抛出的前提下判断实例是否满足一个子 schema。"""
+    try:
+        _validate(value, schema, root, "$")
+    except ReleaseVerifyError:
+        return False
+    return True
+
+
+def _resolve(reference: str, root: dict[str, object], location: str) -> object:
+    """解析 manifest schema 内部使用的本地 `#/` 引用。"""
+    if not reference.startswith("#/"):
+        _fail(location)
+    node: object = root
+    for part in reference[2:].split("/"):
+        if type(node) is not dict or part not in node:
+            _fail(location)
+        node = node[part]  # type: ignore[index]
+    return node
+
+
+def _is_type(value: object, expected: object) -> bool:
+    """按 JSON Schema 语义判断实例类型，整数与布尔严格区分。"""
+    names = expected if type(expected) is list else [expected]
+    for name in names:
+        if name == "object" and type(value) is dict:
+            return True
+        if name == "array" and type(value) is list:
+            return True
+        if name == "string" and type(value) is str:
+            return True
+        if name == "integer" and type(value) is int:
+            return True
+        if name == "number" and type(value) in {int, float}:
+            return True
+        if name == "boolean" and type(value) is bool:
+            return True
+        if name == "null" and value is None:
+            return True
+    return False
+
+
+def _fail(location: str) -> None:
+    """以统一消息报告一次 schema 违规。"""
+    raise ReleaseVerifyError(f"manifest schema violation at {location}")
+
+
+def _read_bytes(path: Path, label: str) -> bytes:
+    """读取一个有字节上限的常规文件。"""
+    candidate = Path(path)
+    if not candidate.is_file() or candidate.is_symlink():
+        raise ReleaseVerifyError(f"{label} must be a regular file")
+    data = candidate.read_bytes()
+    if not data or len(data) > _MAX_DOCUMENT_BYTES:
+        raise ReleaseVerifyError(f"{label} size is out of range")
+    return data
+
+
+def _load_json(data: bytes, label: str) -> object:
+    """把字节解析为 UTF-8 JSON 文档。"""
+    try:
+        return json.loads(data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ReleaseVerifyError(f"{label} is not valid JSON") from error
+
+
+def _sha256(path: Path) -> str:
+    """流式计算一个 regular file 的 SHA-256。"""
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def main(argv: list[str] | None = None) -> int:
+    """解析 CLI 参数并独立复核一个候选 Release。"""
+    parser = argparse.ArgumentParser(description="Verify a candidate Lobster0 release")
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--schema", type=Path, default=Path("release/manifest.schema.json"))
+    parser.add_argument("--artifact-dir", type=Path, required=True)
+    parser.add_argument("--checksums", type=Path, required=True)
+    parser.add_argument("--install-script", type=Path, required=True)
+    arguments = parser.parse_args(argv)
+    try:
+        report = verify_release(
+            manifest=arguments.manifest,
+            schema=arguments.schema,
+            artifact_directory=arguments.artifact_dir,
+            checksums=arguments.checksums,
+            install_script=arguments.install_script,
+        )
+    except ReleaseVerifyError as error:
+        parser.error(str(error))
+        return 2
+    for line in report:
+        print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/lobster0/install/models.py
+++ b/src/lobster0/install/models.py
@@ -10,7 +10,7 @@ from urllib.parse import urlsplit
 _MAX_MANIFEST_BYTES = 1_048_576
 _MAX_ARTIFACT_BYTES = 1_073_741_824
 _MAX_ARTIFACTS = 128
-_DATABASE_SCHEMA_VERSION = 5
+_DATABASE_SCHEMA_VERSION = 7
 _SEMVER = re.compile(
     r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)"
     r"(?:-((?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)"

--- a/tests/install/manifest_v1.json
+++ b/tests/install/manifest_v1.json
@@ -59,6 +59,6 @@
     {"os": "macos", "arch": "arm64"}
   ],
   "features": ["agent", "tools", "memory", "skills", "tui", "feishu", "telegram", "discord", "gateway", "automation", "sandbox", "checkpoint"],
-  "database_schema": 5,
+  "database_schema": 7,
   "minimum_readable_schema": 5
 }

--- a/tests/test_install_models.py
+++ b/tests/test_install_models.py
@@ -18,6 +18,7 @@ from lobster0.install.models import (
     PlatformKey,
     ReleaseManifest,
 )
+from lobster0.storage.migrations import LATEST_SCHEMA_VERSION
 
 
 class InstallModelsTest(unittest.TestCase):
@@ -104,7 +105,7 @@ class InstallModelsTest(unittest.TestCase):
         manifest = ReleaseManifest.from_bytes(self.fixture.read_bytes())
 
         self.assertEqual(manifest.version, "0.7.0")
-        self.assertEqual(manifest.database_schema, 5)
+        self.assertEqual(manifest.database_schema, LATEST_SCHEMA_VERSION)
         selected = manifest.require_artifact("tui", PlatformKey("linux", "x86_64"))
         self.assertEqual(selected.component_version, "0.7.0")
         with self.assertRaises(dataclasses.FrozenInstanceError):
@@ -388,7 +389,9 @@ class InstallModelsTest(unittest.TestCase):
 
         with self.assertRaisesRegex(InstallError, "manifest_invalid"):
             ReleaseManifest.from_bytes(
-                self.manifest_bytes({"minimum_readable_schema": 6})
+                self.manifest_bytes(
+                    {"minimum_readable_schema": LATEST_SCHEMA_VERSION + 1}
+                )
             )
 
     def test_manifest_enforces_byte_and_artifact_budgets(self) -> None:
@@ -598,7 +601,9 @@ class InstallModelsTest(unittest.TestCase):
 
         self.assertEqual(schema["additionalProperties"], False)
         self.assertEqual(schema["properties"]["schema_version"]["const"], 1)
-        self.assertEqual(schema["properties"]["database_schema"]["const"], 5)
+        self.assertEqual(
+            schema["properties"]["database_schema"]["const"], LATEST_SCHEMA_VERSION
+        )
         self.assertEqual(schema["properties"]["artifacts"]["maxItems"], 128)
         self.assertEqual(schema["properties"]["node"]["properties"]["default"]["const"], "24.18.0")
         self.assertEqual(

--- a/tests/test_install_platforms.py
+++ b/tests/test_install_platforms.py
@@ -175,7 +175,7 @@ class InstallPlatformsTest(unittest.TestCase):
                 {"os": "macos", "arch": "arm64"},
             ],
             "features": [],
-            "database_schema": 5,
+            "database_schema": 7,
             "minimum_readable_schema": 5,
         }
         return ReleaseManifest.from_bytes(json.dumps(document).encode("utf-8"))

--- a/tests/test_install_runtime.py
+++ b/tests/test_install_runtime.py
@@ -404,7 +404,7 @@ class InstallRuntimeTests(unittest.TestCase):
                 PlatformKey("macos", "arm64"),
             ),
             features=("agent", "tools", "tui", "feishu", "telegram", "discord"),
-            database_schema=5,
+            database_schema=7,
             minimum_readable_schema=5,
         )
 

--- a/tests/test_release_manifest_build.py
+++ b/tests/test_release_manifest_build.py
@@ -1,0 +1,726 @@
+"""Release manifest、SBOM、checksums 的封闭世界与可复现构建测试。"""
+
+import hashlib
+import io
+import json
+import os
+import subprocess
+import tarfile
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+from lobster0.install.models import ReleaseManifest
+from scripts.build_release_manifest import (
+    ReleaseBuildError,
+    ReleaseInputs,
+    build_checksums,
+    build_manifest,
+    build_release_inputs_document,
+    build_release_outputs,
+    collect_release_inputs,
+    load_features,
+)
+from scripts.build_sbom import SbomBuildError, SbomInputs, build_sbom
+from scripts.render_install_script import ReleaseInputs as BootstrapReleaseInputs
+from scripts.verify_release_artifacts import ReleaseVerifyError, verify_release
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNTIME_VERSIONS = ROOT / "release/runtime-versions.json"
+FEATURES_REGISTRY = ROOT / "release/features.json"
+SCHEMA = ROOT / "release/manifest.schema.json"
+VERSION = "0.7.0"
+COMMIT = "1a2b3c4d" * 5
+EPOCH = 1_754_784_000
+PLATFORMS = ("linux-x86_64", "linux-arm64", "macos-x86_64", "macos-arm64")
+RUNTIME_DIGEST = "a" * 64
+SANDBOX_DIGEST = "b" * 64
+LICENSES = {
+    "MIT": [{"name": "@earendil-works/pi-tui", "versions": ["0.4.0"], "license": "MIT"}],
+    "ISC": [{"name": "yallist", "versions": ["4.0.0"], "license": "ISC"}],
+}
+PYTHON_PACKAGES = (
+    ("croniter", "6.2.0", "MIT"),
+    ("httpx", "0.28.1", "BSD-3-Clause"),
+)
+
+
+def _node_pins() -> tuple[str, dict[str, dict[str, str]]]:
+    """读取仓库真实 Node pin，使 fixture bundle 与生产 pin 精确一致。"""
+    document = json.loads(RUNTIME_VERSIONS.read_text(encoding="utf-8"))
+    return document["node"]["version"], document["node"]["archives"]
+
+
+def _write_tar(path: Path, members: dict[str, bytes], *, link: str | None = None) -> None:
+    """写入只含 regular file 的最小 tar.gz fixture，可选注入一个 symlink。"""
+    with tarfile.open(path, "w:gz") as archive:
+        for name in sorted(members):
+            payload = members[name]
+            member = tarfile.TarInfo(name)
+            member.size = len(payload)
+            member.mode = 0o644
+            archive.addfile(member, io.BytesIO(payload))
+        if link is not None:
+            member = tarfile.TarInfo(link)
+            member.type = tarfile.SYMTYPE
+            member.linkname = "../outside"
+            archive.addfile(member)
+
+
+def _write_wheel(path: Path, *, name: str = "lobster0-agent", version: str = VERSION) -> None:
+    """写入带 dist-info metadata 与 console script 的最小 wheel fixture。"""
+    dist_info = f"lobster0_agent-{version}.dist-info"
+    entries = {
+        "lobster0/__init__.py": b"",
+        f"{dist_info}/METADATA": (
+            f"Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n"
+        ).encode(),
+        f"{dist_info}/WHEEL": b"Wheel-Version: 1.0\nRoot-Is-Purelib: true\n",
+        f"{dist_info}/entry_points.txt": b"[console_scripts]\nlobster0 = lobster0.cli:main\n",
+        f"{dist_info}/RECORD": (
+            f"lobster0/__init__.py,,\n{dist_info}/METADATA,,\n{dist_info}/RECORD,,\n"
+        ).encode(),
+    }
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for entry in sorted(entries):
+            info = zipfile.ZipInfo(entry, (1980, 1, 1, 0, 0, 0))
+            info.external_attr = 0o100644 << 16
+            archive.writestr(info, entries[entry])
+
+
+class ReleaseFixture:
+    """在临时目录里物化一整套 Tier 1 Release artifact。"""
+
+    def __init__(self, root: Path) -> None:
+        """写入 14 个基础 artifact，再用真实 SBOM builder 补齐两份 SBOM。"""
+        self.root = root
+        self.artifacts = root / "artifacts"
+        self.artifacts.mkdir(parents=True)
+        self.node_version, self.node_archives = _node_pins()
+        self.install_script = root / "install.sh"
+        self.install_script.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        self.python_components = root / "uv-cyclonedx.json"
+        self.python_components.write_bytes(self._python_components())
+        _write_wheel(self.artifacts / f"lobster0_agent-{VERSION}-py3-none-any.whl")
+        _write_tar(
+            self.artifacts / f"lobster0_agent-{VERSION}.tar.gz",
+            {
+                f"lobster0_agent-{VERSION}/PKG-INFO": (
+                    f"Metadata-Version: 2.1\nName: lobster0-agent\nVersion: {VERSION}\n"
+                ).encode(),
+                f"lobster0_agent-{VERSION}/pyproject.toml": b"[project]\n",
+            },
+        )
+        (self.artifacts / "requirements-all.lock").write_bytes(self._requirements())
+        (self.artifacts / "lobster0-installer.pyz").write_bytes(self._installer())
+        for platform in PLATFORMS:
+            self.write_node_bundle(platform, self.node_archives[platform]["sha256"])
+            self.write_tui_bundle(platform)
+        (self.artifacts / f"lobster0-runtime-image-{VERSION}.txt").write_text(
+            f"ghcr.io/nedonion/lobster0@sha256:{RUNTIME_DIGEST}\n", encoding="utf-8"
+        )
+        (self.artifacts / f"lobster0-sandbox-image-{VERSION}.txt").write_text(
+            f"ghcr.io/nedonion/lobster0-sandbox@sha256:{SANDBOX_DIGEST}\n", encoding="utf-8"
+        )
+        self.write_sboms()
+
+    def write_node_bundle(self, platform: str, upstream: str) -> Path:
+        """写入一个带 release-component.json 的 managed Node bundle fixture。"""
+        component = {
+            "name": "node",
+            "platform": platform,
+            "upstream_sha256": upstream,
+            "upstream_url": self.node_archives[platform]["url"],
+            "version": self.node_version,
+        }
+        encoded = json.dumps(component, sort_keys=True, separators=(",", ":"))
+        path = self.artifacts / f"lobster0-node-{self.node_version}-{platform}.tar.gz"
+        path.unlink(missing_ok=True)
+        _write_tar(
+            path,
+            {
+                "node/LICENSE": b"Node license\n",
+                "node/bin/node": b"#!/bin/sh\nexit 0\n",
+                "node/release-component.json": f"{encoded}\n".encode(),
+            },
+        )
+        return path
+
+    def write_tui_bundle(self, platform: str, *, link: str | None = None) -> Path:
+        """写入一个带 production licenses.json 的 TUI bundle fixture。"""
+        encoded = json.dumps(LICENSES, sort_keys=True, separators=(",", ":"))
+        path = self.artifacts / f"lobster0-tui-{VERSION}-{platform}.tar.gz"
+        path.unlink(missing_ok=True)
+        _write_tar(
+            path,
+            {
+                "tui/licenses.json": f"{encoded}\n".encode(),
+                "tui/package.json": b'{"name":"lobster0-tui","private":true}\n',
+                "tui/dist/index.js": b"process.exit(0);\n",
+            },
+            link=link,
+        )
+        return path
+
+    def write_sboms(self, *, version: str = VERSION) -> None:
+        """用真实 SBOM builder 生成 CycloneDX 与 SPDX 两份 Release 文档。"""
+        documents = build_sbom(self.sbom_inputs(version=version))
+        (self.artifacts / f"lobster0-{VERSION}-sbom.cyclonedx.json").write_bytes(
+            documents.cyclonedx
+        )
+        (self.artifacts / f"lobster0-{VERSION}-sbom.spdx.json").write_bytes(documents.spdx)
+
+    def sbom_inputs(self, *, version: str = VERSION) -> SbomInputs:
+        """返回覆盖全部可散列 artifact 的 SBOM 输入。"""
+        return SbomInputs(
+            version=version,
+            git_commit=COMMIT,
+            source_date_epoch=EPOCH,
+            python_components=self.python_components,
+            requirements_lock=self.artifacts / "requirements-all.lock",
+            artifacts=tuple(
+                sorted(
+                    path
+                    for path in self.artifacts.iterdir()
+                    if not path.name.endswith((".json", ".txt"))
+                )
+            ),
+            image_digests=tuple(sorted(self.artifacts.glob("lobster0-*-image-*.txt"))),
+        )
+
+    def inputs(self, **overrides: object) -> ReleaseInputs:
+        """返回默认完整、可按字段覆写的 manifest 输入。"""
+        fields: dict[str, object] = {
+            "version": VERSION,
+            "release_tag": f"v{VERSION}",
+            "git_commit": COMMIT,
+            "source_date_epoch": EPOCH,
+            "node_version": self.node_version,
+            "minimum_readable_schema": 1,
+            "features": load_features(FEATURES_REGISTRY),
+            "artifacts": tuple(sorted(self.artifacts.iterdir())),
+            "install_script": self.install_script,
+            "runtime_versions": RUNTIME_VERSIONS,
+        }
+        fields.update(overrides)
+        return ReleaseInputs(**fields)  # type: ignore[arg-type]
+
+    def inputs_without(self, kind: str, os_name: str, arch: str) -> ReleaseInputs:
+        """返回缺少一个具体平台 artifact 的输入。"""
+        dropped = f"-{os_name}-{arch}.tar.gz"
+        remaining = tuple(
+            path
+            for path in sorted(self.artifacts.iterdir())
+            if not (path.name.startswith(f"lobster0-{kind}-") and path.name.endswith(dropped))
+        )
+        return self.inputs(artifacts=remaining)
+
+    def _requirements(self) -> bytes:
+        """写入两条全部带 hash 的 locked requirement。"""
+        lines = [
+            "# This file was autogenerated by uv.",
+        ]
+        for name, version, _license in PYTHON_PACKAGES:
+            digest = hashlib.sha256(f"{name}=={version}".encode()).hexdigest()
+            lines.append(f"{name}=={version} \\")
+            lines.append(f"    --hash=sha256:{digest}")
+        return ("\n".join(lines) + "\n").encode()
+
+    def _python_components(self) -> bytes:
+        """写入与 lock 精确对齐的 uv CycloneDX export fixture。"""
+        document = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.5",
+            "version": 1,
+            "components": [
+                {
+                    "type": "library",
+                    "name": name,
+                    "version": version,
+                    "purl": f"pkg:pypi/{name}@{version}",
+                    "licenses": [{"license": {"id": license_id}}],
+                }
+                for name, version, license_id in PYTHON_PACKAGES
+            ],
+        }
+        return json.dumps(document, sort_keys=True, indent=2).encode() + b"\n"
+
+    def _installer(self) -> bytes:
+        """写入带固定 shebang 的最小 installer zipapp fixture。"""
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+            info = zipfile.ZipInfo("__main__.py", (1980, 1, 1, 0, 0, 0))
+            archive.writestr(info, b"raise SystemExit(0)\n")
+        return b"#!/usr/bin/env python3\n" + buffer.getvalue()
+
+
+class ManifestBuildTest(unittest.TestCase):
+    """验证 manifest 封闭世界、精确一致性与字节级可复现性。"""
+
+    def setUp(self) -> None:
+        """在隔离临时目录构建一整套 Release artifact fixture。"""
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.root = Path(self.temporary_directory.name)
+        self.fixture = ReleaseFixture(self.root)
+        self.inputs = self.fixture.inputs()
+
+    def test_manifest_builder_requires_every_tier1_component(self) -> None:
+        """缺任一 Tier 1 组件必须以精确平台消息失败。"""
+        with self.assertRaisesRegex(ReleaseBuildError, "missing tui artifact for macos-arm64"):
+            build_manifest(self.fixture.inputs_without("tui", "macos", "arm64"))
+        with self.assertRaisesRegex(ReleaseBuildError, "missing node artifact for linux-arm64"):
+            build_manifest(self.fixture.inputs_without("node", "linux", "arm64"))
+        for filename, message in (
+            (f"lobster0_agent-{VERSION}-py3-none-any.whl", "missing wheel artifact"),
+            (f"lobster0_agent-{VERSION}.tar.gz", "missing sdist artifact"),
+            ("requirements-all.lock", "missing requirements artifact"),
+            ("lobster0-installer.pyz", "missing installer artifact"),
+            (f"lobster0-{VERSION}-sbom.spdx.json", "missing sbom artifact for spdx"),
+            (
+                f"lobster0-{VERSION}-sbom.cyclonedx.json",
+                "missing sbom artifact for cyclonedx",
+            ),
+            (f"lobster0-runtime-image-{VERSION}.txt", "missing runtime-image artifact"),
+            (f"lobster0-sandbox-image-{VERSION}.txt", "missing sandbox-image artifact"),
+        ):
+            remaining = tuple(
+                path for path in self.inputs.artifacts if path.name != filename
+            )
+            with self.assertRaisesRegex(ReleaseBuildError, message):
+                build_manifest(self.fixture.inputs(artifacts=remaining))
+
+    def test_same_inputs_produce_byte_identical_manifest_and_checksums(self) -> None:
+        """相同输入必须产生逐字节相同的 manifest 与 checksums。"""
+        first = build_release_outputs(self.inputs)
+        second = build_release_outputs(self.inputs)
+
+        self.assertEqual(first.manifest, second.manifest)
+        self.assertEqual(first.checksums, second.checksums)
+        self.assertTrue(first.manifest.endswith(b"\n"))
+        self.assertNotIn(str(self.root).encode(), first.manifest)
+        self.assertNotIn(str(self.root).encode(), first.checksums)
+
+    def test_manifest_order_and_release_facts_are_exact(self) -> None:
+        """artifact 顺序、commit/tag/version/schema/features 必须精确一致。"""
+        manifest = build_manifest(self.inputs)
+        document = json.loads(manifest.decode("utf-8"))
+
+        order = [
+            (item["kind"], item["platform"]["os"], item["platform"]["arch"], item["filename"])
+            for item in document["artifacts"]
+        ]
+        self.assertEqual(order, sorted(order))
+        self.assertEqual(len(order), 16)
+        self.assertEqual(document["schema_version"], 1)
+        self.assertEqual(document["product"], "lobster0")
+        self.assertEqual(document["version"], VERSION)
+        self.assertEqual(document["git_commit"], COMMIT)
+        self.assertEqual(document["python"], "3.12")
+        self.assertEqual(document["database_schema"], 5)
+        self.assertEqual(document["minimum_readable_schema"], 1)
+        self.assertEqual(tuple(document["features"]), load_features(FEATURES_REGISTRY))
+        self.assertEqual(
+            {item["url"].rsplit("/", 2)[-2] for item in document["artifacts"]},
+            {f"v{VERSION}"},
+        )
+        parsed = ReleaseManifest.from_bytes(manifest)
+        self.assertEqual(parsed.version, VERSION)
+        self.assertEqual(len(parsed.artifacts), 16)
+
+    def test_manifest_rejects_release_identity_disagreement(self) -> None:
+        """tag、version、commit 与 schema 边界不一致必须拒绝。"""
+        with self.assertRaisesRegex(ReleaseBuildError, "release tag"):
+            self.fixture.inputs(release_tag="v0.6.9")
+        with self.assertRaisesRegex(ReleaseBuildError, "git commit"):
+            self.fixture.inputs(git_commit="not-a-commit")
+        with self.assertRaisesRegex(ReleaseBuildError, "version"):
+            self.fixture.inputs(version="0.7", release_tag="v0.7")
+        with self.assertRaisesRegex(ReleaseBuildError, "minimum readable schema"):
+            self.fixture.inputs(minimum_readable_schema=6)
+        with self.assertRaisesRegex(ReleaseBuildError, "feature"):
+            self.fixture.inputs(features=("agent", "agent"))
+        with self.assertRaisesRegex(ReleaseBuildError, "feature"):
+            self.fixture.inputs(features=("browser",))
+
+    def test_manifest_rejects_unexpected_and_duplicate_artifacts(self) -> None:
+        """未登记文件与重复文件名必须以精确消息拒绝。"""
+        stray = self.fixture.artifacts / "lobster0-extra.tar.gz"
+        stray.write_bytes(b"stray\n")
+        with self.assertRaisesRegex(ReleaseBuildError, "unexpected artifact lobster0-extra"):
+            build_manifest(self.fixture.inputs(artifacts=tuple(sorted(
+                self.fixture.artifacts.iterdir()
+            ))))
+        stray.unlink()
+
+        duplicate_root = self.root / "duplicate"
+        duplicate_root.mkdir()
+        wheel = duplicate_root / f"lobster0_agent-{VERSION}-py3-none-any.whl"
+        _write_wheel(wheel)
+        with self.assertRaisesRegex(ReleaseBuildError, "duplicate artifact filename"):
+            build_manifest(self.fixture.inputs(artifacts=self.inputs.artifacts + (wheel,)))
+
+    def test_manifest_rejects_wrong_wheel_metadata(self) -> None:
+        """wheel 的分发名或版本与 Release 不一致必须拒绝。"""
+        wheel = self.fixture.artifacts / f"lobster0_agent-{VERSION}-py3-none-any.whl"
+        _write_wheel(wheel, name="lobster0")
+        with self.assertRaisesRegex(ReleaseBuildError, "wheel metadata mismatch"):
+            build_manifest(self.inputs)
+
+    def test_manifest_rejects_requirements_without_hashes(self) -> None:
+        """lock 中出现无 hash 的 requirement 必须拒绝。"""
+        lock = self.fixture.artifacts / "requirements-all.lock"
+        lock.write_text("croniter==6.2.0\n", encoding="utf-8")
+        with self.assertRaisesRegex(ReleaseBuildError, "requirements entry without hash"):
+            build_manifest(self.inputs)
+
+    def test_manifest_rejects_node_upstream_hash_mismatch(self) -> None:
+        """Node bundle 记录的上游 hash 必须与固定 pin 精确一致。"""
+        self.fixture.write_node_bundle("linux-x86_64", "c" * 64)
+        with self.assertRaisesRegex(
+            ReleaseBuildError, "node upstream hash mismatch for linux-x86_64"
+        ):
+            build_manifest(self.inputs)
+
+    def test_manifest_rejects_archive_links(self) -> None:
+        """Release archive 中出现 link entry 必须拒绝。"""
+        self.fixture.write_tui_bundle("linux-x86_64", link="tui/dist/link.js")
+        with self.assertRaisesRegex(ReleaseBuildError, "archive contains an unsafe entry"):
+            build_manifest(self.inputs)
+
+    def test_manifest_rejects_sbom_subject_mismatch(self) -> None:
+        """SBOM 主体版本或 wheel hash 与 Release 不一致必须拒绝。"""
+        self.fixture.write_sboms(version="0.6.9")
+        with self.assertRaisesRegex(ReleaseBuildError, "sbom subject mismatch"):
+            build_manifest(self.inputs)
+
+    def test_manifest_rejects_image_without_digest(self) -> None:
+        """GHCR digest 文件必须是精确的 repository@sha256 单行。"""
+        digest_file = self.fixture.artifacts / f"lobster0-runtime-image-{VERSION}.txt"
+        digest_file.write_text("ghcr.io/nedonion/lobster0:latest\n", encoding="utf-8")
+        with self.assertRaisesRegex(ReleaseBuildError, "image digest missing"):
+            build_manifest(self.inputs)
+
+    def test_checksums_cover_trust_root_files_in_sorted_order(self) -> None:
+        """SHA256SUMS 必须按文件名排序并覆盖 manifest、install.sh 与全部 artifact。"""
+        outputs = build_release_outputs(self.inputs)
+        lines = outputs.checksums.decode("utf-8").splitlines()
+        names = [line.split("  ", 1)[1] for line in lines]
+
+        self.assertEqual(names, sorted(names))
+        self.assertEqual(len(names), 18)
+        self.assertIn("release-manifest.json", names)
+        self.assertIn("install.sh", names)
+        self.assertEqual(
+            lines[names.index("release-manifest.json")].split("  ", 1)[0],
+            hashlib.sha256(outputs.manifest).hexdigest(),
+        )
+        self.assertEqual(
+            lines[names.index("install.sh")].split("  ", 1)[0],
+            hashlib.sha256(self.fixture.install_script.read_bytes()).hexdigest(),
+        )
+        document = json.loads(outputs.manifest.decode("utf-8"))
+        manifest_names = {item["filename"] for item in document["artifacts"]}
+        self.assertNotIn("install.sh", manifest_names)
+        self.assertNotIn("SHA256SUMS", manifest_names)
+        self.assertTrue(manifest_names.issubset(set(names)))
+        self.assertTrue(outputs.checksums.endswith(b"\n"))
+
+    def test_release_inputs_document_binds_manifest_and_installer(self) -> None:
+        """release-inputs.json 必须精确绑定 manifest 与 installer 事实。"""
+        outputs = build_release_outputs(self.inputs)
+        payload = build_release_inputs_document(outputs.manifest, self.inputs)
+        document = json.loads(payload.decode("utf-8"))
+        installer = self.fixture.artifacts / "lobster0-installer.pyz"
+
+        self.assertEqual(document["release_tag"], f"v{VERSION}")
+        self.assertEqual(document["manifest_filename"], "release-manifest.json")
+        self.assertEqual(
+            document["manifest_sha256"], hashlib.sha256(outputs.manifest).hexdigest()
+        )
+        self.assertEqual(document["manifest_size"], len(outputs.manifest))
+        self.assertEqual(document["installer_filename"], "lobster0-installer.pyz")
+        self.assertEqual(document["installer_size"], installer.stat().st_size)
+        self.assertEqual(BootstrapReleaseInputs(**document).release_tag, f"v{VERSION}")
+
+    def test_checksums_require_the_canonical_install_script_name(self) -> None:
+        """checksums 只接受名为 install.sh 的 bootstrap 信任根文件。"""
+        renamed = self.root / "bootstrap.sh"
+        renamed.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        with self.assertRaisesRegex(ReleaseBuildError, "install script"):
+            build_checksums(b"{}\n", self.fixture.inputs(install_script=renamed))
+
+    def test_checksums_refuse_an_incomplete_release(self) -> None:
+        """checksums 与 manifest 共用同一封闭世界完整性门禁。"""
+        with self.assertRaisesRegex(ReleaseBuildError, "missing tui artifact for macos-arm64"):
+            build_checksums(b"{}\n", self.fixture.inputs_without("tui", "macos", "arm64"))
+
+
+class SbomBuildTest(unittest.TestCase):
+    """验证 CycloneDX/SPDX 输出覆盖全部 locked 与 production 依赖。"""
+
+    def setUp(self) -> None:
+        """物化一整套 artifact 以便直接驱动 SBOM builder。"""
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.root = Path(self.temporary_directory.name)
+        self.fixture = ReleaseFixture(self.root)
+        self.documents = build_sbom(self.fixture.sbom_inputs())
+
+    def test_sbom_lists_every_locked_and_production_package_once(self) -> None:
+        """每个 locked Python 包与 production Node 包必须恰好出现一次。"""
+        cyclonedx = json.loads(self.documents.cyclonedx.decode("utf-8"))
+        spdx = json.loads(self.documents.spdx.decode("utf-8"))
+        purls = [
+            component["purl"]
+            for component in cyclonedx["components"]
+            if "purl" in component
+        ]
+        spdx_purls = [
+            reference["referenceLocator"]
+            for package in spdx["packages"]
+            for reference in package.get("externalRefs", ())
+        ]
+
+        for name, version, _license in PYTHON_PACKAGES:
+            self.assertEqual(purls.count(f"pkg:pypi/{name}@{version}"), 1)
+            self.assertEqual(spdx_purls.count(f"pkg:pypi/{name}@{version}"), 1)
+        for entries in LICENSES.values():
+            for entry in entries:
+                purl = f"pkg:npm/{entry['name']}@{entry['versions'][0]}"
+                self.assertEqual(purls.count(purl), 1)
+                self.assertEqual(spdx_purls.count(purl), 1)
+        self.assertEqual(len(purls), len(set(purls)))
+        self.assertEqual(len(spdx_purls), len(set(spdx_purls)))
+
+    def test_sbom_is_canonical_and_records_artifact_hashes(self) -> None:
+        """SBOM 必须字节可复现并携带每个 artifact 的 SHA-256。"""
+        again = build_sbom(self.fixture.sbom_inputs())
+        cyclonedx = json.loads(self.documents.cyclonedx.decode("utf-8"))
+        spdx = json.loads(self.documents.spdx.decode("utf-8"))
+        wheel = self.fixture.artifacts / f"lobster0_agent-{VERSION}-py3-none-any.whl"
+        digest = hashlib.sha256(wheel.read_bytes()).hexdigest()
+        hashes = {
+            component["name"]: component["hashes"][0]["content"]
+            for component in cyclonedx["components"]
+            if "hashes" in component
+        }
+        spdx_hashes = {
+            package["name"]: package["checksums"][0]["checksumValue"]
+            for package in spdx["packages"]
+            if "checksums" in package
+        }
+
+        self.assertEqual(self.documents.cyclonedx, again.cyclonedx)
+        self.assertEqual(self.documents.spdx, again.spdx)
+        self.assertEqual(hashes[wheel.name], digest)
+        self.assertEqual(spdx_hashes[wheel.name], digest)
+        self.assertEqual(cyclonedx["specVersion"], "1.5")
+        self.assertEqual(spdx["spdxVersion"], "SPDX-2.3")
+        self.assertEqual(cyclonedx["metadata"]["component"]["version"], VERSION)
+        self.assertTrue(
+            any(
+                relationship["relationshipType"] == "DESCRIBES"
+                for relationship in spdx["relationships"]
+            )
+        )
+        self.assertNotIn(str(self.root).encode(), self.documents.cyclonedx)
+        self.assertNotIn(str(self.root).encode(), self.documents.spdx)
+
+    def test_sbom_rejects_python_package_set_mismatch(self) -> None:
+        """uv export 与 lock 的包集合不一致必须拒绝。"""
+        lock = self.fixture.artifacts / "requirements-all.lock"
+        lock.write_text(
+            "croniter==6.2.0 \\\n    --hash=sha256:" + "d" * 64 + "\n", encoding="utf-8"
+        )
+        with self.assertRaisesRegex(SbomBuildError, "python package set mismatch"):
+            build_sbom(self.fixture.sbom_inputs())
+
+    def test_sbom_rejects_divergent_tui_license_inventories(self) -> None:
+        """四个平台 TUI bundle 的 production license 清单必须完全一致。"""
+        path = self.fixture.artifacts / f"lobster0-tui-{VERSION}-macos-arm64.tar.gz"
+        path.unlink()
+        _write_tar(
+            path,
+            {
+                "tui/licenses.json": b'{"MIT":[{"name":"other","versions":["1.0.0"]}]}\n',
+                "tui/package.json": b"{}\n",
+            },
+        )
+        with self.assertRaisesRegex(SbomBuildError, "license inventory mismatch"):
+            build_sbom(self.fixture.sbom_inputs())
+
+
+class ReleaseInputCollectionTest(unittest.TestCase):
+    """验证从 Git 仓库收集 Release 事实的门禁。"""
+
+    def setUp(self) -> None:
+        """构造一个带 v0.7.0 tag 的离线临时仓库。"""
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.root = Path(self.temporary_directory.name)
+        self.repository = self.root / "repository"
+        self.fixture = ReleaseFixture(self.root)
+        (self.repository / "src/lobster0").mkdir(parents=True)
+        (self.repository / "release").mkdir(parents=True)
+        (self.repository / "src/lobster0/_version.py").write_text(
+            f'__version__: str = "{VERSION}"\n', encoding="utf-8"
+        )
+        (self.repository / "release/features.json").write_bytes(
+            FEATURES_REGISTRY.read_bytes()
+        )
+        (self.repository / "release/runtime-versions.json").write_bytes(
+            RUNTIME_VERSIONS.read_bytes()
+        )
+        self._git("init", "--quiet", "--initial-branch=main")
+        self._git("add", ".")
+        self._git("commit", "--quiet", "-m", "release fixture")
+        self._git("tag", f"v{VERSION}")
+        self.commit_epoch = int(
+            self._git("show", "-s", "--format=%ct", f"v{VERSION}^{{commit}}").strip()
+        )
+
+    def _git(self, *arguments: str) -> str:
+        """在固定身份与时间下运行一个受控 git 子命令。"""
+        environment = dict(os.environ)
+        environment.update(
+            {
+                "GIT_AUTHOR_NAME": "Lobster0 Release",
+                "GIT_AUTHOR_EMAIL": "release@example.invalid",
+                "GIT_COMMITTER_NAME": "Lobster0 Release",
+                "GIT_COMMITTER_EMAIL": "release@example.invalid",
+                "GIT_AUTHOR_DATE": f"{EPOCH} +0000",
+                "GIT_COMMITTER_DATE": f"{EPOCH} +0000",
+                "GIT_CONFIG_GLOBAL": str(self.root / "gitconfig"),
+                "GIT_CONFIG_SYSTEM": str(self.root / "gitconfig"),
+            }
+        )
+        completed = subprocess.run(
+            ["git", "-C", str(self.repository), *arguments],
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=True,
+            shell=False,
+        )
+        return completed.stdout
+
+    def test_collect_requires_clean_tree_and_matching_source_date_epoch(self) -> None:
+        """脏工作区、错 tag 时间与错版本必须拒绝，干净仓库产生精确事实。"""
+        inputs = collect_release_inputs(
+            self.repository,
+            self.fixture.artifacts,
+            self.fixture.install_script,
+            {"SOURCE_DATE_EPOCH": str(self.commit_epoch)},
+        )
+        self.assertEqual(inputs.version, VERSION)
+        self.assertEqual(inputs.release_tag, f"v{VERSION}")
+        self.assertEqual(inputs.source_date_epoch, self.commit_epoch)
+        self.assertEqual(len(inputs.artifacts), 16)
+
+        with self.assertRaisesRegex(ReleaseBuildError, "SOURCE_DATE_EPOCH"):
+            collect_release_inputs(
+                self.repository,
+                self.fixture.artifacts,
+                self.fixture.install_script,
+                {"SOURCE_DATE_EPOCH": str(self.commit_epoch + 1)},
+            )
+        with self.assertRaisesRegex(ReleaseBuildError, "SOURCE_DATE_EPOCH"):
+            collect_release_inputs(
+                self.repository, self.fixture.artifacts, self.fixture.install_script, {}
+            )
+
+        (self.repository / "src/lobster0/_version.py").write_text(
+            '__version__: str = "0.7.0"\n# dirty\n', encoding="utf-8"
+        )
+        with self.assertRaisesRegex(ReleaseBuildError, "git worktree is not clean"):
+            collect_release_inputs(
+                self.repository,
+                self.fixture.artifacts,
+                self.fixture.install_script,
+                {"SOURCE_DATE_EPOCH": str(self.commit_epoch)},
+            )
+
+    def test_collect_rejects_tag_that_is_not_head(self) -> None:
+        """tag 未指向 HEAD 的候选提交必须拒绝。"""
+        self._git("commit", "--quiet", "--allow-empty", "-m", "after tag")
+        with self.assertRaisesRegex(ReleaseBuildError, "release tag"):
+            collect_release_inputs(
+                self.repository,
+                self.fixture.artifacts,
+                self.fixture.install_script,
+                {"SOURCE_DATE_EPOCH": str(self.commit_epoch)},
+            )
+
+
+class VerifyReleaseTest(unittest.TestCase):
+    """验证独立 verifier 能重新发现 builder 输出中的任何漂移。"""
+
+    def setUp(self) -> None:
+        """构建一份完整候选 Release 并落盘 manifest 与 checksums。"""
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.root = Path(self.temporary_directory.name)
+        self.fixture = ReleaseFixture(self.root)
+        outputs = build_release_outputs(self.fixture.inputs())
+        self.manifest = self.root / "release-manifest.json"
+        self.checksums = self.root / "SHA256SUMS"
+        self.manifest.write_bytes(outputs.manifest)
+        self.checksums.write_bytes(outputs.checksums)
+
+    def _verify(self) -> tuple[str, ...]:
+        """用磁盘上的文件独立复核一次候选 Release。"""
+        return verify_release(
+            manifest=self.manifest,
+            schema=SCHEMA,
+            artifact_directory=self.fixture.artifacts,
+            checksums=self.checksums,
+            install_script=self.fixture.install_script,
+        )
+
+    def test_verifier_accepts_a_complete_candidate_release(self) -> None:
+        """完整候选 Release 必须通过 schema、hash 与 checksums 复核。"""
+        report = self._verify()
+        self.assertIn(f"manifest {VERSION} verified", report)
+        self.assertIn("artifacts 16 verified", report)
+        self.assertIn("checksums 18 verified", report)
+
+    def test_verifier_rejects_tampered_artifact_and_broken_schema(self) -> None:
+        """任一 artifact 被改写或 manifest 违反 schema 都必须失败。"""
+        wheel = self.fixture.artifacts / f"lobster0_agent-{VERSION}-py3-none-any.whl"
+        wheel.write_bytes(wheel.read_bytes() + b"tampered")
+        with self.assertRaisesRegex(ReleaseVerifyError, "artifact hash mismatch"):
+            self._verify()
+
+        document = json.loads(self.manifest.read_text(encoding="utf-8"))
+        document["database_schema"] = 4
+        self.manifest.write_text(json.dumps(document), encoding="utf-8")
+        with self.assertRaisesRegex(ReleaseVerifyError, "manifest schema violation"):
+            self._verify()
+
+
+class FeatureRegistryTest(unittest.TestCase):
+    """验证 features 注册表只声明已实现且可断言的能力。"""
+
+    def test_registry_maps_each_feature_to_one_assertion(self) -> None:
+        """每个 feature 必须在 schema 枚举内且恰好一条 import 断言。"""
+        document = json.loads(FEATURES_REGISTRY.read_text(encoding="utf-8"))
+        schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+        allowed = set(schema["properties"]["features"]["items"]["enum"])
+        names = [entry["feature"] for entry in document["features"]]
+
+        self.assertEqual(document["schema_version"], 1)
+        self.assertEqual(names, sorted(names))
+        self.assertEqual(len(names), len(set(names)))
+        self.assertTrue(set(names).issubset(allowed))
+        self.assertNotIn("evolution", names)
+        for entry in document["features"]:
+            self.assertEqual(set(entry), {"feature", "module", "attribute"})
+            self.assertTrue(entry["module"].startswith("lobster0."))
+            self.assertTrue(entry["attribute"].isidentifier())
+        self.assertEqual(load_features(FEATURES_REGISTRY), tuple(names))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_release_manifest_build.py
+++ b/tests/test_release_manifest_build.py
@@ -11,7 +11,10 @@ import unittest
 import zipfile
 from pathlib import Path
 
+from lobster0.install import models as install_models
 from lobster0.install.models import ReleaseManifest
+from lobster0.storage import migrations as storage_migrations
+from lobster0.storage.migrations import LATEST_SCHEMA_VERSION
 from scripts.build_release_manifest import (
     ReleaseBuildError,
     ReleaseInputs,
@@ -318,7 +321,7 @@ class ManifestBuildTest(unittest.TestCase):
         self.assertEqual(document["version"], VERSION)
         self.assertEqual(document["git_commit"], COMMIT)
         self.assertEqual(document["python"], "3.12")
-        self.assertEqual(document["database_schema"], 5)
+        self.assertEqual(document["database_schema"], LATEST_SCHEMA_VERSION)
         self.assertEqual(document["minimum_readable_schema"], 1)
         self.assertEqual(tuple(document["features"]), load_features(FEATURES_REGISTRY))
         self.assertEqual(
@@ -329,6 +332,40 @@ class ManifestBuildTest(unittest.TestCase):
         self.assertEqual(parsed.version, VERSION)
         self.assertEqual(len(parsed.artifacts), 16)
 
+    def test_database_schema_tracks_the_migration_source_of_truth(self) -> None:
+        """manifest、strict model 与 JSON schema 必须跟随迁移单一来源。"""
+        document = json.loads(build_manifest(self.inputs).decode("utf-8"))
+        schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+
+        self.assertEqual(
+            max(storage_migrations._MIGRATION_RESOURCES), LATEST_SCHEMA_VERSION
+        )
+        self.assertEqual(
+            sorted(storage_migrations._MIGRATION_RESOURCES),
+            list(range(1, LATEST_SCHEMA_VERSION + 1)),
+        )
+        self.assertEqual(document["database_schema"], LATEST_SCHEMA_VERSION)
+        self.assertEqual(
+            install_models._DATABASE_SCHEMA_VERSION,
+            LATEST_SCHEMA_VERSION,
+            "install/models.py cannot import migrations across the stdlib-only zipapp "
+            "boundary, so its literal must be updated with every new migration",
+        )
+        self.assertEqual(
+            schema["properties"]["database_schema"]["const"],
+            LATEST_SCHEMA_VERSION,
+            "release/manifest.schema.json is static and must be updated with every "
+            "new migration",
+        )
+        self.assertEqual(
+            schema["properties"]["minimum_readable_schema"]["maximum"],
+            LATEST_SCHEMA_VERSION,
+            "minimum_readable_schema 的上界与 database_schema 同源，漏改会让 schema "
+            "自相矛盾：允许的最早可读版本上限低于本 Runtime 实际写入的版本",
+        )
+        self.assertLessEqual(document["minimum_readable_schema"], LATEST_SCHEMA_VERSION)
+        ReleaseManifest.from_bytes(build_manifest(self.inputs))
+
     def test_manifest_rejects_release_identity_disagreement(self) -> None:
         """tag、version、commit 与 schema 边界不一致必须拒绝。"""
         with self.assertRaisesRegex(ReleaseBuildError, "release tag"):
@@ -338,7 +375,7 @@ class ManifestBuildTest(unittest.TestCase):
         with self.assertRaisesRegex(ReleaseBuildError, "version"):
             self.fixture.inputs(version="0.7", release_tag="v0.7")
         with self.assertRaisesRegex(ReleaseBuildError, "minimum readable schema"):
-            self.fixture.inputs(minimum_readable_schema=6)
+            self.fixture.inputs(minimum_readable_schema=LATEST_SCHEMA_VERSION + 1)
         with self.assertRaisesRegex(ReleaseBuildError, "feature"):
             self.fixture.inputs(features=("agent", "agent"))
         with self.assertRaisesRegex(ReleaseBuildError, "feature"):


### PR DESCRIPTION
## Summary

Milestone 7 / Task 15:可复现的发布产物组装层——把一个干净的 tag 提交加一组构建产物,变成规范化的 `release-manifest.json`、SBOM 和排序后的 `SHA256SUMS`,并用封闭世界校验拒绝任何缺件的发布。

- `release/features.json` —— 14 项已验证的 Phase 0-6 公开能力,每项映射到恰好一条 import 断言。
- `scripts/build_release_manifest.py` —— `manifest` 与 `checksums` 两个子命令。封闭世界要求 **16** 个产物齐全(wheel、sdist、lock、installer pyz、2 份 SBOM、2 个镜像摘要,加 4 个 Node bundle 与 4 个 TUI bundle),缺任何一个平台产物都以精确信息失败。
- `scripts/build_sbom.py` —— 规范化 CycloneDX 1.5 + SPDX 2.3 双格式输出。
- `scripts/verify_release_artifacts.py` —— **真正独立**的校验器:自带一套 JSON Schema 子集校验器,不与构建器共用代码,重新加载并重新哈希每个产物,目的就是能抓出构建器自身的 bug。

## 复核发现并修复的阻塞级缺陷

构建器把 `database_schema` 写死成 **5**,而实际 `LATEST_SCHEMA_VERSION` 已是 **7**(Phase 7 的 `0007_controlled_evolution` 迁移从并行分支合入)。发布出去的 manifest 会低报两个版本——而 Task 13 的 `UpdateCoordinator` 正是依据这个字段判断升级/回滚是否安全,**错误的 schema 事实会让"安全回滚"的判断本身失效**。

该缺陷可自我掩盖:测试把 5 断言成了期望值,自己的套件永远抓不到漂移。

三处同源写死值全部处理:
1. 构建器改为从 `LATEST_SCHEMA_VERSION` 派生;
2. `install/models.py` 受 stdlib-only zipapp 的 import 边界约束**无法** import 业务模块,只能保留字面量,改由测试盯住;
3. `release/manifest.schema.json` 是静态 JSON,同样由测试盯住——并补上了修复过程中被漏改的 `minimum_readable_schema` 上界(仍为 5,与新的 7 自相矛盾)。

新增回归测试断言四者与 `LATEST_SCHEMA_VERSION` 全等,并校验迁移资源 1..LATEST 连续无缺口。该断言经过反向验证(故意改错必失败、改回即通过),确保下一个新增迁移的人不会再踩同一个坑。

另确认 `minimum_readable_schema = 1` 的判断**正确**:迁移文件 1-7 无缺口,`apply_migrations` 迭代 `range(1, LATEST+1)`,代码确实能从 schema 1 迁上来;既有夹具里的 5 只是任意测试值,非策略声明。

## Verification

- 焦点测试 25/25;schema 变动波及的既有模块(models/platforms/runtime/zipapp)169/169。
- 双次构建字节级一致:wheel 与 installer pyz 各构建两次 `cmp` 均完全相同。
- 全量 1481 项,除已知的本机 `TuiBundleTest`(Node/pnpm 门槛)外,另 3 项 `browser_evals`/`cli_eval` 失败为新工作区缺 `browser-worker/dist` 本地构建产物所致,此前已在纯净 main 上复现验证,非本次回归。
- Ruff、docs validator 均 PASS。

## 复核记录的非阻塞观察

installer pyz 的校验相对浅(仅 shebang + `is_zipfile`),而它是整个发布中安全等级最高的产物(会在用户机器上以其权限被执行)。建议后续补充 `__main__.py` 入口断言与 `zipfile.testzip()` 完整性检查。

## Checklist

- [x] 变更聚焦既定范围。
- [x] 已运行相关检查。
- [x] 台账已记录缺陷与修复。
- [x] 未包含密钥、凭证或个人数据。
