### PR TITLE
docs(install): 交付 Milestone 10 一行安装文档与 v0.7.0 发布候选记录

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,89 @@ Lobster0 不是“把聊天框接到 Shell”——模型只提出 Tool Call，C
 
 ## 快速开始
 
-### 环境要求
+### 一行安装
 
-- Python 3.12+
-- [uv](https://docs.astral.sh/uv/)
-- Node.js 22.22.3–<23 或 24.15.0–<25 与 pnpm（默认 pi-tui；managed 默认 24.18.0）
-- Chrome/Chromium 与 Playwright（仅在启用 Browser Agent 时需要）
-- 一个 OpenAI-compatible 模型端点；默认配置为 `deepseek-v4-pro`
+```bash
+curl -fsSL --proto '=https' --tlsv1.2 \
+  https://github.com/NEDONION/lobster0/releases/latest/download/install.sh | bash
+```
 
-### 安装与启动
+> [!IMPORTANT]
+> 这条命令描述的是 v0.7.0 Release 发布**之后**的行为。本仓库目前还没有任何 Release 或 tag，
+> 该 URL 现在会 404。一行安装链路的状态是 **RELEASE CANDIDATE / PUBLIC GATES PENDING**：
+> 真机安装矩阵、包发布与镜像摘要冒烟一次都没有执行过。逐项证据见
+> [v0.7.0 一行安装候选记录](docs/evals/releases/v0.7.0-install.md)。
+> 在正式发布之前，请使用下面的[源码开发安装](#源码开发安装)。
+
+安装器自带 pinned uv、受管 Python 3.12、受管 Node.js 与平台 pi-tui bundle，因此**不需要预装
+Python、Node.js 或 pnpm**。默认安装到 `~/.lobster0`，命令入口是 `~/.local/bin/lobster0`，
+默认安装过程不请求 sudo；需要系统包、linger 或系统级前缀时会先展示精确计划再单独确认。
+Python 分发名是 `lobster0-agent`，CLI、import 与状态根仍是 `lobster0`。
+
+先看计划、零写入、零下载：
+
+```bash
+curl -fsSL --proto '=https' --tlsv1.2 \
+  https://github.com/NEDONION/lobster0/releases/latest/download/install.sh | bash -s -- --dry-run
+```
+
+完全非交互安装（需要事先准备好配置模板与 owner-only Secret 文件）：
+
+```bash
+curl -fsSL --proto '=https' --tlsv1.2 \
+  https://github.com/NEDONION/lobster0/releases/latest/download/install.sh \
+  | bash -s -- --no-onboard --no-install-service --json \
+      --config /absolute/path/to/config.toml \
+      --secrets-file /absolute/path/to/secrets.env
+```
+
+其余参数：`--version <semver>`、`--channel stable|dev`、`--prefix <绝对路径>`、`--system-prefix`、
+`--install-service`、`--allow-system-packages`、`--verbose`。stdin 不是 TTY 且参数不足时 fail closed；
+Secret 只从 `/dev/tty` 隐藏输入、owner-only Secret 文件或现有进程环境读取，不接受命令行明文。
+
+### 支持矩阵
+
+| 平台 | 版本 | 架构 | 常驻服务 |
+| --- | --- | --- | --- |
+| Ubuntu | 22.04、24.04 | x86_64、arm64 | systemd user |
+| Debian | 12、13 | x86_64、arm64 | systemd user |
+| RHEL / Rocky / Alma | 9、10 | x86_64、arm64 | systemd user |
+| macOS | 13 及以上 | Intel（x86_64）、Apple Silicon（arm64） | LaunchAgent |
+
+明确不支持、且在任何写入前就返回 `unsupported_platform`：Windows 原生与 WSL、Alpine/musl、
+NixOS 声明式安装、Android/Termux、32 位架构，以及没有 systemd 的 Linux 常驻服务宿主。
+
+上表是设计上的 Tier 1 范围，不是已验证结论——这些组合目前都还没有跑过真机安装矩阵。
+
+### Node 策略
+
+受管 Node.js 默认 24.18.0。只接受 `22.22.3 <= version < 23.0.0` 或 `24.15.0 <= version < 25.0.0`，
+Node 20/23/25/26 一律拒绝。一行安装会自己下载并校验受管 Node，不使用也不要求机器上已有的 Node。
+
+### 服务、升级与卸载
+
+| 命令 | 用途 |
+| --- | --- |
+| `lobster0 service install` | 安装并启用受管 Gateway 用户服务（systemd user / LaunchAgent） |
+| `lobster0 service status` | 查看受管服务状态 |
+| `lobster0 service logs` | 读取受管服务日志 |
+| `lobster0 service restart` | 重启受管服务 |
+| `lobster0 service uninstall` | 只移除受管服务，保留安装与数据 |
+| `lobster0 uninstall` | 移除受管 Runtime、launcher 与 receipt，**保留 `~/.lobster0` 下全部用户数据** |
+| `lobster0 uninstall --purge-data --yes-i-understand-data-loss` | 额外删除枚举出来的状态；`workspace/` 仍然保留 |
+
+**升级的方式是重新运行上面的一行安装命令。** 已安装 CLI 上的 `lobster0 update` 目前会打印
+`update_requires_bootstrap` 并以退出码 2 结束：升级流水线需要 bootstrap 建立的信任根（pinned uv 与
+受管 Python），而受管 Runtime 在激活时按设计删除 `.inputs`，所以它 fail closed，而不是退化到
+`PATH` 上的不可信 uv。升级中途失败会自动回滚；若迁移之后已经产生新写入，则返回 `rollback_conflict`
+并保留现场，人工恢复步骤见[安装与发布运维手册](docs/engineering/operations/20260809_install-release-operations.md)。
+
+### 源码开发安装
+
+开发与贡献走源码路径，需要本机自备 Python 3.12+、[uv](https://docs.astral.sh/uv/)、
+Node.js 22.22.3–<23 或 24.15.0–<25 与 pnpm（默认 pi-tui；受管默认 24.18.0）；启用 Browser Agent 时
+另需 Chrome/Chromium 与 Playwright；对话需要一个 OpenAI-compatible 模型端点，默认配置为
+`deepseek-v4-pro`。
 
 ```bash
 git clone https://github.com/NEDONION/lobster0.git
@@ -117,7 +191,7 @@ LOBSTER0_TUI=textual uv run lobster0
 | `uv run lobster0 init` | 幂等初始化 owner-only 状态、配置、Memory、Skills 和 SQLite。 |
 | `uv run lobster0 doctor` | 检查配置、目录权限、Provider、TUI 和数据库状态。 |
 | `uv run lobster0 gateway` | 启动已配置的 Feishu/Telegram/Discord Gateway。 |
-| `lobster0 service install/status/restart/uninstall` | 管理 Feishu-only macOS LaunchAgent；生产 runtime 使用独立 managed Python 3.12。 |
+| `lobster0 service install/status/logs/restart/uninstall` | 管理受管 Gateway 用户服务（Linux systemd user / macOS LaunchAgent）；service 永远指向稳定 launcher。 |
 | `uv run lobster0 task list` | 查看 durable ScheduledTask；`show/runs/pause/resume/run/cancel/halt/unhalt` 提供完整控制面。 |
 | `uv run lobster0 eval validate --root evals/scenarios` | 校验版本化 JSONL 场景。 |
 | `uv run lobster0 eval run --suite offline --root evals/scenarios` | 跑真实 Core/Policy/Tool/SQLite 离线回归。 |
@@ -132,7 +206,7 @@ Channel 的 allowlist、Owner 身份与平台凭据配置见[本地运行指南]
 Desktop 当前是开发构建，不是已签名安装包。它复用同一 Python Core、Policy、SQLite 与 Automation，不在
 Renderer 中复制 Agent 逻辑或直接访问本机能力。
 
-macOS 已安装 `uv`、Node.js `>=22.19.0` 和 Corepack 后，首选直接在 Finder 双击根目录的
+macOS 已安装 `uv`、满足 22.22.3–<23 或 24.15.0–<25 的 Node.js 和 Corepack 后，首选直接在 Finder 双击根目录的
 `start-desktop.command`，或从终端执行：
 
 ```bash
@@ -312,10 +386,14 @@ Policy；截图和下载只返回私有 Artifact ID。当前状态为 **IMPLEMEN
 | Telegram / Discord | Implementation PASS；真实平台 Live Gate 仍 pending |
 | Memory Autopilot | A～E IMPLEMENTATION PASS；真实 IM Live 结论沿用各平台 gate |
 | Phase 6 | **IMPLEMENTATION PASS / PRODUCTION SOAK PENDING**；生产 Gate tooling 完成，严格 25-case 与 24h 尚未完成 |
+| 一行安装与发布 | **RELEASE CANDIDATE / PUBLIC GATES PENDING**；真机安装矩阵、包发布、镜像摘要冒烟与 attestation 校验均未执行，仓库尚无 Release 或 tag |
 
 本地 fake SDK、离线场景和 660/660 soak 只代表 **IMPLEMENTATION PASS**，不会冒充真实平台 Live PASS。历史发布证据见 [`docs/evals/releases/`](docs/evals/releases/)。
 Memory 上线前的 Phase 5 历史基线为 562 Python、30 TypeScript、29/29 Agent；Memory v0.6.0 的历史基线为
 666 Python、35 TypeScript、39/39 Agent；Phase 6 历史基线为 798 Python。当前发布数字以上表和 v0.6.5 为准。
+上表的 1005 是 Phase 6.5 的 Python 计数基线；安装/发布链路新增的测试尚未并入该数字，本机全量
+`unittest discover` 当前为 1547 项，逐项结果见
+[v0.7.0 一行安装候选记录](docs/evals/releases/v0.7.0-install.md)。
 
 ### 验证命令
 
@@ -383,6 +461,8 @@ tests/           # Python unittest
 | [产品需求文档](docs/product/20260807_产品需求文档.md) | 产品范围、非目标和验收标准 |
 | [系统架构](docs/architecture/20260807_系统架构.md) | 模块边界、数据流与安全原则 |
 | [本地运行指南](docs/getting-started/20260807_本地运行指南.md) | 安装、配置、TUI、Gateway 与排障 |
+| [安装与发布运维手册](docs/engineering/operations/20260809_install-release-operations.md) | 草稿 Release 提升、PyPI/GHCR 核对、`rollback_conflict` 恢复与撤销流程 |
+| [v0.7.0 一行安装候选记录](docs/evals/releases/v0.7.0-install.md) | 一行安装链路的真实门禁状态与最终 PASS 所需外部证据（当前 PENDING） |
 | [工程文档索引](docs/engineering/README.md) | 已实现模块与规划文档的边界 |
 | [开发与交付时间线](docs/engineering/20260809_development-timeline.md) | 架构 Phase、真实版本顺序与证据状态的对应关系 |
 | [开发进度页](docs/progress/index.html) | 当前 Phase、证据和下一步 |

--- a/README_EN.md
+++ b/README_EN.md
@@ -64,15 +64,98 @@ New installations and older configurations without `tools.mode` default to `auto
 
 ## Quick start
 
-### Requirements
+### One-line install
 
-- Python 3.12+
-- [uv](https://docs.astral.sh/uv/)
-- Node.js 22.22.3–<23 or 24.15.0–<25 and pnpm for the default pi-tui (managed default: 24.18.0)
-- Chrome/Chromium and Playwright when Browser Agent is enabled
-- An OpenAI-compatible model endpoint; the default model is `deepseek-v4-pro`
+```bash
+curl -fsSL --proto '=https' --tlsv1.2 \
+  https://github.com/NEDONION/lobster0/releases/latest/download/install.sh | bash
+```
 
-### Install and run
+> [!IMPORTANT]
+> This command describes the behaviour **after** the v0.7.0 Release is published. This repository
+> has no Release and no tag yet, so the URL currently returns 404. The one-line install path is
+> **RELEASE CANDIDATE / PUBLIC GATES PENDING**: the real-machine install matrix, the package
+> publish and the image digest smokes have never been executed. Per-item evidence lives in the
+> [v0.7.0 one-line install candidate record](docs/evals/releases/v0.7.0-install.md).
+> Until then, use the [source development install](#source-development-install) below.
+
+The installer ships its own pinned uv, managed Python 3.12, managed Node.js and platform pi-tui
+bundle, so **no preinstalled Python, Node.js or pnpm is required**. It installs into `~/.lobster0`
+with the command entry at `~/.local/bin/lobster0`, and a default install never asks for sudo;
+system packages, linger and a system prefix each print an exact plan and ask again. The Python
+distribution name is `lobster0-agent`; the CLI, the import package and the state home stay
+`lobster0`.
+
+Print the plan with zero writes and zero component downloads:
+
+```bash
+curl -fsSL --proto '=https' --tlsv1.2 \
+  https://github.com/NEDONION/lobster0/releases/latest/download/install.sh | bash -s -- --dry-run
+```
+
+Fully non-interactive install (prepare the config template and the owner-only Secret file first):
+
+```bash
+curl -fsSL --proto '=https' --tlsv1.2 \
+  https://github.com/NEDONION/lobster0/releases/latest/download/install.sh \
+  | bash -s -- --no-onboard --no-install-service --json \
+      --config /absolute/path/to/config.toml \
+      --secrets-file /absolute/path/to/secrets.env
+```
+
+Remaining flags: `--version <semver>`, `--channel stable|dev`, `--prefix <absolute-path>`,
+`--system-prefix`, `--install-service`, `--allow-system-packages`, `--verbose`. A non-TTY stdin with
+incomplete arguments fails closed; secrets are only read from hidden `/dev/tty` input, an owner-only
+Secret file or the existing process environment — never from the command line.
+
+### Supported platforms
+
+| Platform | Versions | Architectures | Managed service |
+| --- | --- | --- | --- |
+| Ubuntu | 22.04, 24.04 | x86_64, arm64 | systemd user |
+| Debian | 12, 13 | x86_64, arm64 | systemd user |
+| RHEL / Rocky / Alma | 9, 10 | x86_64, arm64 | systemd user |
+| macOS | 13 and newer | Intel (x86_64), Apple Silicon (arm64) | LaunchAgent |
+
+Explicitly unsupported, rejected with `unsupported_platform` before any write: native Windows and
+WSL, Alpine/musl, declarative NixOS installs, Android/Termux, 32-bit architectures, and Linux hosts
+without systemd as a resident service host.
+
+That table is the designed Tier 1 scope, not a verified result — none of those combinations has run
+the real-machine install matrix yet.
+
+### Node policy
+
+The managed Node.js version is 24.18.0. Only `22.22.3 <= version < 23.0.0` and
+`24.15.0 <= version < 25.0.0` are accepted; Node 20/23/25/26 are rejected. The one-line installer
+downloads and verifies its own managed Node and neither uses nor requires a machine-wide Node.
+
+### Service, upgrade and uninstall
+
+| Command | Purpose |
+| --- | --- |
+| `lobster0 service install` | Install and enable the managed Gateway user service |
+| `lobster0 service status` | Inspect the managed service |
+| `lobster0 service logs` | Read managed service logs |
+| `lobster0 service restart` | Restart the managed service |
+| `lobster0 service uninstall` | Remove only the service, keeping the install and all data |
+| `lobster0 uninstall` | Remove the managed Runtime, launcher and receipt, **keeping every user file under `~/.lobster0`** |
+| `lobster0 uninstall --purge-data --yes-i-understand-data-loss` | Also delete the enumerated state; `workspace/` is still kept |
+
+**Upgrading means re-running the one-line install command above.** `lobster0 update` on an installed
+CLI currently prints `update_requires_bootstrap` and exits with code 2: the update pipeline needs the
+trust root established by bootstrap (a pinned uv and a managed Python), and the managed Runtime
+deletes `.inputs` on activation by design, so it fails closed instead of degrading to an untrusted
+`PATH` uv. A failed upgrade rolls back automatically; if external writes happened after the
+migration it returns `rollback_conflict` and preserves the scene — manual recovery is documented in
+the [install and release operations runbook](docs/engineering/operations/20260809_install-release-operations.md).
+
+### Source development install
+
+Contributors use the source path and provide their own Python 3.12+,
+[uv](https://docs.astral.sh/uv/), Node.js 22.22.3–<23 or 24.15.0–<25 and pnpm for the default pi-tui
+(managed default: 24.18.0), plus Chrome/Chromium and Playwright when Browser Agent is enabled, plus
+an OpenAI-compatible model endpoint (default `deepseek-v4-pro`).
 
 ```bash
 git clone https://github.com/NEDONION/lobster0.git
@@ -252,9 +335,12 @@ Read the [system architecture](docs/architecture/20260807_系统架构.md) and [
 | Telegram / Discord | Implementation PASS; real-platform Live Gates pending |
 | Memory Autopilot | A–E IMPLEMENTATION PASS; live conclusions remain platform-specific |
 | Phase 6 | **IMPLEMENTATION PASS / PRODUCTION SOAK PENDING**; production tooling is complete, strict 25-case and 24h evidence are pending |
+| One-line install and release | **RELEASE CANDIDATE / PUBLIC GATES PENDING**; the real-machine install matrix, package publish, image digest smokes and attestation verification have never run, and the repository has no Release or tag |
 
 Fake SDKs, offline scenarios, and the 660/660 local soak only establish **IMPLEMENTATION PASS**. They never masquerade as a live-platform PASS. Historical evidence lives under [`docs/evals/releases/`](docs/evals/releases/).
 The pre-Memory Phase 5 historical baseline was 562 Python, 30 TypeScript, and 29/29 Agent. Memory v0.6.0 recorded 666 Python tests and Phase 6 recorded 798; current figures are in the table above and v0.6.5.
+The 1005 figure is the Phase 6.5 Python baseline; the install/release tests are not folded into it yet, and a full local `unittest discover` currently runs 1547 tests — per-item results are in the
+[v0.7.0 one-line install candidate record](docs/evals/releases/v0.7.0-install.md).
 
 ### Verification
 
@@ -319,6 +405,8 @@ tests/           # Python unittest suite
 | [Product requirements](docs/product/20260807_产品需求文档.md) | Scope, non-goals, and acceptance criteria |
 | [System architecture](docs/architecture/20260807_系统架构.md) | Module boundaries, data flow, and safety principles |
 | [Local setup guide](docs/getting-started/20260807_本地运行指南.md) | Installation, config, TUI, Gateway, troubleshooting |
+| [Install and release operations](docs/engineering/operations/20260809_install-release-operations.md) | Draft Release promotion, PyPI/GHCR verification, `rollback_conflict` recovery, revocation |
+| [v0.7.0 one-line install candidate](docs/evals/releases/v0.7.0-install.md) | Real gate status of the install path and the external evidence required for a final verdict (currently PENDING) |
 | [Engineering index](docs/engineering/README.md) | Implemented modules versus planned designs |
 | [Development timeline](docs/engineering/20260809_development-timeline.md) | Mapping between architecture phases, delivery versions, and evidence states |
 | [Progress page](docs/progress/index.html) | Current phase, evidence, and next work |

--- a/docs/README.md
+++ b/docs/README.md
@@ -78,6 +78,8 @@
 | [v0.7.0 发布证据](evals/releases/v0.7.0.md) | 798/798 Python、35/35 TypeScript、39/39 Agent、33/33 Channel、660/660 soak 与 15/15 Automation |
 | [Phase 6.5 Browser Agent](engineering/phase-6/browser-agent.md) | 已实现的专用 Profile、Worker、snapshot/ref、Policy/Approval、Artifact 与恢复 |
 | [v0.6.5 Browser 发布证据](evals/releases/v0.6.5.md) | 925/925 Python、14/14 Worker、18/18 Browser 与 360/360 soak |
+| [安装与发布运维手册](engineering/operations/20260809_install-release-operations.md) | 草稿 Release 提升、Trusted Publisher、镜像摘要核对、`rollback_conflict` 人工恢复与撤销流程 |
+| [v0.7.0 一行安装候选记录](evals/releases/v0.7.0-install.md) | 一行安装链路的真实门禁状态与最终判定所需的外部 `release-evidence.json`（当前 PENDING） |
 | [能力对齐工程落地总方案](engineering/20260808_openclaw-hermes-alignment-engineering-roadmap.md) | 模块、数据模型、配置、错误码、测试矩阵与各 Phase 退出条件 |
 
 ## 使用与开发

--- a/docs/architecture/20260807_系统架构.md
+++ b/docs/architecture/20260807_系统架构.md
@@ -502,6 +502,43 @@ browser-worker/
 └── test/              # 14 条协议与真实 headless Chromium 回归
 ```
 
+## 一行安装与受管 Runtime
+
+发布形态与开发形态共用同一个 Core，但安装链路是独立的：Python 分发名是 `lobster0-agent`，
+CLI、import 与状态根仍是 `lobster0`。安装事实源是 GitHub Release 上不可变的
+`release-manifest.json`，不是 PyPI，也不是任何镜像站。
+
+```mermaid
+flowchart LR
+    CURL["curl | bash<br/>install.sh"] --> UV["pinned uv<br/>+ 受管 Python 3.12"]
+    UV --> PYZ["lobster0-installer.pyz<br/>stdlib-only"]
+    PYZ --> MAN["release-manifest.json<br/>size + SHA-256"]
+    MAN --> STAGE["runtimes/&lt;version&gt; staging<br/>wheel / deps / node / tui"]
+    STAGE --> SMOKE["install-smoke<br/>+ doctor + DB guard"]
+    SMOKE --> CUR["原子切换 current"]
+    CUR --> SVC["systemd user / LaunchAgent<br/>指向稳定 launcher"]
+```
+
+分层职责：
+
+- `install.sh` 是最小 POSIX bootstrap：只按内嵌 SHA-256 建立信任根，不解析配置、不写 service、
+  不碰已有安装的 `current`，随后 `exec` 交出控制权；
+- `lobster0-installer.pyz` 是 stdlib-only 安装器：校验平台、构造 `InstallPlan`、按 manifest 下载并
+  校验每个组件、在 `runtimes/<version>` 里完成 staging；
+- 只有新 Runtime 通过 smoke、数据库保护与服务健康检查之后，才原子替换 `current`，
+  并保留 N-1 Runtime 供回滚；
+- 稳定 launcher（`~/.lobster0/bin/lobster0`，PATH 入口 `~/.local/bin/lobster0`）不随版本漂移，
+  service unit 永远指向它而不是版本目录；
+- 配置、Secret、SQLite、Memory、Skills、Workspace 与日志都不属于任何一个 Runtime。
+
+安全边界：exact argv + `shell=False`；源 URL 只能来自已验证 manifest 与固定 allowlist；
+解包拒绝绝对路径、`..`、symlink、hardlink、设备文件与目标逃逸；Secret 只从 `/dev/tty`、
+owner-only Secret 文件或现有进程环境读取，不出现在 argv、事件、receipt 或日志里。
+
+升级方向是单向的：已安装 CLI 的 `lobster0 update` 会 fail closed（`update_requires_bootstrap`），
+升级必须重新运行 pinned 安装器。这条链路当前的真实门禁状态见
+[v0.7.0 一行安装候选记录](../evals/releases/v0.7.0-install.md)。
+
 ## 当前约束与下一阶段
 
 - 单用户、一个 SQLite、一个活动 TUI Turn；默认终端链路是 Python launcher → Node UI → Python Core Bridge；

--- a/docs/engineering/operations/20260809_install-release-operations.md
+++ b/docs/engineering/operations/20260809_install-release-operations.md
@@ -1,0 +1,187 @@
+# Lobster0 安装与发布运维手册
+
+> 适用版本：`0.7.0`；Python 分发名 `lobster0-agent`；容器 `ghcr.io/nedonion/lobster0`
+>
+> 当前发布状态：**RELEASE CANDIDATE / PUBLIC GATES PENDING**，逐项证据见
+> [v0.7.0 一行安装候选记录](../../evals/releases/v0.7.0-install.md)
+
+这份手册写给执行发布和处理安装事故的人。它只描述**已经实现的代码行为**和**需要人工完成的外部
+配置**，不假设任何公共门禁已经通过。
+
+## 1. 事实源与不变量
+
+| 事实 | 唯一来源 |
+| --- | --- |
+| 版本号 | `src/lobster0/_version.py` |
+| uv / Node / pnpm 固定版本与 SHA-256 | `release/runtime-versions.json` |
+| 一行安装脚本模板 | `release/install.sh.tmpl`（由 `scripts/render_install_script.py` 渲染） |
+| Release 资产清单与 hash | Release 上的 `release-manifest.json` |
+| 已安装实例的受管文件所有权 | `~/.lobster0/install-receipt.json` |
+
+不变量：
+
+- 安装事实源是 Release 上的 immutable manifest，不是 PyPI，也不是任何镜像站；
+- 一行安装不需要预装 Python、Node.js 或 pnpm，安装器自己带 pinned uv 与受管 Python 3.12；
+- 新 Runtime 通过 smoke、数据库保护和 service health 之前不替换 `current`；
+- 卸载默认保留全部用户数据；只有 `--purge-data` 才删除枚举出来的状态路径。
+
+## 2. 发布前检查单
+
+1. 工作区干净，`git status --short` 无输出；
+2. `src/lobster0/_version.py`、`pyproject.toml`、目标 tag、manifest 与发布记录版本号一致；
+3. 同提交本地门禁全绿（`unittest`、`ruff`、`uv build`、installer zipapp、`validate_docs.py`、
+   两次 `git diff --check`）；
+4. `release/runtime-versions.json` 里四个平台的 uv archive SHA-256 未漂移；
+5. PyPI Trusted Publisher 与 GHCR 权限已按 §4、§5 配置好；
+6. Tier 1 自托管 runner 已注册——**当前实测注册数为 0**，见候选记录 §3.1。
+
+## 3. 草稿 Release 提升流程
+
+发布流水线只允许按下面顺序推进，任何一步失败都停在草稿状态：
+
+1. 推 tag `v0.7.0`，流水线构建全部资产并生成 `release-manifest.json`、`checksums.txt`、
+   两份 SBOM 与 `lobster0-installer.pyz`；
+2. 创建 **draft** Release 并上传资产；draft 阶段 `latest` 不指向它；
+3. 跑 Tier 1 安装矩阵：每个平台组合都要覆盖 fresh install、service 安装、宿主重启恢复、
+   N→N+1 升级、N-1 回滚、默认卸载；
+4. 发布 PyPI（§4）与 GHCR（§5），并把实际摘要与 manifest 逐一比对；
+5. 生成、附加并 attest `release-evidence.json`（契约见候选记录 §4）；
+6. 全部门禁都不是 PENDING 也不是 FAIL 时，才把 draft 提升为 stable，此时
+   `https://github.com/NEDONION/lobster0/releases/latest/download/install.sh` 开始生效；
+7. 提升后立刻在全新 Tier 1 主机上跑一次公网 `latest` 安装冒烟。
+
+提升后公网冒烟失败时：立即把 Release 退回 draft，记录 FAIL 证据，**不要**删除或覆盖已经不可变的
+PyPI 版本，修复走 `0.7.1`。
+
+## 4. PyPI Trusted Publisher 配置
+
+`lobster0-agent` 使用 GitHub Actions OIDC 的 Trusted Publisher，仓库里**不存放** PyPI token：
+
+1. 在 PyPI 项目设置里新增 pending publisher：owner `NEDONION`、repository `lobster0`、
+   workflow 文件名与发布 job 一致、environment 填受保护的 `pypi`；
+2. 发布 job 只在该 environment 下运行，并且只在该 job 打开 `id-token: write`；
+3. 上传后立刻在干净环境校验：`pip download lobster0-agent==0.7.0`、
+   `python -c "import lobster0"`、`lobster0 --version`；
+4. PyPI 版本不可变：一旦上传就不能替换同版本文件。
+
+## 5. GHCR 摘要核对
+
+1. 镜像名固定 `ghcr.io/nedonion/lobster0`，tag 用精确版本，不用 `latest` 做事实源；
+2. 推送后取回 manifest 摘要：
+   ```bash
+   docker buildx imagetools inspect ghcr.io/nedonion/lobster0:0.7.0
+   ```
+3. 该摘要必须与 `release-evidence.json` 的 `images[*].digest` 和 Release manifest 记录一致；
+4. 冒烟必须**按摘要**拉取（`ghcr.io/nedonion/lobster0@sha256:...`），不能按 tag，
+   并验证进程非 root、containment 生效。
+
+### 5.1 原生 bundle 构建参数（不可省略）
+
+`deploy/Dockerfile` 的 `LOBSTER0_REQUIRE_NATIVE_BUNDLES` 默认 `"0"`，此时
+`deploy/artifacts/` 缺少 TUI/Node bundle 会**静默跳过**解包，产出不含原生包的开发镜像。
+正式镜像必须显式要求原生 bundle：
+
+```bash
+docker build -f deploy/Dockerfile \
+  --build-arg LOBSTER0_REQUIRE_NATIVE_BUNDLES=1 \
+  --build-arg LOBSTER0_WHEEL_SHA256=<64 hex> \
+  -t ghcr.io/nedonion/lobster0:0.7.0 .
+```
+
+缺 bundle 时构建会显式失败。核对方法：镜像内 `/opt/lobster0/current/native-bundles-required`
+必须是 `1`，且 `/opt/lobster0/current` 下存在 TUI 与 Node 目录。开发者本机若 Node 版本低于
+`22.22.3`（或 `24.15.0`）无法构建 bundle，本机镜像必然不完整，不得用于发布。
+
+## 6. 升级、回滚与 `rollback_conflict` 人工恢复
+
+### 6.1 受支持的升级方式
+
+重新运行一行安装命令：
+
+```bash
+curl -fsSL --proto '=https' --tlsv1.2 \
+  https://github.com/NEDONION/lobster0/releases/latest/download/install.sh | bash
+```
+
+已安装 CLI 上的 `lobster0 update` 会打印 `update_requires_bootstrap` 并以退出码 2 结束。
+这是设计行为：升级流水线需要 bootstrap 建立的信任根（pinned uv 与受管 Python），而受管 Runtime
+在激活时按设计删除 `.inputs`。不要试图用 `PATH` 上的 uv 绕过它。
+
+### 6.2 自动回滚
+
+`UpdateCoordinator` 在停掉旧 service 后备份数据库、运行新 Runtime 的迁移、原子切换、再健康检查。
+任一阶段失败先停新 service，然后按 `PRAGMA data_version` 判断迁移之后有没有外部写入：
+
+- 没有外部写入：恢复数据库备份与旧 Runtime、重启旧 service，抛出原始错误；
+- 有外部写入：**不覆盖**这些数据，保留备份与当前状态，抛出 `rollback_conflict`。
+
+### 6.3 `rollback_conflict` 的人工恢复
+
+出现 `rollback_conflict` 说明升级失败，但用户在迁移之后已经写入了新数据；自动恢复会造成数据丢失，
+所以代码故意停手。人工处理顺序：
+
+1. **先停服务**：`lobster0 service status`，必要时 `lobster0 service uninstall`，
+   避免 Gateway 继续写库；
+2. **保留现场**：把 `~/.lobster0/` 下形如 `.lobster0.db.update-backup.*` 的备份文件和当前
+   `lobster0.db` 一起复制到只读位置，两个都不要删；
+3. **确认现状**：`~/.lobster0/current` 指向哪个 `runtimes/<version>`，
+   `install-receipt.json` 里的版本是否与之一致；
+4. **二选一**：
+   - 保留升级后数据 → 保持当前数据库，重新运行一行安装命令把 Runtime 补齐到目标版本；
+   - 放弃升级后数据 → 人工用备份覆盖 `lobster0.db`（同时删除 `-wal`/`-shm`），再重新安装 N-1 版本；
+5. 恢复完成后 `lobster0 doctor`，确认无误再 `lobster0 service install`；
+6. 事后把冲突时间点与选择记录进事故记录，不要让它只存在于终端历史里。
+
+Memory、Skills、Workspace 文件不参与自动回滚，任何情况下都不要用旧备份覆盖它们。
+
+## 7. 卸载与数据边界
+
+```bash
+lobster0 service uninstall
+lobster0 uninstall
+lobster0 uninstall --purge-data --yes-i-understand-data-loss
+```
+
+- 默认 `lobster0 uninstall`：停止并移除受管服务、删除受管 Runtime / launcher / receipt，
+  **保留 `~/.lobster0` 下全部用户数据**，并打印保留路径与重装方法；
+- `--purge-data` 只删除枚举出来的路径：`config.toml`、`secrets.env`、`lobster0.db`（含
+  `-wal`/`-shm`）、`SOUL.md`、`USER.md`、`MEMORY.md`，以及 `memory/`、`prompts/`、`skills/`、
+  `evals/`、`browser/`、`artifacts/`、`downloads/`、`logs/`、`run/`、`checkpoints/` 和升级备份；
+- **`workspace/` 永远保留**，即使 `--purge-data` 也不删；
+- 卸载器拒绝把 `/`、Home 根或 Workspace 当作删除目标，不跟随 symlink，不递归删除 receipt 之外的路径；
+- 非交互 `--purge-data` 还必须附带 `--yes-i-understand-data-loss`，否则 fail closed。
+
+## 8. 撤销与吊销
+
+| 场景 | 动作 |
+| --- | --- |
+| Release 资产有问题 | 把 Release 退回 draft，使 `latest` 不再指向它；修复走新版本号 |
+| PyPI 版本有问题 | 用 yank 标记该版本（yank 不删除文件，已 pin 的安装仍可解析）；修复发 `0.7.1` |
+| 镜像有问题 | 删除或停止发布该 tag，并在发布记录里登记被撤销的摘要 |
+| 凭据泄漏 | 立即在 PyPI 移除 Trusted Publisher 绑定、吊销 GHCR token，再排查 Release 资产是否被替换 |
+| 安装脚本被替换 | 停止分发该 URL，用 `scripts/verify_release_artifacts.py` 独立复核全部资产 hash |
+
+绝不通过重新上传同一版本号来"修复"已发布内容。
+
+## 9. 事故排查入口
+
+| 症状 | 首选命令 |
+| --- | --- |
+| 安装到一半失败 | 重跑一行安装命令并加 `--verbose`；用 `--dry-run` 查看计划 |
+| 想先看计划不落盘 | 一行安装命令后追加 `-s -- --dry-run` |
+| 服务不健康 | `lobster0 service status`、`lobster0 service logs`、`lobster0 doctor` |
+| 升级失败 | 见 §6 |
+| 平台不受支持 | 安装器在任何写入前返回 `unsupported_platform`，不会留下半安装状态 |
+
+稳定错误码：`unsupported_platform`、`install_locked`、`artifact_download_failed`、
+`artifact_hash_mismatch`、`manifest_invalid`、`system_dependency_missing`、`privilege_denied`、
+`runtime_install_failed`、`tui_smoke_failed`、`service_install_failed`、`doctor_blocked`、
+`activation_failed`、`rollback_conflict`、`uninstall_ownership_mismatch`、`request_invalid`、
+`plan_invalid`、`installer_error`。
+
+## 10. 相关文档
+
+- [v0.7.0 一行安装候选记录](../../evals/releases/v0.7.0-install.md)
+- [本地运行指南](../../getting-started/20260807_本地运行指南.md)
+- [系统架构](../../architecture/20260807_系统架构.md)
+- [工程文档索引](../README.md)

--- a/docs/evals/README.md
+++ b/docs/evals/README.md
@@ -62,3 +62,4 @@ Phase 6 macOS + 飞书生产验收工具已完成，仍为 **PRODUCTION SOAK PEN
 - [v0.6.1：Memory A～E + Feishu callback/continuation hardening](releases/v0.6.1.md)
 - [v0.7.0：Phase 6 Autonomy + Sandbox + Checkpoint](releases/v0.7.0.md)
 - [v0.6.5：Phase 6.5 Isolated Browser Agent capability record](releases/v0.6.5.md)
+- [v0.7.0-install：一行安装与可信发布候选记录（RELEASE CANDIDATE / PUBLIC GATES PENDING）](releases/v0.7.0-install.md)

--- a/docs/evals/releases/v0.7.0-install.md
+++ b/docs/evals/releases/v0.7.0-install.md
@@ -1,0 +1,173 @@
+# Lobster0 v0.7.0-install：一行安装与可信发布候选记录
+
+> 记录日期：2026-08-11
+>
+> 候选基线：`origin/main` 的 `90e39d3`（Task 0～16 全部合并）+ 本记录所在的文档提交
+>
+> Python 分发名：`lobster0-agent`；CLI/import/状态根：`lobster0` / `lobster0` / `~/.lobster0`
+>
+> 结论：**RELEASE CANDIDATE / PUBLIC GATES PENDING**
+
+这份记录描述"一行安装 + 可信发布"这条链路在**本机同一提交**上跑出来的结果。它**不是**发布结论。
+公共发布门禁（Tier 1 真机安装矩阵、PyPI 发布、GHCR 摘要冒烟、attestation 校验、公网 `latest`
+安装冒烟）一条都没有执行过，因此本记录的最终状态是候选，不是通过。
+
+## 1. 这份记录声明什么、不声明什么
+
+| 声明 | 状态 |
+| --- | --- |
+| 安装器、manifest、Runtime、service、update、uninstall 的**离线确定性行为**已被单元测试覆盖 | 是 |
+| 本机同一提交的 `unittest` / `ruff` / `uv build` / installer zipapp / 文档校验结果 | 是，见 §2 |
+| 一行安装命令在 Tier 1 真机上完成过 fresh / service / reboot / upgrade / rollback / uninstall | 否，见 §3 |
+| `lobster0-agent` 已发布到 PyPI、镜像已推送到 GHCR、artifact 已完成 attestation 校验 | 否，见 §3 |
+| `https://github.com/NEDONION/lobster0/releases/latest/download/install.sh` 这个 URL 现在可用 | 否，见 §3 |
+
+## 2. 同提交本地门禁（真实结果）
+
+在候选提交的干净工作区上实际执行，结果如实抄录：
+
+| Gate | 命令 | 结果 |
+| --- | --- | --- |
+| Python 单元测试 | `uv run python -m unittest discover -s tests -v` | Ran 1547 tests；除 §6 列出的既有环境问题（1 error + 3 failures，1 skipped）外全部通过 |
+| 静态检查 | `uv run ruff check .` | All checks passed |
+| Python 包构建 | `uv build` | `lobster0_agent-0.7.0-py3-none-any.whl` + `lobster0_agent-0.7.0.tar.gz` |
+| 安装器 zipapp | `uv run python scripts/build_installer_zipapp.py --output dist/lobster0-installer.pyz` | 构建成功 |
+| 文档契约 | `uv run python scripts/validate_docs.py` | 通过 |
+| 工作区/暂存区 diff | `git diff --check`、`git diff --cached --check` | 干净 |
+
+未在本机执行的计划命令：`uv sync --extra dev`（依赖锁定文件由并行的 CI/Release 任务持有）、
+`corepack pnpm --dir tui test`（本机 Node 低于 `tui/package.json` 的 `>=22.22.3 <23 || >=24.15.0 <25`
+门槛，见 §6）。
+
+**这一节的全部结果都只代表本机离线行为。** 它不能代替真机安装矩阵，也不能替换任何公共发布门禁。
+
+## 3. 未执行的公共门禁
+
+| 门禁 | 当前状态 | 阻塞原因 |
+| --- | --- | --- |
+| Tier 1 真机安装矩阵（CI job `tier1-install`） | PENDING | 本仓库自托管 runner 注册数为 0 |
+| PyPI 发布与安装后校验（`lobster0-agent`） | PENDING | 未打 tag、未发布，Trusted Publisher 未配置 |
+| GHCR 镜像摘要冒烟（non-root + containment） | PENDING | 镜像未推送，无可核对摘要 |
+| Artifact attestation 校验 | PENDING | 无 Release、无 attestation |
+| 公网 `latest` 安装冒烟 | PENDING | 仓库当前没有任何 Release 或 tag |
+
+### 3.1 Tier 1 runner 注册数实测
+
+2026-08-11 对候选仓库实测：
+
+```text
+$ gh api repos/NEDONION/lobster0/actions/runners
+{"total_count":0,"runners":[]}
+```
+
+零注册 runner 意味着 `tier1-install` 这条 job 在任何提交上都**没有运行过一次**。
+Ubuntu 22.04/24.04、Debian 12/13、RHEL/Rocky/Alma 9/10 的 x86_64/arm64 与 macOS 13+
+Intel/Apple Silicon 全部处于未验证状态。任何"Tier 1 已验证"的说法在本仓库当前都是错误的。
+
+### 3.2 Release / tag 实测
+
+同日实测 `gh api repos/NEDONION/lobster0/releases` 与 `.../tags` 均返回空数组。因此
+`https://github.com/NEDONION/lobster0/releases/latest/download/install.sh`
+目前会 404；README 里的一行安装命令描述的是 v0.7.0 发布**之后**的行为，
+在草稿 Release 提升为 stable 之前它不可用。
+
+## 4. 最终 PASS 需要的外部 `release-evidence.json`（当前 PENDING）
+
+本记录是仓库内的候选文件，**不能自证发布成功**。最终结论只能来自发布流水线生成、附加到 Release
+并完成 attestation 的 `release-evidence.json`。它必须是同一 tag、同一 commit 的产物，且满足下面的
+精确契约：
+
+```json
+{
+  "schema": "lobster0.release-evidence/1",
+  "version": "0.7.0",
+  "tag": "v0.7.0",
+  "commit": "<40 hex，等于 origin/main 上被发布的提交>",
+  "workflow_run": {"id": "<GitHub Actions run id>", "attempt": 1},
+  "verdict": "PASS",
+  "gates": [
+    {
+      "id": "tier1-install",
+      "status": "PASS",
+      "cases": {"total": 0, "passed": 0},
+      "platforms": ["ubuntu-22.04-x86_64", "macos-13-arm64"]
+    }
+  ],
+  "artifacts": [{"filename": "install.sh", "sha256": "<64 hex>"}],
+  "images": [{"reference": "ghcr.io/nedonion/lobster0:0.7.0", "digest": "sha256:<64 hex>"}],
+  "python_distribution": {"name": "lobster0-agent", "version": "0.7.0", "index": "pypi.org"}
+}
+```
+
+判定规则：
+
+- `verdict` 只有在**全部** `gates[*].status` 都不是 `PENDING` 且不是 `FAIL` 时才允许是 `PASS`；
+- `gates` 必须至少覆盖 `offline`、`node-22`、`node-24`、`artifact-build`、`tier1-install`、
+  `attestation`、`publish` 这七个 id；缺任何一个 id 视为 `PENDING`；
+- `tier1-install` 的 `platforms` 必须覆盖设计里 Tier 1 的全部组合，且每个组合都包含
+  fresh install、service 安装、宿主重启恢复、N→N+1 升级、N-1 回滚和默认卸载六个 case；
+- `commit` 必须等于 `origin/main` 上被发布的提交；不允许为了补证据再产生一次 tag 之后的提交；
+- `artifacts[*].sha256` 与 `images[*].digest` 必须与 Release manifest、PyPI 上传件和 GHCR
+  实际摘要逐一相等；
+- 校验方式是重新下载 Release 资产并用 `scripts/verify_release_artifacts.py` 独立复核，
+  而不是相信本文件或任何仓库内文档。
+
+在拿到满足上述契约的 `release-evidence.json` 之前，本记录的结论固定为
+**RELEASE CANDIDATE / PUBLIC GATES PENDING**。
+
+## 5. 必须如实记录的三条产品事实
+
+### 5.1 Tier 1 真机安装矩阵未执行
+
+见 §3 与 §3.1。零 runner、零 Release、零 tag。
+
+### 5.2 `lobster0 update` 当前 fail closed
+
+已安装的 CLI 执行 `lobster0 update` 会向 stderr 打印：
+
+```text
+error: update_requires_bootstrap
+Re-run the pinned Lobster0 installer to update; the installed Runtime intentionally keeps no bootstrap trust root.
+```
+
+退出码为 `2`。这是设计行为不是缺陷：DB-guarded 升级流水线由安装器 zipapp 驱动，而它需要 bootstrap
+建立的信任根（pinned uv 与受管 Python）。受管 Runtime 在激活时按设计删除 `.inputs`，因此已安装的 CLI
+手里没有可信 uv。此处 fail closed，而不是退化到 `PATH` 上的不可信 uv 或第二套下载逻辑。
+
+**因此当前唯一受支持的升级方式是重新运行一行安装命令。** 文档不得把 `lobster0 update` 写成可用。
+
+### 5.3 容器镜像的原生 bundle 依赖发布期构建参数
+
+`deploy/Dockerfile` 的 `LOBSTER0_REQUIRE_NATIVE_BUNDLES` 默认是 `"0"`：本地开发构建在
+`deploy/artifacts/` 缺少 TUI/Node bundle 时会静默跳过解包，产出**不含原生 bundle**的镜像。
+本机因 Node 低于门槛（§6）无法构建这些 bundle，所以本机镜像必然不完整。
+
+正式镜像必须由发布流水线用 `--build-arg LOBSTER0_REQUIRE_NATIVE_BUNDLES=1` 构建；缺 bundle 时
+构建会显式失败而不是降级。核对方法与摘要流程见
+[安装与发布运维手册](../../engineering/operations/20260809_install-release-operations.md)。
+
+## 6. 本机环境限制（不是代码缺陷）
+
+| 现象 | 事实 | 处理 |
+| --- | --- | --- |
+| `test_release_bundles.TuiBundleTest.setUpClass` 报错 | 本机 `node --version` 为 v22.19.0，低于 `tui/package.json` 要求的 22.22.3；系统 `pnpm --version` 为 7.29.2 | 环境限制，未修改代码或门槛 |
+| `test_browser_evals` 1 项、`test_cli_eval` 2 项失败 | 全新 worktree 缺少本地 `browser-worker/dist` 构建产物 | 环境限制，已在纯净 `main` 上复现 |
+| `corepack pnpm --dir tui test` 失败 | 同上 Node 门槛；`tui/node_modules` 未安装 | 环境限制，TUI 门禁留给 CI |
+
+以上三项都不构成对安装链路的否定证据，也不构成对它的肯定证据。
+
+## 7. 复现命令
+
+```bash
+uv run python -m unittest discover -s tests -v
+uv run ruff check .
+uv build
+uv run python scripts/build_installer_zipapp.py --output dist/lobster0-installer.pyz
+uv run python scripts/validate_docs.py
+git diff --check
+git diff --cached --check
+```
+
+发布期需要额外执行、且当前尚未执行的步骤见
+[安装与发布运维手册](../../engineering/operations/20260809_install-release-operations.md)。
+历史发布记录索引见 [`docs/evals/README.md`](../README.md)。

--- a/docs/getting-started/20260807_本地运行指南.md
+++ b/docs/getting-started/20260807_本地运行指南.md
@@ -50,6 +50,14 @@ Checkpoint 只覆盖主 Workspace，Rollback 暂无 CLI/TUI；Browser 默认关�
 
 ## 1. 环境要求
 
+下面两条路径的环境要求不一样：
+
+- **一行安装**（见 2.1）：只需要 `curl`、`tar`、`sha256sum` 或 `shasum` 这类基础命令，
+  **不需要预装 Python、Node.js 或 pnpm**，安装器自带 pinned uv、受管 Python 3.12 与受管 Node.js。
+- **源码开发安装**（见 2.2）：需要下面列出的全部本机依赖。
+
+源码开发安装的环境要求：
+
 - Python 3.12+；
 - Node.js 22.22.3–<23 或 24.15.0–<25 与 pnpm（默认 pi-tui；managed 默认 24.18.0）；
 - Chrome/Chromium 与 Playwright（仅 Browser Agent 需要）；
@@ -60,6 +68,49 @@ Checkpoint 只覆盖主 Workspace，Rollback 暂无 CLI/TUI；Browser 默认关�
 - TUI 对话需要 DeepSeek Key 与网络。
 
 ## 2. 安装
+
+### 2.1 一行安装（发布后的推荐路径）
+
+```bash
+curl -fsSL --proto '=https' --tlsv1.2 \
+  https://github.com/NEDONION/lobster0/releases/latest/download/install.sh | bash
+```
+
+> **状态提醒**：这条命令描述的是 v0.7.0 Release 发布之后的行为。本仓库当前没有任何 Release 或
+> tag，该 URL 会 404；一行安装链路的状态是 **RELEASE CANDIDATE / PUBLIC GATES PENDING**，
+> 真机安装矩阵尚未执行。逐项证据见
+> [v0.7.0 一行安装候选记录](../evals/releases/v0.7.0-install.md)。在此之前请用 2.2 的源码路径。
+
+一行安装的行为：
+
+- bootstrap 只负责建立信任根（按内嵌 SHA-256 校验的 pinned uv、受管 Python 3.12、Release manifest
+  与 `lobster0-installer.pyz`），随后把全部决策交给 stdlib-only 安装器；
+- 默认安装到 `~/.lobster0`，命令入口 `~/.local/bin/lobster0`；受管 Runtime 在
+  `~/.lobster0/runtimes/<version>`，`current` 只有在新 Runtime 通过 smoke、数据库保护与服务健康
+  检查之后才切换；
+- 默认不请求 sudo；需要系统包、linger 或系统级前缀时会分别展示精确计划并再次确认；
+- Python 分发名是 `lobster0-agent`，CLI、import 与状态根保持 `lobster0`；
+- 受管 Node.js 默认 24.18.0，只接受 22.22.3–<23 或 24.15.0–<25。
+
+常用参数（通过 `bash -s --` 透传）：
+
+```bash
+# 只输出计划，零写入、零下载、零 sudo、零 Secret 读取
+curl -fsSL --proto '=https' --tlsv1.2 \
+  https://github.com/NEDONION/lobster0/releases/latest/download/install.sh | bash -s -- --dry-run
+
+# 完全非交互：跳过向导、不装服务、输出 NDJSON 事件
+curl -fsSL --proto '=https' --tlsv1.2 \
+  https://github.com/NEDONION/lobster0/releases/latest/download/install.sh \
+  | bash -s -- --no-onboard --no-install-service --json \
+      --config /absolute/path/to/config.toml \
+      --secrets-file /absolute/path/to/secrets.env
+```
+
+其余参数：`--version`、`--channel stable|dev`、`--prefix`、`--system-prefix`、`--install-service`、
+`--allow-system-packages`、`--verbose`。stdin 不是 TTY 且参数不足时 fail closed。
+
+### 2.2 源码开发安装
 
 ```bash
 uv venv
@@ -76,6 +127,31 @@ Python 运行依赖包含 HTTPX 与迁移期 Textual fallback；TypeScript TUI �
 [project.scripts]
 lobster0 = "lobster0.cli:main"
 ```
+
+### 2.3 受管服务、升级与卸载
+
+受管安装完成后：
+
+| 命令 | 作用 |
+| --- | --- |
+| `lobster0 service install` | 安装并启用受管 Gateway 用户服务 |
+| `lobster0 service status` | 查看受管服务状态 |
+| `lobster0 service logs` | 读取受管服务日志 |
+| `lobster0 service restart` | 重启受管服务 |
+| `lobster0 service uninstall` | 只移除服务，保留安装与数据 |
+| `lobster0 uninstall` | 移除受管 Runtime、launcher 与 receipt，保留全部用户数据 |
+| `lobster0 uninstall --purge-data --yes-i-understand-data-loss` | 额外删除枚举出来的状态；`workspace/` 仍然保留 |
+
+**升级 = 重新运行 2.1 的一行安装命令。** `lobster0 update` 目前会打印 `update_requires_bootstrap`
+并以退出码 2 结束：升级流水线需要 bootstrap 建立的信任根，而受管 Runtime 在激活时按设计删除
+`.inputs`，因此它 fail closed，不会退化到 `PATH` 上的不可信 uv。升级失败会自动回滚；若迁移之后已
+产生新写入则返回 `rollback_conflict` 并保留现场，人工恢复步骤见
+[安装与发布运维手册](../engineering/operations/20260809_install-release-operations.md)。
+
+`--purge-data` 删除的是枚举出来的路径（`config.toml`、`secrets.env`、`lobster0.db` 及其
+`-wal`/`-shm`、`SOUL.md`、`USER.md`、`MEMORY.md`，以及 `memory/`、`prompts/`、`skills/`、`evals/`、
+`browser/`、`artifacts/`、`downloads/`、`logs/`、`run/`、`checkpoints/` 和升级备份），
+**不会**删除 `workspace/`，也不会递归删除 receipt 之外的路径。
 
 ## 3. 配置模型凭据
 

--- a/docs/product/20260807_产品需求文档.md
+++ b/docs/product/20260807_产品需求文档.md
@@ -578,6 +578,27 @@ flowchart LR
     NOTE["不开放业务端口<br/>不挂载 Home / SSH / Docker Socket"] -.-> HOST
 ```
 
+### 11.3 一行安装与分发
+
+面向普通用户的主安装方式是一行命令：
+
+```bash
+curl -fsSL --proto '=https' --tlsv1.2 \
+  https://github.com/NEDONION/lobster0/releases/latest/download/install.sh | bash
+```
+
+- Python 分发名固定 `lobster0-agent`；产品名、仓库、CLI、import 与默认状态根保持 `Lobster0` /
+  `lobster0` / `lobster0` / `~/.lobster0`；
+- 安装器自带 pinned uv、受管 Python 3.12 与受管 Node.js，不要求用户预装 Python、Node.js 或 pnpm；
+- 默认用户安装不请求 sudo；系统包、linger 与系统级前缀都要展示精确计划并单独确认；
+- 升级方式是重新运行一行安装命令；默认卸载保留全部用户数据，`--purge-data` 是唯一破坏性路径且
+  始终保留 Workspace。
+
+**该 Gap 尚未关闭。** 一行安装链路当前状态是 **RELEASE CANDIDATE / PUBLIC GATES PENDING**：真机
+安装矩阵、包发布与镜像摘要冒烟都没有执行过，本仓库也还没有任何 Release 或 tag。只有拿到发布流水线
+生成并 attest 的外部 `release-evidence.json`，才允许把这条能力标记为完成，判定契约见
+[v0.7.0 一行安装候选记录](../evals/releases/v0.7.0-install.md)。
+
 ## 12. 错误处理
 
 - 飞书事件先持久化并入队，避免超过 3 秒回调限制。
@@ -591,7 +612,8 @@ flowchart LR
 
 v0.1 发布必须同时满足：
 
-1. 新用户按 README 准备 Python 3.12 与 Node 22.19+ 后，能在 15 分钟内完成 CLI 首次对话，不计算下载和飞书应用审批时间。
+1. 新用户按 README 完成安装后（一行安装无需预装 Python/Node.js/pnpm；源码路径需要 Python 3.12 与
+   Node.js 22.22.3–<23 或 24.15.0–<25），能在 15 分钟内完成 CLI 首次对话，不计算下载和飞书应用审批时间。
 2. `lobster0 doctor` 能发现缺失模型配置、不可写 Workspace、缺失飞书变量和 SDK/schema 问题；真实凭证有效性由 live smoke 验证。
 3. CLI 和飞书消息走同一个 Agent Core。
 4. 飞书私聊可以连续完成至少 20 轮对话。

--- a/docs/progress/index.html
+++ b/docs/progress/index.html
@@ -608,12 +608,27 @@
         <div class="decision"><code>lark-cli</code><p>Channel 负责收发消息；业务查询由 Skill 生成 lark-cli argv 并经过 run_command / Policy / Approval。私有标题和 URL 进入模型前必须得到 Owner 授权。</p></div>
         <div class="decision"><code>commits</code><p><a href="https://github.com/NEDONION/lobster0/commit/c5f5e5b">c5f5e5b Worker + provenance</a> · <a href="https://github.com/NEDONION/lobster0/commit/cc31b74">cc31b74 Artifact CAS</a> · <a href="https://github.com/NEDONION/lobster0/commit/3cf3fe7">3cf3fe7 Browser gate</a></p></div>
       </article>
+      <article class="work-card">
+        <p class="eyebrow">一行安装与可信发布 · RELEASE CANDIDATE / PUBLIC GATES PENDING</p>
+        <h3>安装与发布链路</h3>
+        <p>面向普通用户的主安装方式是一行命令 <code>curl -fsSL --proto '=https' --tlsv1.2 https://github.com/NEDONION/lobster0/releases/latest/download/install.sh | bash</code>；Python 分发名是 <code>lobster0-agent</code>，CLI、import 与状态根保持 <code>lobster0</code>。</p>
+        <ul class="checklist">
+          <li class="complete">POSIX bootstrap → stdlib-only installer zipapp → 已校验 manifest → 版本化 Runtime staging</li>
+          <li class="complete">受管 Python 3.12 / Node 24.18.0 / pi-tui bundle；用户无需预装 Python、Node.js 或 pnpm</li>
+          <li class="complete">smoke + 数据库保护 + 服务健康检查通过后才原子切换 current；保留 N-1 Runtime</li>
+          <li class="complete">默认卸载保留全部用户数据；<code>--purge-data</code> 是唯一破坏性路径且始终保留 Workspace</li>
+          <li class="pending">真机安装矩阵：本仓库自托管 runner 注册数实测为 0，从未运行</li>
+          <li class="pending">包发布、镜像摘要冒烟与 attestation 校验：仓库当前没有任何 Release 或 tag，一行安装 URL 会 404</li>
+          <li class="pending">升级入口：<code>lobster0 update</code> 按设计 fail closed（<code>update_requires_bootstrap</code>），升级方式是重新运行一行安装命令</li>
+        </ul>
+        <p>判定契约与逐项证据见 <a href="../evals/releases/v0.7.0-install.md">v0.7.0 一行安装候选记录</a> 与 <a href="../engineering/operations/20260809_install-release-operations.md">安装与发布运维手册</a>。</p>
+      </article>
     </section>
 
     <footer class="footer">
       <span>Last updated · 2026-08-10 · 1005 Python + 41/41 TUI + 14/14 Worker · Agent 39/39 · Channel 33/33 · Automation 15/15 · Browser 18/18 · Phase 6 production tooling pass · soak pending</span>
       <span>Historical Phase 5 implementation pass baseline · 562 Python · 30 TypeScript · Agent 29/29 · Channel 32/32 · local soak 640/640.</span>
-      <span><a href="../engineering/phase-6/20260810_macos-feishu-production-acceptance.md">Production Runbook</a> · <a href="../engineering/phase-6/browser-agent.md">Browser Agent</a> · <a href="../evals/releases/v0.6.5.md">v0.6.5</a> · <a href="../engineering/phase-6/20260809_autonomy-runtime.md">Autonomy Runtime</a> · <a href="../engineering/phase-6/20260809_sandbox-and-checkpoint.md">Sandbox + Checkpoint</a> · <a href="../engineering/phase-5/20260809_memory-autopilot.md">Memory Autopilot</a></span>
+      <span><a href="../engineering/operations/20260809_install-release-operations.md">Install + Release Runbook</a> · <a href="../evals/releases/v0.7.0-install.md">v0.7.0 install candidate</a> · <a href="../engineering/phase-6/20260810_macos-feishu-production-acceptance.md">Production Runbook</a> · <a href="../engineering/phase-6/browser-agent.md">Browser Agent</a> · <a href="../evals/releases/v0.6.5.md">v0.6.5</a> · <a href="../engineering/phase-6/20260809_autonomy-runtime.md">Autonomy Runtime</a> · <a href="../engineering/phase-6/20260809_sandbox-and-checkpoint.md">Sandbox + Checkpoint</a> · <a href="../engineering/phase-5/20260809_memory-autopilot.md">Memory Autopilot</a></span>
     </footer>
   </main>
 </body>

--- a/scripts/validate_docs.py
+++ b/scripts/validate_docs.py
@@ -39,6 +39,8 @@ CURRENT_RELATIVE_DOCS = (
     Path("docs/evals/releases/v0.6.1.md"),
     Path("docs/evals/releases/v0.7.0.md"),
     Path("docs/evals/releases/v0.6.5.md"),
+    Path("docs/engineering/operations/20260809_install-release-operations.md"),
+    Path("docs/evals/releases/v0.7.0-install.md"),
 )
 FACT_RELATIVE_DOCS = (
     Path("README.md"),
@@ -65,6 +67,131 @@ REQUIRED_FACTS = (
     "15-CASE LIVE PENDING",
     "PRODUCTION SOAK PENDING",
 )
+INSTALL_URL = "https://github.com/NEDONION/lobster0/releases/latest/download/install.sh"
+INSTALL_CURL = "curl -fsSL --proto '=https' --tlsv1.2"
+CANDIDATE_LABEL = "RELEASE CANDIDATE / PUBLIC GATES PENDING"
+_README_INSTALL_FACTS = (
+    INSTALL_URL,
+    INSTALL_CURL,
+    CANDIDATE_LABEL,
+    "lobster0-agent",
+    "Ubuntu",
+    "22.04",
+    "24.04",
+    "Debian",
+    "Rocky",
+    "Alma",
+    "macOS",
+    "x86_64",
+    "arm64",
+    "systemd user",
+    "LaunchAgent",
+    "unsupported_platform",
+    "Windows",
+    "WSL",
+    "Alpine",
+    "22.22.3",
+    "24.15.0",
+    "24.18.0",
+    "lobster0 service install",
+    "lobster0 service logs",
+    "lobster0 service uninstall",
+    "lobster0 uninstall",
+    "--purge-data",
+    "--yes-i-understand-data-loss",
+    "--no-onboard",
+    "--no-install-service",
+    "--dry-run",
+    "--json",
+    "update_requires_bootstrap",
+    "uv sync",
+    "pnpm --dir tui",
+)
+# 每个入口文档必须自己说清一行安装、支持矩阵、Node 策略、服务/卸载语义与
+# 候选状态；缺任何一条都视为文档回归。
+INSTALL_REQUIRED_FACTS: tuple[tuple[Path, tuple[str, ...]], ...] = (
+    (Path("README.md"), _README_INSTALL_FACTS),
+    (Path("README_EN.md"), _README_INSTALL_FACTS),
+    (
+        Path("docs/getting-started/20260807_本地运行指南.md"),
+        (
+            INSTALL_URL,
+            INSTALL_CURL,
+            CANDIDATE_LABEL,
+            "lobster0-agent",
+            "22.22.3",
+            "24.18.0",
+            "update_requires_bootstrap",
+            "lobster0 service status",
+            "--purge-data",
+            "--dry-run",
+            "uv sync",
+        ),
+    ),
+    (
+        Path("docs/engineering/operations/20260809_install-release-operations.md"),
+        (
+            INSTALL_URL,
+            CANDIDATE_LABEL,
+            "release-evidence.json",
+            "Trusted Publisher",
+            "ghcr.io/nedonion/lobster0",
+            "LOBSTER0_REQUIRE_NATIVE_BUNDLES=1",
+            "rollback_conflict",
+            "update_requires_bootstrap",
+            "draft",
+            "yank",
+            "0.7.1",
+        ),
+    ),
+    (
+        Path("docs/evals/releases/v0.7.0-install.md"),
+        (
+            INSTALL_URL,
+            CANDIDATE_LABEL,
+            "release-evidence.json",
+            "actions/runners",
+            "tier1-install",
+            "update_requires_bootstrap",
+            "LOBSTER0_REQUIRE_NATIVE_BUNDLES",
+            "lobster0-agent",
+        ),
+    ),
+    (
+        Path("docs/product/20260807_产品需求文档.md"),
+        (INSTALL_URL, CANDIDATE_LABEL, "lobster0-agent"),
+    ),
+    (
+        Path("docs/architecture/20260807_系统架构.md"),
+        (
+            "install.sh",
+            "lobster0-installer.pyz",
+            "release-manifest.json",
+            "runtimes/<version>",
+            "lobster0-agent",
+        ),
+    ),
+    (
+        Path("docs/progress/index.html"),
+        (INSTALL_URL, CANDIDATE_LABEL, "lobster0-agent"),
+    ),
+)
+# 一行安装范围内的文档不得复活旧命名、旧 Node 门槛或全局 pnpm 前置条件。
+FORBIDDEN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("legacy_distribution_name", re.compile(r"name\s*=\s*\"?lobster0\"?(?![-\w])")),
+    ("legacy_node_floor", re.compile(r"(?:>=|≥)\s*`?22\.19|22\.19(?:\.\d+)?\s*\+")),
+    (
+        "global_pnpm_requirement",
+        re.compile(r"(?:全局(?:安装)?\s*pnpm|globally\s+install(?:ed)?\s+pnpm|global\s+pnpm)"),
+    ),
+)
+# 只要一行同时谈到公共发布门禁主体和 PASS，就必须在同一行说明它仍是 PENDING。
+PENDING_SUBJECT = re.compile(
+    r"(?i)(?:tier\s*1|tier1-install|self-hosted|PyPI|GHCR|ghcr\.io|attestation|"
+    r"release-evidence|Trusted Publisher|install\.sh)"
+)
+PASS_TOKEN = re.compile(r"(?<![A-Za-z])PASS(?![A-Za-z])")
+INSTALL_SCOPE_RELATIVE_DOCS = frozenset(relative for relative, _ in INSTALL_REQUIRED_FACTS)
 LINK = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
 FENCE = re.compile(r"^\s*```([^`]*)$")
 VOID_TAGS = frozenset(
@@ -144,6 +271,7 @@ def main(argv: list[str] | None = None) -> int:
             for marker in ("DESIGN READY", "IMPLEMENTATION PENDING"):
                 if marker in content:
                     failures.append(f"draft:{_display(root, path)}:{marker}")
+    failures.extend(_install_documentation_failures(root))
     html_paths = [root / "docs/progress/index.html", *arguments.html]
     for html in html_paths:
         failure = _html_failure(html)
@@ -160,6 +288,37 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     print("Documentation validation: PASS")
     return 0
+
+
+def _install_documentation_failures(root: Path) -> list[str]:
+    """校验一行安装文档契约：必需事实、被禁表述与 PENDING 门禁的诚实标注。"""
+    failures: list[str] = []
+    for relative, facts in INSTALL_REQUIRED_FACTS:
+        path = root / relative
+        if not path.is_file():
+            failures.append(f"missing:{relative.as_posix()}")
+            continue
+        content = path.read_text(encoding="utf-8")
+        for fact in facts:
+            if fact not in content:
+                failures.append(f"install_fact:{relative.as_posix()}:{fact}")
+        for label, pattern in FORBIDDEN_PATTERNS:
+            if pattern.search(content) is not None:
+                failures.append(f"forbidden:{relative.as_posix()}:{label}")
+        failures.extend(_pending_claim_failures(relative, content))
+    return failures
+
+
+def _pending_claim_failures(relative: Path, content: str) -> list[str]:
+    """拒绝把尚未执行的公共发布门禁写成已经通过。"""
+    failures: list[str] = []
+    for line_number, line in enumerate(content.splitlines(), 1):
+        if PENDING_SUBJECT.search(line) is None or PASS_TOKEN.search(line) is None:
+            continue
+        if "PENDING" in line:
+            continue
+        failures.append(f"pending_claimed_pass:{relative.as_posix()}:{line_number}")
+    return failures
 
 
 def _broken_links(root: Path, path: Path, content: str) -> list[str]:


### PR DESCRIPTION
## Summary

Milestone 10 / Task 18:面向用户的安装文档、运维手册与 v0.7.0 发布候选记录。

- README / README_EN 主安装方式改为一行 `curl | bash`,附支持平台表、Node 策略、service/update/uninstall 命令、默认卸载保留数据说明与源码开发路径。
- 新增 `docs/engineering/operations/20260809_install-release-operations.md` 运维手册:草稿 Release 提升、PyPI Trusted Publisher、GHCR 摘要核对、`rollback_conflict` 人工恢复、撤销流程、镜像构建参数要求。
- 新增 `docs/evals/releases/v0.7.0-install.md` 发布候选记录,标注为 **RELEASE CANDIDATE / PUBLIC GATES PENDING**,并定义最终 PASS 所需的外部 `release-evidence.json` 契约(schema、七个必备 gate id、`verdict: "PASS"` 仅在无 PENDING/FAIL 时合法、需重新下载资产并用 `verify_release_artifacts.py` 校验而非信任仓库内文档)。
- `scripts/validate_docs.py` 扩展断言驱动本次 RED→GREEN:改动前 71 项失败,改动后 PASS。

## 本任务的核心:不夸大未验证的事实

新增 `_pending_claim_failures` 行级规则作为**结构性防线**:任何提及 `Tier 1` / `self-hosted` / `PyPI` / `GHCR` / `attestation` / `release-evidence` / `Trusted Publisher` / `install.sh` 的行,只要含独立 `PASS` 记号,就必须同时含 `PENDING`,否则校验失败。

三条必须如实记录的事实及其落点:

1. **Tier 1 真机矩阵从未执行** —— `v0.7.0-install.md` §3 / §3.1 引用实测 `gh api .../actions/runners` 返回 `{"total_count":0}`;README/README_EN 项目状态表、产品需求文档 §11.3、运维手册 §2、进度页均有呼应。
2. **`lobster0 update` 当前 fail closed** —— `v0.7.0-install.md` §5.2 记录精确 stderr 与退出码 2;README/README_EN/入门指南/运维手册/架构文档一致说明"升级 = 重跑一行安装命令"。
3. **镜像原生 bundle 依赖发布期构建参数** —— 运维手册 §5.1 给出完整 `--build-arg LOBSTER0_REQUIRE_NATIVE_BUNDLES=1` 命令与 `/opt/lobster0/current/native-bundles-required` 校验方式。

README 中一行安装命令处带 `[!IMPORTANT]` 提示:**该 URL 目前会 404**(仓库尚无任何 Release 或 tag)。

## 计划文字与代码不符处(一律以代码为准)

- `--no-service` → 实际为 `--no-install-service`。
- 清除确认参数因二进制而异:installer pyz 用 `--confirm-data-loss`,已安装 CLI 用 `--yes-i-understand-data-loss`;文档采用用户实际会敲的 CLI 形式。
- 安装布局:设计稿的 `~/.lobster0/bin/uv` 与 `state/` 在代码中不存在,文档按 `InstallLayout` 与实际 purge 枚举集撰写。
- `lobster0 service` 实际注册 5 个子命令(含 `logs`),且已覆盖 systemd user,非"仅 macOS LaunchAgent"。

## Verification

- `validate_docs.py`:RED 71 项失败 → GREEN PASS;仓库自带的 `test_documentation` 同步跟随该转变。
- 全量 1547 项,除已知的本机 `TuiBundleTest`(Node/pnpm 门槛)与新工作区缺 `browser-worker/dist` 导致的 3 项外无其他失败。
- Ruff、`uv build`、`build_installer_zipapp.py`、两次 `git diff --check` 均通过。
- 未执行计划 Step 7/8(推 tag 与真实发布)——属用户决策,`git tag` 数为 0。
- 独立复核额外核查:全文搜索"已完成验证/已发布/Tier 1 已"等不含 `PASS` 字面量的暗示性表述,三处命中均为正确用法(禁止重传的规则、明确答"否"的表格行、以及"任何 'Tier 1 已验证' 的说法都是错误的"这句自我否定)。

## 遗留待办(已在报告中记录,不在本任务范围)

- README/PRD/进度页仍写着 `1005/1005` Python 测试数,实际已 1547(Task 0–16 累积漂移)。已在两个 README 加注说明 1005 是 Phase 6.5 基线、当前真实值为 1547,完整刷新需单独任务。
- README 版本徽章仍为 `package-v0.1.0`,未改动——在包尚未发布时改成 0.7.0 可能被误读为"已发布"。

## Checklist

- [x] 变更聚焦既定范围,未触碰并行 Task 17 的文件。
- [x] 已运行相关检查。
- [x] 未宣称任何未真实通过的门禁。
- [x] 未包含密钥、凭证或个人数据。
