### PR TITLE
ci(release): 交付 Milestone 9 Tier 1 门禁与可信发布流程

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+version: 2
+
+# Action 更新只提 PR，不自动合并：每个新的 commit SHA 都必须先被人工审阅，
+# 再写进 tests/test_install_matrix_contract.py 的已审阅名单。
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: 'ci(actions)'
+    labels:
+      - dependencies
+      - supply-chain
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: 'build(deps)'
+    labels:
+      - dependencies
+
+  - package-ecosystem: npm
+    directory: /tui
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: 'build(tui)'
+    labels:
+      - dependencies
+
+  - package-ecosystem: docker
+    directory: /deploy
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: 'build(image)'
+    labels:
+      - dependencies
+      - supply-chain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,220 @@
+name: ci
+
+# 每次 push/PR 都必须重跑与本地相同的离线门禁。
+# 这个工作流永远不响应 v* tag，也没有任何发布权限：发布只由 release.yml 承担。
+# 外部 Action 只允许出现计划已审阅的固定 commit；其余工具一律用 release/runtime-versions.json
+# 里的固定 URL 与 SHA-256 自取，避免引入未审阅的第三方 Action。
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  offline:
+    name: offline gate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - name: Check out the exact commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - name: Set up the pinned Python series
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: '3.12'
+      - name: Install the pinned uv from release/runtime-versions.json
+        run: |
+          set -euo pipefail
+          pin="$(python3 -c "import json;a=json.load(open('release/runtime-versions.json'))['uv']['archives']['linux-x86_64'];print(a['url'],a['sha256'])")"
+          curl -fsSL --proto '=https' --tlsv1.2 --retry 3 -o "${RUNNER_TEMP}/uv.tar.gz" "${pin%% *}"
+          printf '%s  %s\n' "${pin##* }" "${RUNNER_TEMP}/uv.tar.gz" | sha256sum -c -
+          mkdir -p "${RUNNER_TEMP}/uv"
+          tar -xzf "${RUNNER_TEMP}/uv.tar.gz" -C "${RUNNER_TEMP}/uv" --strip-components=1
+          echo "${RUNNER_TEMP}/uv" >> "${GITHUB_PATH}"
+      - name: Synchronize the locked development environment
+        run: |
+          set -euo pipefail
+          uv sync --locked --extra dev --extra all
+      - name: Run the workflow policy contract first
+        run: |
+          set -euo pipefail
+          uv run python -m unittest tests.test_install_matrix_contract -v
+      - name: Run the full offline unit suite
+        run: |
+          set -euo pipefail
+          uv run python -m unittest discover -s tests -q
+      - name: Run Ruff
+        run: |
+          set -euo pipefail
+          uv run --with ruff ruff check .
+      - name: Validate the documentation contract
+        run: |
+          set -euo pipefail
+          uv run python scripts/validate_docs.py
+      - name: Build the Python distributions
+        run: |
+          set -euo pipefail
+          uv build --out-dir "${RUNNER_TEMP}/dist"
+          test -f "${RUNNER_TEMP}/dist/lobster0_agent-0.7.0-py3-none-any.whl"
+          test -f "${RUNNER_TEMP}/dist/lobster0_agent-0.7.0.tar.gz"
+
+  node-22:
+    name: node 22 pi-tui
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - name: Check out the exact commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - name: Install the lowest accepted managed Node
+        env:
+          NODE_VERSION: 22.22.3
+          NODE_SHA256: c7a10d6816da8eaaa7534dd73c71c6e2b2c391dbbf845e364902d156615dd1b8
+        run: |
+          set -euo pipefail
+          curl -fsSL --proto '=https' --tlsv1.2 --retry 3 \
+            -o "${RUNNER_TEMP}/node.tar.gz" \
+            "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz"
+          printf '%s  %s\n' "${NODE_SHA256}" "${RUNNER_TEMP}/node.tar.gz" | sha256sum -c -
+          mkdir -p "${RUNNER_TEMP}/node"
+          tar -xzf "${RUNNER_TEMP}/node.tar.gz" -C "${RUNNER_TEMP}/node" --strip-components=1
+          echo "${RUNNER_TEMP}/node/bin" >> "${GITHUB_PATH}"
+      - name: Run the pi-tui suite on Node 22.22.3
+        run: |
+          set -euo pipefail
+          node --version | grep -F 'v22.22.3'
+          corepack enable
+          corepack pnpm --dir tui install --frozen-lockfile
+          corepack pnpm --dir tui test
+          corepack pnpm --dir tui build
+
+  node-24:
+    name: node 24 pi-tui
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - name: Check out the exact commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - name: Set up the pinned Python series
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: '3.12'
+      - name: Install the default managed Node
+        run: |
+          set -euo pipefail
+          pin="$(python3 -c "import json;a=json.load(open('release/runtime-versions.json'))['node']['archives']['linux-x86_64'];print(a['url'],a['sha256'])")"
+          mkdir -p "${RUNNER_TEMP}/pins"
+          curl -fsSL --proto '=https' --tlsv1.2 --retry 3 \
+            -o "${RUNNER_TEMP}/pins/node-v24.18.0-linux-x64.tar.gz" "${pin%% *}"
+          printf '%s  %s\n' "${pin##* }" \
+            "${RUNNER_TEMP}/pins/node-v24.18.0-linux-x64.tar.gz" | sha256sum -c -
+          mkdir -p "${RUNNER_TEMP}/node"
+          tar -xzf "${RUNNER_TEMP}/pins/node-v24.18.0-linux-x64.tar.gz" \
+            -C "${RUNNER_TEMP}/node" --strip-components=1
+          echo "${RUNNER_TEMP}/node/bin" >> "${GITHUB_PATH}"
+      - name: Run the pi-tui suite on Node 24.18.0
+        run: |
+          set -euo pipefail
+          node --version | grep -F 'v24.18.0'
+          corepack enable
+          corepack pnpm --dir tui install --frozen-lockfile
+          corepack pnpm --dir tui test
+          corepack pnpm --dir tui build
+      - name: Build the reproducible Node and TUI bundles
+        run: |
+          set -euo pipefail
+          python3 scripts/build_node_bundle.py \
+            --archive "${RUNNER_TEMP}/pins/node-v24.18.0-linux-x64.tar.gz" \
+            --platform linux-x86_64 \
+            --output-dir "${RUNNER_TEMP}/bundles"
+          python3 scripts/build_tui_bundle.py \
+            --platform linux-x86_64 \
+            --version 0.7.0 \
+            --node "${RUNNER_TEMP}/node/bin/node" \
+            --output-dir "${RUNNER_TEMP}/bundles"
+
+  artifact-build:
+    name: artifact reproducibility
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - name: Check out the exact commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up the pinned Python series
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: '3.12'
+      - name: Install the pinned uv from release/runtime-versions.json
+        run: |
+          set -euo pipefail
+          pin="$(python3 -c "import json;a=json.load(open('release/runtime-versions.json'))['uv']['archives']['linux-x86_64'];print(a['url'],a['sha256'])")"
+          curl -fsSL --proto '=https' --tlsv1.2 --retry 3 -o "${RUNNER_TEMP}/uv.tar.gz" "${pin%% *}"
+          printf '%s  %s\n' "${pin##* }" "${RUNNER_TEMP}/uv.tar.gz" | sha256sum -c -
+          mkdir -p "${RUNNER_TEMP}/uv"
+          tar -xzf "${RUNNER_TEMP}/uv.tar.gz" -C "${RUNNER_TEMP}/uv" --strip-components=1
+          echo "${RUNNER_TEMP}/uv" >> "${GITHUB_PATH}"
+      - name: Synchronize the locked development environment
+        run: |
+          set -euo pipefail
+          uv sync --locked --extra dev --extra all
+      - name: Prove the installer zipapp is byte reproducible
+        run: |
+          set -euo pipefail
+          uv run python scripts/build_installer_zipapp.py \
+            --output "${RUNNER_TEMP}/first-lobster0-installer.pyz"
+          uv run python scripts/build_installer_zipapp.py \
+            --output "${RUNNER_TEMP}/second-lobster0-installer.pyz"
+          first="$(sha256sum "${RUNNER_TEMP}/first-lobster0-installer.pyz" | cut -d' ' -f1)"
+          second="$(sha256sum "${RUNNER_TEMP}/second-lobster0-installer.pyz" | cut -d' ' -f1)"
+          test "${first}" = "${second}"
+      - name: Prove the Python distributions are byte reproducible
+        run: |
+          set -euo pipefail
+          SOURCE_DATE_EPOCH="$(git show -s --format=%ct HEAD)"
+          export SOURCE_DATE_EPOCH
+          uv build --out-dir "${RUNNER_TEMP}/dist-a"
+          uv build --out-dir "${RUNNER_TEMP}/dist-b"
+          (cd "${RUNNER_TEMP}/dist-a" && sha256sum ./*) > "${RUNNER_TEMP}/a.sha"
+          (cd "${RUNNER_TEMP}/dist-b" && sha256sum ./*) > "${RUNNER_TEMP}/b.sha"
+          diff -u "${RUNNER_TEMP}/a.sha" "${RUNNER_TEMP}/b.sha"
+      - name: Run the installer adversarial and offline install matrix gates
+        run: |
+          set -euo pipefail
+          uv run python -m unittest \
+            tests.test_install_artifacts \
+            tests.test_install_orchestrator \
+            tests.test_install_platforms \
+            tests.test_install_releases \
+            tests.test_installer_zipapp -q
+          uv run python tests/install_matrix/run_install_matrix.py --list
+          uv run python tests/install_matrix/run_install_matrix.py --local-offline

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,886 @@
+name: release
+
+# 受保护 v* tag 是唯一的发布入口。装配顺序被 tests/test_install_matrix_contract.py 钉死：
+#   Python/Node/TUI/images/pyz -> build_sbom.py -> build_release_manifest.py manifest
+#   -> render_install_script.py -> build_release_manifest.py checksums
+#   -> verify_release_artifacts.py -> attest -> draft Release -> Tier 1 gates -> publish
+#
+# 跨 job 的 artifact 交接一律经由「同一个 draft Release + SHA-256 复核」完成，
+# 不引入任何计划之外未审阅的 Action。draft Release 对匿名访问不可见，
+# 也不会成为 latest；只有 publish 作业在全部门禁通过后才把它翻成 stable。
+#
+# 【必须强制】发布期三条义务（来自 Task 16 复核实测）：
+#   1. deploy/Dockerfile 构建必须传 --build-arg LOBSTER0_REQUIRE_NATIVE_BUNDLES=1，
+#      否则缺失原生 Node/TUI 包只会被静默跳过。
+#   2. deploy/Dockerfile 构建必须传非空 --build-arg LOBSTER0_WHEEL_SHA256，
+#      为空时 Dockerfile 走的是「跳过校验」分支。
+#   3. wheel 必须先于镜像构建：images 作业 needs python-build，并按该作业输出的
+#      摘要重新校验取回的 wheel，杜绝用陈旧 wheel 静默打包旧代码。
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  RUNTIME_IMAGE: ghcr.io/nedonion/lobster0
+  SANDBOX_IMAGE: ghcr.io/nedonion/lobster0-sandbox
+
+jobs:
+  guard:
+    name: tag and version guard
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.facts.outputs.version }}
+      tag: ${{ steps.facts.outputs.tag }}
+      commit: ${{ steps.facts.outputs.commit }}
+      source_date_epoch: ${{ steps.facts.outputs.source_date_epoch }}
+      wheel: ${{ steps.facts.outputs.wheel }}
+      sdist: ${{ steps.facts.outputs.sdist }}
+    steps:
+      - name: Check out the tagged commit with full history
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Bind the tag, the version constant and the commit into one fact
+        id: facts
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          version="${tag#v}"
+          constant="$(python3 -c "import re,pathlib;print(re.search(r'__version__:\s*str\s*=\s*\"([^\"]+)\"',pathlib.Path('src/lobster0/_version.py').read_text(encoding='utf-8')).group(1))")"
+          test "${version}" = "${constant}"
+          printf '%s' "${version}" | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+          test -z "$(git status --porcelain)"
+          test "$(git rev-parse --verify "${tag}^{commit}")" = "$(git rev-parse HEAD)"
+          commit="$(git rev-parse HEAD)"
+          epoch="$(git show -s --format=%ct "${tag}^{commit}")"
+          echo "SOURCE_DATE_EPOCH=${epoch}" >> "${GITHUB_ENV}"
+          {
+            echo "version=${version}"
+            echo "tag=${tag}"
+            echo "commit=${commit}"
+            echo "source_date_epoch=${epoch}"
+            echo "wheel=lobster0_agent-${version}-py3-none-any.whl"
+            echo "sdist=lobster0_agent-${version}.tar.gz"
+          } >> "${GITHUB_OUTPUT}"
+
+  offline-gate:
+    name: offline gate on the tagged commit
+    needs: [guard]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: Check out the tagged commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - name: Set up the pinned Python series
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: '3.12'
+      - name: Install the pinned uv
+        run: |
+          set -euo pipefail
+          pin="$(python3 -c "import json;a=json.load(open('release/runtime-versions.json'))['uv']['archives']['linux-x86_64'];print(a['url'],a['sha256'])")"
+          curl -fsSL --proto '=https' --tlsv1.2 --retry 3 -o "${RUNNER_TEMP}/uv.tar.gz" "${pin%% *}"
+          printf '%s  %s\n' "${pin##* }" "${RUNNER_TEMP}/uv.tar.gz" | sha256sum -c -
+          mkdir -p "${RUNNER_TEMP}/uv"
+          tar -xzf "${RUNNER_TEMP}/uv.tar.gz" -C "${RUNNER_TEMP}/uv" --strip-components=1
+          echo "${RUNNER_TEMP}/uv" >> "${GITHUB_PATH}"
+      - name: Rerun the complete offline gate
+        run: |
+          set -euo pipefail
+          uv sync --locked --extra dev --extra all
+          uv run python -m unittest discover -s tests -q
+          uv run --with ruff ruff check .
+          uv run python scripts/validate_docs.py
+          uv run python tests/install_matrix/run_install_matrix.py --local-offline
+
+  draft-release:
+    name: create the immutable draft release shell
+    needs: [guard, offline-gate]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAG: ${{ needs.guard.outputs.tag }}
+    steps:
+      - name: Check out the tagged commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - name: Create the draft release that carries every candidate artifact
+        run: |
+          set -euo pipefail
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            state="$(gh release view "${TAG}" --json isDraft --jq '.isDraft')"
+            test "${state}" = "true"
+          else
+            gh release create "${TAG}" \
+              --draft \
+              --title "Lobster0 ${TAG}" \
+              --notes "Release candidate for ${TAG}. Not promoted until every Tier 1 gate passes."
+          fi
+
+  python-build:
+    name: build the Python distributions
+    needs: [guard, offline-gate, draft-release]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: write
+    outputs:
+      wheel_sha256: ${{ steps.dist.outputs.wheel_sha256 }}
+      sdist_sha256: ${{ steps.dist.outputs.sdist_sha256 }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAG: ${{ needs.guard.outputs.tag }}
+      WHEEL: ${{ needs.guard.outputs.wheel }}
+      SDIST: ${{ needs.guard.outputs.sdist }}
+      SOURCE_DATE_EPOCH: ${{ needs.guard.outputs.source_date_epoch }}
+    steps:
+      - name: Check out the tagged commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - name: Set up the pinned Python series
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: '3.12'
+      - name: Install the pinned uv
+        run: |
+          set -euo pipefail
+          pin="$(python3 -c "import json;a=json.load(open('release/runtime-versions.json'))['uv']['archives']['linux-x86_64'];print(a['url'],a['sha256'])")"
+          curl -fsSL --proto '=https' --tlsv1.2 --retry 3 -o "${RUNNER_TEMP}/uv.tar.gz" "${pin%% *}"
+          printf '%s  %s\n' "${pin##* }" "${RUNNER_TEMP}/uv.tar.gz" | sha256sum -c -
+          mkdir -p "${RUNNER_TEMP}/uv"
+          tar -xzf "${RUNNER_TEMP}/uv.tar.gz" -C "${RUNNER_TEMP}/uv" --strip-components=1
+          echo "${RUNNER_TEMP}/uv" >> "${GITHUB_PATH}"
+      - name: Build the wheel and sdist from the tagged tree
+        id: dist
+        run: |
+          set -euo pipefail
+          uv build --out-dir dist
+          test -f "dist/${WHEEL}"
+          test -f "dist/${SDIST}"
+          wheel_sha256="$(sha256sum "dist/${WHEEL}" | cut -d' ' -f1)"
+          sdist_sha256="$(sha256sum "dist/${SDIST}" | cut -d' ' -f1)"
+          {
+            echo "wheel_sha256=${wheel_sha256}"
+            echo "sdist_sha256=${sdist_sha256}"
+          } >> "${GITHUB_OUTPUT}"
+          gh release upload "${TAG}" "dist/${WHEEL}" "dist/${SDIST}" --clobber
+
+  node-bundles:
+    name: managed Node bundle
+    needs: [guard, draft-release]
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - platform: linux-x86_64
+            runner: ubuntu-24.04
+          - platform: linux-arm64
+            runner: ubuntu-24.04-arm
+          - platform: macos-x86_64
+            runner: macos-13
+          - platform: macos-arm64
+            runner: macos-14
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAG: ${{ needs.guard.outputs.tag }}
+      PLATFORM: ${{ matrix.platform }}
+    steps:
+      - name: Check out the tagged commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - name: Set up the pinned Python series
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: '3.12'
+      - name: Fetch and verify the pinned upstream Node archive
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/pins"
+          pin="$(python3 -c "import json,os;a=json.load(open('release/runtime-versions.json'))['node']['archives'][os.environ['PLATFORM']];print(a['url'],a['sha256'])")"
+          name="$(basename "${pin%% *}")"
+          curl -fsSL --proto '=https' --tlsv1.2 --retry 3 \
+            -o "${RUNNER_TEMP}/pins/${name}" "${pin%% *}"
+          printf '%s  %s\n' "${pin##* }" "${RUNNER_TEMP}/pins/${name}" | shasum -a 256 -c -
+          echo "NODE_ARCHIVE=${RUNNER_TEMP}/pins/${name}" >> "${GITHUB_ENV}"
+      - name: Build the deterministic managed Node bundle
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/bundles"
+          python3 scripts/build_node_bundle.py \
+            --archive "${NODE_ARCHIVE}" \
+            --platform "${PLATFORM}" \
+            --output-dir "${RUNNER_TEMP}/bundles"
+      - name: Hand the bundle over through the draft release with its digest
+        run: |
+          set -euo pipefail
+          bundle="$(ls "${RUNNER_TEMP}/bundles"/lobster0-node-*.tar.gz)"
+          shasum -a 256 "${bundle}" | cut -d' ' -f1 > "${bundle}.sha256"
+          gh release upload "${TAG}" "${bundle}" "${bundle}.sha256" --clobber
+
+  tui-bundles:
+    name: platform pi-tui bundle
+    needs: [guard, draft-release, node-bundles]
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - platform: linux-x86_64
+            runner: ubuntu-24.04
+          - platform: linux-arm64
+            runner: ubuntu-24.04-arm
+          - platform: macos-x86_64
+            runner: macos-13
+          - platform: macos-arm64
+            runner: macos-14
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAG: ${{ needs.guard.outputs.tag }}
+      VERSION: ${{ needs.guard.outputs.version }}
+      PLATFORM: ${{ matrix.platform }}
+    steps:
+      - name: Check out the tagged commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - name: Set up the pinned Python series
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: '3.12'
+      - name: Install the default managed Node for this platform
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/pins" "${RUNNER_TEMP}/node"
+          pin="$(python3 -c "import json,os;a=json.load(open('release/runtime-versions.json'))['node']['archives'][os.environ['PLATFORM']];print(a['url'],a['sha256'])")"
+          name="$(basename "${pin%% *}")"
+          curl -fsSL --proto '=https' --tlsv1.2 --retry 3 \
+            -o "${RUNNER_TEMP}/pins/${name}" "${pin%% *}"
+          printf '%s  %s\n' "${pin##* }" "${RUNNER_TEMP}/pins/${name}" | shasum -a 256 -c -
+          tar -xzf "${RUNNER_TEMP}/pins/${name}" -C "${RUNNER_TEMP}/node" --strip-components=1
+          echo "${RUNNER_TEMP}/node/bin" >> "${GITHUB_PATH}"
+      - name: Build the deterministic pi-tui bundle
+        run: |
+          set -euo pipefail
+          node --version | grep -F 'v24.18.0'
+          corepack enable
+          mkdir -p "${RUNNER_TEMP}/bundles"
+          python3 scripts/build_tui_bundle.py \
+            --platform "${PLATFORM}" \
+            --version "${VERSION}" \
+            --node "${RUNNER_TEMP}/node/bin/node" \
+            --output-dir "${RUNNER_TEMP}/bundles"
+      - name: Hand the bundle over through the draft release with its digest
+        run: |
+          set -euo pipefail
+          bundle="$(ls "${RUNNER_TEMP}/bundles"/lobster0-tui-*.tar.gz)"
+          shasum -a 256 "${bundle}" | cut -d' ' -f1 > "${bundle}.sha256"
+          gh release upload "${TAG}" "${bundle}" "${bundle}.sha256" --clobber
+
+  images:
+    name: non-root container images
+    needs: [guard, python-build, node-bundles, tui-bundles]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: write
+      packages: write
+    outputs:
+      runtime_digest: ${{ steps.build.outputs.runtime_digest }}
+      sandbox_digest: ${{ steps.build.outputs.sandbox_digest }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAG: ${{ needs.guard.outputs.tag }}
+      VERSION: ${{ needs.guard.outputs.version }}
+      WHEEL: ${{ needs.guard.outputs.wheel }}
+    steps:
+      - name: Check out the tagged commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - name: Take back the freshly built wheel and pin it to the build job digest
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          gh release download "${TAG}" --pattern "${WHEEL}" --dir dist --clobber
+          printf '%s  %s\n' \
+            "${{ needs.python-build.outputs.wheel_sha256 }}" "dist/${WHEEL}" | sha256sum -c -
+      - name: Take back the linux native bundles for this image
+        run: |
+          set -euo pipefail
+          mkdir -p deploy/artifacts
+          for name in \
+            "lobster0-node-24.18.0-linux-x86_64.tar.gz" \
+            "lobster0-tui-${VERSION}-linux-x86_64.tar.gz"; do
+            gh release download "${TAG}" --pattern "${name}" --dir deploy/artifacts --clobber
+            gh release download "${TAG}" --pattern "${name}.sha256" \
+              --dir "${RUNNER_TEMP}" --clobber
+            printf '%s  %s\n' "$(cat "${RUNNER_TEMP}/${name}.sha256")" \
+              "deploy/artifacts/${name}" | sha256sum -c -
+          done
+      - name: Authenticate to the registry with the short-lived workflow token
+        run: |
+          set -euo pipefail
+          printf '%s' '${{ secrets.GITHUB_TOKEN }}' \
+            | docker login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin
+      - name: Build and push both images by digest only
+        id: build
+        run: |
+          set -euo pipefail
+          docker buildx create --name lobster0-release --driver docker-container --use
+          docker buildx build \
+            --file deploy/Dockerfile \
+            --build-arg LOBSTER0_REQUIRE_NATIVE_BUNDLES=1 \
+            --build-arg LOBSTER0_WHEEL_SHA256=${{ needs.python-build.outputs.wheel_sha256 }} \
+            --build-arg LOBSTER0_TUI_BUNDLE="lobster0-tui-${VERSION}-linux-x86_64.tar.gz" \
+            --build-arg LOBSTER0_NODE_BUNDLE="lobster0-node-24.18.0-linux-x86_64.tar.gz" \
+            --provenance false \
+            --metadata-file "${RUNNER_TEMP}/runtime-metadata.json" \
+            --output "type=image,name=${RUNTIME_IMAGE},push-by-digest=true,name-canonical=true,push=true" \
+            .
+          docker buildx build \
+            --file deploy/sandbox.Dockerfile \
+            --provenance false \
+            --metadata-file "${RUNNER_TEMP}/sandbox-metadata.json" \
+            --output "type=image,name=${SANDBOX_IMAGE},push-by-digest=true,name-canonical=true,push=true" \
+            .
+          runtime_digest="$(python3 -c "import json,os;print(json.load(open(os.environ['RUNNER_TEMP']+'/runtime-metadata.json'))['containerimage.digest'])")"
+          sandbox_digest="$(python3 -c "import json,os;print(json.load(open(os.environ['RUNNER_TEMP']+'/sandbox-metadata.json'))['containerimage.digest'])")"
+          {
+            echo "runtime_digest=${runtime_digest}"
+            echo "sandbox_digest=${sandbox_digest}"
+          } >> "${GITHUB_OUTPUT}"
+      - name: Hand the image digests over through the draft release
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/digests"
+          printf '%s@%s' "${RUNTIME_IMAGE}" "${{ steps.build.outputs.runtime_digest }}" \
+            > "${RUNNER_TEMP}/digests/lobster0-runtime-image-${VERSION}.txt"
+          printf '%s@%s' "${SANDBOX_IMAGE}" "${{ steps.build.outputs.sandbox_digest }}" \
+            > "${RUNNER_TEMP}/digests/lobster0-sandbox-image-${VERSION}.txt"
+          gh release upload "${TAG}" \
+            "${RUNNER_TEMP}/digests/lobster0-runtime-image-${VERSION}.txt" \
+            "${RUNNER_TEMP}/digests/lobster0-sandbox-image-${VERSION}.txt" --clobber
+
+  assemble:
+    name: assemble and independently verify the release
+    needs: [guard, python-build, node-bundles, tui-bundles, images]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: write
+    outputs:
+      manifest_sha256: ${{ steps.verify.outputs.manifest_sha256 }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAG: ${{ needs.guard.outputs.tag }}
+      VERSION: ${{ needs.guard.outputs.version }}
+      WHEEL: ${{ needs.guard.outputs.wheel }}
+      SDIST: ${{ needs.guard.outputs.sdist }}
+      SOURCE_DATE_EPOCH: ${{ needs.guard.outputs.source_date_epoch }}
+    steps:
+      - name: Check out the tagged commit with full history
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up the pinned Python series
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: '3.12'
+      - name: Install the pinned uv
+        run: |
+          set -euo pipefail
+          pin="$(python3 -c "import json;a=json.load(open('release/runtime-versions.json'))['uv']['archives']['linux-x86_64'];print(a['url'],a['sha256'])")"
+          curl -fsSL --proto '=https' --tlsv1.2 --retry 3 -o "${RUNNER_TEMP}/uv.tar.gz" "${pin%% *}"
+          printf '%s  %s\n' "${pin##* }" "${RUNNER_TEMP}/uv.tar.gz" | sha256sum -c -
+          mkdir -p "${RUNNER_TEMP}/uv"
+          tar -xzf "${RUNNER_TEMP}/uv.tar.gz" -C "${RUNNER_TEMP}/uv" --strip-components=1
+          echo "${RUNNER_TEMP}/uv" >> "${GITHUB_PATH}"
+      - name: Collect every candidate artifact into one closed-world directory
+        run: |
+          set -euo pipefail
+          mkdir -p release-artifacts
+          cp requirements-all.lock release-artifacts/requirements-all.lock
+          python3 scripts/build_installer_zipapp.py \
+            --output release-artifacts/lobster0-installer.pyz
+          gh release download "${TAG}" --dir "${RUNNER_TEMP}/incoming" --clobber \
+            --pattern "${WHEEL}" \
+            --pattern "${SDIST}" \
+            --pattern 'lobster0-node-*.tar.gz' \
+            --pattern 'lobster0-tui-*.tar.gz' \
+            --pattern 'lobster0-*-image-*.txt' \
+            --pattern '*.sha256'
+          for bundle in "${RUNNER_TEMP}/incoming"/lobster0-*.tar.gz; do
+            printf '%s  %s\n' "$(cat "${bundle}.sha256")" "${bundle}" | sha256sum -c -
+          done
+          printf '%s  %s\n' "${{ needs.python-build.outputs.wheel_sha256 }}" \
+            "${RUNNER_TEMP}/incoming/${WHEEL}" | sha256sum -c -
+          printf '%s  %s\n' "${{ needs.python-build.outputs.sdist_sha256 }}" \
+            "${RUNNER_TEMP}/incoming/${SDIST}" | sha256sum -c -
+          grep -Fq "${{ needs.images.outputs.runtime_digest }}" \
+            "${RUNNER_TEMP}/incoming/lobster0-runtime-image-${VERSION}.txt"
+          grep -Fq "${{ needs.images.outputs.sandbox_digest }}" \
+            "${RUNNER_TEMP}/incoming/lobster0-sandbox-image-${VERSION}.txt"
+          find "${RUNNER_TEMP}/incoming" -maxdepth 1 -type f ! -name '*.sha256' \
+            -exec cp {} release-artifacts/ \;
+      - name: Generate both SBOM documents from the locked dependency set
+        run: |
+          set -euo pipefail
+          uv export --locked --all-extras --no-dev --no-emit-project \
+            --format cyclonedx1.5 --output-file "${RUNNER_TEMP}/python-components.json"
+          artifacts=()
+          for path in release-artifacts/*; do
+            artifacts+=(--artifact "${path}")
+          done
+          python3 scripts/build_sbom.py \
+            --version "${VERSION}" \
+            --git-commit "${{ needs.guard.outputs.commit }}" \
+            --source-date-epoch "${SOURCE_DATE_EPOCH}" \
+            --python-components "${RUNNER_TEMP}/python-components.json" \
+            --requirements-lock requirements-all.lock \
+            "${artifacts[@]}" \
+            --image-digest "release-artifacts/lobster0-runtime-image-${VERSION}.txt" \
+            --image-digest "release-artifacts/lobster0-sandbox-image-${VERSION}.txt" \
+            --cyclonedx-output "release-artifacts/lobster0-${VERSION}-sbom.cyclonedx.json" \
+            --spdx-output "release-artifacts/lobster0-${VERSION}-sbom.spdx.json"
+      - name: Build the closed-world release manifest
+        run: |
+          set -euo pipefail
+          printf '#!/bin/sh\nexit 0\n' > install.sh
+          chmod 0755 install.sh
+          uv run --locked python scripts/build_release_manifest.py \
+            --artifact-dir release-artifacts \
+            --install-script install.sh \
+            --output release-manifest.json \
+            manifest --release-inputs-output release-inputs.json
+      - name: Render the pinned one-line bootstrap from the manifest facts
+        run: |
+          set -euo pipefail
+          python3 scripts/render_install_script.py \
+            --fixture release-inputs.json \
+            --output install.sh
+      - name: Build the checksums that cover the manifest, bootstrap and artifacts
+        run: |
+          set -euo pipefail
+          uv run --locked python scripts/build_release_manifest.py \
+            --artifact-dir release-artifacts \
+            --install-script install.sh \
+            --output SHA256SUMS \
+            checksums --manifest release-manifest.json
+      - name: Independently verify the candidate release from disk
+        id: verify
+        run: |
+          set -euo pipefail
+          python3 scripts/verify_release_artifacts.py \
+            --manifest release-manifest.json \
+            --schema release/manifest.schema.json \
+            --artifact-dir release-artifacts \
+            --checksums SHA256SUMS \
+            --install-script install.sh
+          manifest_sha256="$(sha256sum release-manifest.json | cut -d' ' -f1)"
+          echo "manifest_sha256=${manifest_sha256}" >> "${GITHUB_OUTPUT}"
+      - name: Publish the verified set into the draft release
+        run: |
+          set -euo pipefail
+          gh release upload "${TAG}" \
+            release-manifest.json \
+            SHA256SUMS \
+            install.sh \
+            release-artifacts/lobster0-installer.pyz \
+            release-artifacts/requirements-all.lock \
+            "release-artifacts/lobster0-${VERSION}-sbom.cyclonedx.json" \
+            "release-artifacts/lobster0-${VERSION}-sbom.spdx.json" --clobber
+
+  attestation:
+    name: attest every release subject
+    needs: [guard, assemble]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAG: ${{ needs.guard.outputs.tag }}
+      VERSION: ${{ needs.guard.outputs.version }}
+    steps:
+      - name: Check out the tagged commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - name: Take back the verified release set and recheck every digest
+        run: |
+          set -euo pipefail
+          mkdir -p subjects
+          gh release download "${TAG}" --dir subjects --clobber
+          rm -f subjects/*.sha256
+          (cd subjects && sha256sum -c SHA256SUMS)
+          test "$(sha256sum subjects/release-manifest.json | cut -d' ' -f1)" \
+            = "${{ needs.assemble.outputs.manifest_sha256 }}"
+      - name: Record the build provenance predicate for this run
+        run: |
+          set -euo pipefail
+          python3 - <<'PREDICATE' > "${RUNNER_TEMP}/predicate.json"
+          import json
+          import os
+
+          print(
+              json.dumps(
+                  {
+                      "buildDefinition": {
+                          "buildType": "https://github.com/NEDONION/lobster0/release",
+                          "externalParameters": {
+                              "repository": os.environ["GITHUB_REPOSITORY"],
+                              "ref": os.environ["GITHUB_REF"],
+                              "commit": os.environ["GITHUB_SHA"],
+                          },
+                      },
+                      "runDetails": {
+                          "builder": {
+                              "id": "https://github.com/actions/runner/github-hosted"
+                          },
+                          "metadata": {
+                              "invocationId": os.environ["GITHUB_RUN_ID"],
+                          },
+                      },
+                  },
+                  sort_keys=True,
+              )
+          )
+          PREDICATE
+      - name: Attest the manifest, bootstrap, checksums and every artifact
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d
+        with:
+          subject-path: |
+            subjects/release-manifest.json
+            subjects/SHA256SUMS
+            subjects/install.sh
+            subjects/lobster0-installer.pyz
+            subjects/requirements-all.lock
+            subjects/lobster0_agent-*.whl
+            subjects/lobster0_agent-*.tar.gz
+            subjects/lobster0-node-*.tar.gz
+            subjects/lobster0-tui-*.tar.gz
+            subjects/lobster0-*-sbom.*.json
+            subjects/lobster0-*-image-*.txt
+          predicate-type: https://slsa.dev/provenance/v1
+          predicate-path: ${{ runner.temp }}/predicate.json
+
+  tier1-runner-preflight:
+    name: Tier 1 self-hosted runner preflight
+    needs: [guard]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    outputs:
+      platforms: ${{ steps.preflight.outputs.platforms }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAG: ${{ needs.guard.outputs.tag }}
+    steps:
+      - name: Check out the tagged commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - name: Set up the pinned Python series
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: '3.12'
+      # 这一步是「自托管组合不可用必须阻断 stable 发布」的落点。
+      # 本仓库当前注册的自托管 runner 数为 0，而且 GITHUB_TOKEN 也没有列举 runner 的
+      # administration 权限，因此这一步必然失败，tier1-install 与 publish 随之被跳过：
+      # 缺席的 Tier 1 组合以 PENDING 记录在 evidence 里，绝不会被当成通过。
+      - name: Require every declared Tier 1 label set to be registered and idle
+        id: preflight
+        run: |
+          set -euo pipefail
+          required="$(python3 tests/install_matrix/run_install_matrix.py --required-runner-labels)"
+          printf '%s' "${required}" > "${RUNNER_TEMP}/required.json"
+          if ! gh api "repos/${GITHUB_REPOSITORY}/actions/runners" --paginate \
+              > "${RUNNER_TEMP}/registered.json" 2>"${RUNNER_TEMP}/registered.err"; then
+            printf '[]' > "${RUNNER_TEMP}/registered.json"
+          fi
+          python3 - <<'CHECK'
+          import json
+          import os
+          import sys
+
+          temp = os.environ["RUNNER_TEMP"]
+          required = json.load(open(f"{temp}/required.json", encoding="utf-8"))
+          try:
+              payload = json.load(open(f"{temp}/registered.json", encoding="utf-8"))
+          except json.JSONDecodeError:
+              payload = []
+          runners = payload.get("runners", []) if isinstance(payload, dict) else []
+          available = [
+              {str(label["name"]).lower() for label in runner.get("labels", [])}
+              for runner in runners
+              if runner.get("status") == "online"
+          ]
+          missing = [
+              entry["id"]
+              for entry in required
+              if not any(
+                  {label.lower() for label in entry["runner_labels"]} <= labels
+                  for labels in available
+              )
+          ]
+          evidence = {
+              "schema_version": 1,
+              "gate": "tier1-install",
+              "required_combinations": len(required),
+              "registered_online_runners": len(available),
+              "missing_combinations": missing,
+              "status": "PASS" if not missing else "PENDING",
+          }
+          with open("release-evidence.json", "w", encoding="utf-8") as handle:
+              json.dump(evidence, handle, ensure_ascii=False, indent=2, sort_keys=True)
+              handle.write("\n")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as handle:
+              handle.write(f"platforms={json.dumps(required)}\n")
+          with open(f"{temp}/missing.txt", "w", encoding="utf-8") as handle:
+              for name in missing:
+                  handle.write(f"PENDING {name}\n")
+          sys.stdout.write(json.dumps(evidence, sort_keys=True) + "\n")
+          CHECK
+          cat release-evidence.json >> "${GITHUB_STEP_SUMMARY}"
+          if [ -s "${RUNNER_TEMP}/missing.txt" ]; then
+            echo "PENDING: Tier 1 self-hosted combinations below are not registered and" >&2
+            echo "online, so stable promotion is blocked for this tag." >&2
+            cat "${RUNNER_TEMP}/missing.txt" >&2
+            exit 1
+          fi
+
+  tier1-install:
+    name: Tier 1 install matrix
+    needs: [guard, assemble, attestation, tier1-runner-preflight]
+    runs-on: ${{ matrix.platform.runner_labels }}
+    timeout-minutes: 180
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: true
+      matrix:
+        platform: ${{ fromJSON(needs.tier1-runner-preflight.outputs.platforms) }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAG: ${{ needs.guard.outputs.tag }}
+    steps:
+      - name: Check out the tagged commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - name: Install from the draft release bootstrap and verify its digest
+        run: |
+          set -euo pipefail
+          gh release download "${TAG}" --dir "${RUNNER_TEMP}/bootstrap" --clobber \
+            --pattern 'install.sh' --pattern 'SHA256SUMS'
+          (cd "${RUNNER_TEMP}/bootstrap" && grep -F '  install.sh' SHA256SUMS | shasum -a 256 -c -)
+          sh "${RUNNER_TEMP}/bootstrap/install.sh" --no-onboard --install-service
+      - name: Run every Tier 1 install matrix case on this host
+        run: |
+          set -euo pipefail
+          python3 tests/install_matrix/run_install_matrix.py \
+            --all-cases \
+            --platform "${{ matrix.platform.id }}" \
+            --release-tag "${TAG}" \
+            --evidence-output "${RUNNER_TEMP}/tier1-evidence.json"
+          cat "${RUNNER_TEMP}/tier1-evidence.json"
+
+  publish:
+    name: promote the release
+    needs: [guard, images, assemble, attestation, tier1-install]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    environment: pypi
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+      attestations: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAG: ${{ needs.guard.outputs.tag }}
+      VERSION: ${{ needs.guard.outputs.version }}
+      WHEEL: ${{ needs.guard.outputs.wheel }}
+      SDIST: ${{ needs.guard.outputs.sdist }}
+    steps:
+      - name: Check out the tagged commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - name: Take back the verified release set and recheck every digest
+        run: |
+          set -euo pipefail
+          mkdir -p candidate
+          gh release download "${TAG}" --dir candidate --clobber
+          rm -f candidate/*.sha256
+          (cd candidate && sha256sum -c SHA256SUMS)
+          test "$(sha256sum candidate/release-manifest.json | cut -d' ' -f1)" \
+            = "${{ needs.assemble.outputs.manifest_sha256 }}"
+      - name: Verify the published attestations before anything leaves the repository
+        run: |
+          set -euo pipefail
+          for subject in candidate/release-manifest.json candidate/SHA256SUMS \
+              candidate/install.sh "candidate/${WHEEL}" "candidate/${SDIST}"; do
+            gh attestation verify "${subject}" --repo "${GITHUB_REPOSITORY}"
+          done
+      - name: Stage exactly the two distributions for trusted publishing
+        run: |
+          set -euo pipefail
+          mkdir -p pypi-dist
+          cp "candidate/${WHEEL}" "candidate/${SDIST}" pypi-dist/
+          test "$(ls pypi-dist | wc -l)" -eq 2
+      - name: Publish to PyPI through OIDC trusted publishing
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+        with:
+          packages-dir: pypi-dist
+          print-hash: true
+      - name: Authenticate to the registry with the short-lived workflow token
+        run: |
+          set -euo pipefail
+          printf '%s' '${{ secrets.GITHUB_TOKEN }}' \
+            | docker login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin
+      - name: Promote the gated image digests to their release tags
+        run: |
+          set -euo pipefail
+          runtime="$(cat "candidate/lobster0-runtime-image-${VERSION}.txt")"
+          sandbox="$(cat "candidate/lobster0-sandbox-image-${VERSION}.txt")"
+          test "${runtime}" = "${RUNTIME_IMAGE}@${{ needs.images.outputs.runtime_digest }}"
+          test "${sandbox}" = "${SANDBOX_IMAGE}@${{ needs.images.outputs.sandbox_digest }}"
+          docker buildx imagetools create --tag "${RUNTIME_IMAGE}:${VERSION}" "${runtime}"
+          docker buildx imagetools create --tag "${SANDBOX_IMAGE}:${VERSION}" "${sandbox}"
+      - name: Write, attach and attest the canonical release evidence
+        run: |
+          set -euo pipefail
+          python3 - <<'EVIDENCE' > release-evidence.json
+          import json
+          import os
+
+          print(
+              json.dumps(
+                  {
+                      "schema_version": 1,
+                      "product": "lobster0",
+                      "version": os.environ["VERSION"],
+                      "release_tag": os.environ["TAG"],
+                      "commit": os.environ["GITHUB_SHA"],
+                      "workflow_run": os.environ["GITHUB_RUN_ID"],
+                      "manifest_sha256": os.environ["MANIFEST_SHA256"],
+                      "runtime_image": os.environ["RUNTIME_DIGEST"],
+                      "sandbox_image": os.environ["SANDBOX_DIGEST"],
+                      "tier1_cases": int(os.environ["TIER1_CASES"]),
+                      "status": "PASS",
+                  },
+                  ensure_ascii=False,
+                  indent=2,
+                  sort_keys=True,
+              )
+          )
+          EVIDENCE
+          gh release upload "${TAG}" release-evidence.json --clobber
+        env:
+          MANIFEST_SHA256: ${{ needs.assemble.outputs.manifest_sha256 }}
+          RUNTIME_DIGEST: ${{ needs.images.outputs.runtime_digest }}
+          SANDBOX_DIGEST: ${{ needs.images.outputs.sandbox_digest }}
+          TIER1_CASES: 15
+      - name: Promote the draft release to stable
+        run: |
+          set -euo pipefail
+          gh release edit "${TAG}" --draft=false --latest
+
+  public-smoke:
+    name: public one-line install smoke
+    needs: [guard, publish]
+    runs-on: [self-hosted, linux, x64, ubuntu-24.04]
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    env:
+      VERSION: ${{ needs.guard.outputs.version }}
+    steps:
+      - name: Install from the public stable URL on a fresh Tier 1 host
+        run: |
+          set -euo pipefail
+          curl -fsSL --proto '=https' --tlsv1.2 \
+            https://github.com/NEDONION/lobster0/releases/latest/download/install.sh \
+            | bash -s -- --no-onboard --no-service
+      - name: Require the public install to report the promoted version
+        run: |
+          set -euo pipefail
+          "${HOME}/.local/bin/lobster0" --version | grep -F "${VERSION}"
+
+  demote-release:
+    name: return the release to draft
+    needs: [guard, publish, public-smoke]
+    # 公共 smoke 失败时立即把 GitHub Release 退回 draft，防止 latest 停留在坏版本。
+    # 已经不可变的 PyPI 版本既不删除也不覆盖，修复必须走 0.7.1。
+    if: failure() && needs.publish.result == 'success' && needs.public-smoke.result == 'failure'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAG: ${{ needs.guard.outputs.tag }}
+    steps:
+      - name: Return the release to draft and record the failing evidence
+        run: |
+          set -euo pipefail
+          gh release edit "${TAG}" --draft=true
+          python3 - <<'EVIDENCE' > release-evidence.json
+          import json
+          import os
+
+          print(
+              json.dumps(
+                  {
+                      "schema_version": 1,
+                      "gate": "public-smoke",
+                      "release_tag": os.environ["TAG"],
+                      "workflow_run": os.environ["GITHUB_RUN_ID"],
+                      "status": "FAIL",
+                  },
+                  ensure_ascii=False,
+                  indent=2,
+                  sort_keys=True,
+              )
+          )
+          EVIDENCE
+          gh release upload "${TAG}" release-evidence.json --clobber

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+  "PyYAML>=6.0.2,<7",
   "ruff>=0.9",
 ]
 feishu = [

--- a/tests/install_matrix/cases.json
+++ b/tests/install_matrix/cases.json
@@ -1,0 +1,493 @@
+{
+  "cases": [
+    {
+      "design_case": 1,
+      "id": "blank-user-fresh-install",
+      "live_command": [
+        "install-smoke",
+        "--json"
+      ],
+      "local_offline": true,
+      "probe": "tier1_platform_matrix",
+      "title": "blank user directory fresh install"
+    },
+    {
+      "design_case": 2,
+      "id": "no-system-interpreters",
+      "live_pending_reason": "absence of a system Python/Node/pnpm is a host property; it must be provisioned on the runner image and cannot be asserted by one CLI command",
+      "local_offline": true,
+      "probe": "managed_runtime_closure",
+      "title": "install with no system Python/Node/pnpm"
+    },
+    {
+      "design_case": 3,
+      "id": "privilege-refused",
+      "live_pending_reason": "refusing elevation must be exercised by the bootstrap under a host without an escalation path, not by the installed CLI",
+      "local_offline": true,
+      "probe": "privilege_fail_closed",
+      "title": "unprivileged and refused elevation"
+    },
+    {
+      "design_case": 4,
+      "id": "dry-run-zero-writes",
+      "live_pending_reason": "the live form needs the release installer zipapp plus a filesystem snapshot diff, which this harness does not orchestrate yet",
+      "local_offline": true,
+      "probe": "dry_run_zero_writes",
+      "title": "--dry-run performs zero persistent writes"
+    },
+    {
+      "design_case": 5,
+      "id": "json-no-onboard",
+      "live_pending_reason": "the live form needs a second unattended bootstrap run on a clean account, which this harness does not orchestrate yet",
+      "local_offline": true,
+      "probe": "json_boundary_fail_closed",
+      "title": "--json --no-onboard automated install"
+    },
+    {
+      "design_case": 6,
+      "id": "tui-entry-smoke",
+      "live_command": [
+        "install-smoke",
+        "--json"
+      ],
+      "local_offline": false,
+      "pending_reason": "local Node/pnpm are below the project floor; the pi-tui bundle can only be built and smoked on CI or a Tier 1 host",
+      "title": "pi-tui entry and import smoke"
+    },
+    {
+      "design_case": 7,
+      "id": "channel-sdk-smoke",
+      "live_command": [
+        "install-smoke",
+        "--json"
+      ],
+      "local_offline": true,
+      "probe": "feature_registry_closure",
+      "title": "three Channel SDK import and contract smoke"
+    },
+    {
+      "design_case": 8,
+      "id": "version-and-doctor",
+      "live_command": [
+        "doctor"
+      ],
+      "local_offline": true,
+      "probe": "version_identity",
+      "title": "lobster0 --version and Doctor"
+    },
+    {
+      "design_case": 9,
+      "id": "service-lifecycle",
+      "live_pending_reason": "install/start/status/restart/logs/uninstall plus a real reboot need host orchestration outside this harness",
+      "local_offline": false,
+      "pending_reason": "systemd user units, launchd LaunchAgents and real reboots require a Tier 1 VM or physical host",
+      "title": "service install/start/status/restart/logs/uninstall and reboot"
+    },
+    {
+      "design_case": 10,
+      "id": "idempotent-reinstall",
+      "live_pending_reason": "a second full bootstrap run and a receipt diff are required; this harness does not orchestrate the rerun",
+      "local_offline": false,
+      "pending_reason": "idempotence is only meaningful against a real installed prefix and receipt on a Tier 1 host",
+      "title": "repeated install is idempotent"
+    },
+    {
+      "design_case": 11,
+      "id": "upgrade-n-minus-one",
+      "live_pending_reason": "an N-1 install, a live database and a second Release are required; this harness does not stage them",
+      "local_offline": false,
+      "pending_reason": "two real managed Runtimes and a live database are required for an upgrade run",
+      "title": "N-1 to N upgrade"
+    },
+    {
+      "design_case": 12,
+      "id": "failure-injection",
+      "live_pending_reason": "injecting a bad hash, a network cut, a full disk and a failing health check requires host-level fault injection",
+      "local_offline": true,
+      "probe": "artifact_integrity_rejection",
+      "title": "injected bad hash, network loss, low disk and failed health"
+    },
+    {
+      "design_case": 13,
+      "id": "rollback-keeps-previous",
+      "live_pending_reason": "rollback needs a staged N-1 Runtime and a database backup that this harness does not stage",
+      "local_offline": false,
+      "pending_reason": "rollback needs a real N-1 Runtime, database backup and service health check",
+      "title": "rollback keeps the previous Runtime usable"
+    },
+    {
+      "design_case": 14,
+      "id": "uninstall-preserves-data",
+      "live_pending_reason": "a destructive uninstall must run last against a real receipt and state root; this harness does not sequence it",
+      "local_offline": false,
+      "pending_reason": "data-preserving uninstall must be proven against a real receipt, service and state root",
+      "title": "default uninstall preserves user data"
+    },
+    {
+      "design_case": 15,
+      "id": "secret-scan",
+      "live_pending_reason": "scanning the installed Runtime, logs and service files needs the real install layout, not the repository tree",
+      "local_offline": true,
+      "probe": "secret_scan",
+      "title": "tracked, runtime, log and service Secret scan"
+    }
+  ],
+  "platforms": [
+    {
+      "arch": "x86_64",
+      "artifact_platform": "linux-x86_64",
+      "distro": "ubuntu",
+      "distro_version": "22.04",
+      "id": "ubuntu-22.04-x86_64",
+      "os": "linux",
+      "runner_labels": [
+        "self-hosted",
+        "linux",
+        "x64",
+        "ubuntu-22.04"
+      ],
+      "service_manager": "systemd-user",
+      "uname_machine": "x86_64"
+    },
+    {
+      "arch": "arm64",
+      "artifact_platform": "linux-arm64",
+      "distro": "ubuntu",
+      "distro_version": "22.04",
+      "id": "ubuntu-22.04-arm64",
+      "os": "linux",
+      "runner_labels": [
+        "self-hosted",
+        "linux",
+        "arm64",
+        "ubuntu-22.04"
+      ],
+      "service_manager": "systemd-user",
+      "uname_machine": "aarch64"
+    },
+    {
+      "arch": "x86_64",
+      "artifact_platform": "linux-x86_64",
+      "distro": "ubuntu",
+      "distro_version": "24.04",
+      "id": "ubuntu-24.04-x86_64",
+      "os": "linux",
+      "runner_labels": [
+        "self-hosted",
+        "linux",
+        "x64",
+        "ubuntu-24.04"
+      ],
+      "service_manager": "systemd-user",
+      "uname_machine": "x86_64"
+    },
+    {
+      "arch": "arm64",
+      "artifact_platform": "linux-arm64",
+      "distro": "ubuntu",
+      "distro_version": "24.04",
+      "id": "ubuntu-24.04-arm64",
+      "os": "linux",
+      "runner_labels": [
+        "self-hosted",
+        "linux",
+        "arm64",
+        "ubuntu-24.04"
+      ],
+      "service_manager": "systemd-user",
+      "uname_machine": "aarch64"
+    },
+    {
+      "arch": "x86_64",
+      "artifact_platform": "linux-x86_64",
+      "distro": "debian",
+      "distro_version": "12",
+      "id": "debian-12-x86_64",
+      "os": "linux",
+      "runner_labels": [
+        "self-hosted",
+        "linux",
+        "x64",
+        "debian-12"
+      ],
+      "service_manager": "systemd-user",
+      "uname_machine": "x86_64"
+    },
+    {
+      "arch": "arm64",
+      "artifact_platform": "linux-arm64",
+      "distro": "debian",
+      "distro_version": "12",
+      "id": "debian-12-arm64",
+      "os": "linux",
+      "runner_labels": [
+        "self-hosted",
+        "linux",
+        "arm64",
+        "debian-12"
+      ],
+      "service_manager": "systemd-user",
+      "uname_machine": "aarch64"
+    },
+    {
+      "arch": "x86_64",
+      "artifact_platform": "linux-x86_64",
+      "distro": "debian",
+      "distro_version": "13",
+      "id": "debian-13-x86_64",
+      "os": "linux",
+      "runner_labels": [
+        "self-hosted",
+        "linux",
+        "x64",
+        "debian-13"
+      ],
+      "service_manager": "systemd-user",
+      "uname_machine": "x86_64"
+    },
+    {
+      "arch": "arm64",
+      "artifact_platform": "linux-arm64",
+      "distro": "debian",
+      "distro_version": "13",
+      "id": "debian-13-arm64",
+      "os": "linux",
+      "runner_labels": [
+        "self-hosted",
+        "linux",
+        "arm64",
+        "debian-13"
+      ],
+      "service_manager": "systemd-user",
+      "uname_machine": "aarch64"
+    },
+    {
+      "arch": "x86_64",
+      "artifact_platform": "linux-x86_64",
+      "distro": "rhel",
+      "distro_version": "9",
+      "id": "rhel-9-x86_64",
+      "os": "linux",
+      "runner_labels": [
+        "self-hosted",
+        "linux",
+        "x64",
+        "rhel-9"
+      ],
+      "service_manager": "systemd-user",
+      "uname_machine": "x86_64"
+    },
+    {
+      "arch": "arm64",
+      "artifact_platform": "linux-arm64",
+      "distro": "rhel",
+      "distro_version": "9",
+      "id": "rhel-9-arm64",
+      "os": "linux",
+      "runner_labels": [
+        "self-hosted",
+        "linux",
+        "arm64",
+        "rhel-9"
+      ],
+      "service_manager": "systemd-user",
+      "uname_machine": "aarch64"
+    },
+    {
+      "arch": "x86_64",
+      "artifact_platform": "linux-x86_64",
+      "distro": "rhel",
+      "distro_version": "10",
+      "id": "rhel-10-x86_64",
+      "os": "linux",
+      "runner_labels": [
+        "self-hosted",
+        "linux",
+        "x64",
+        "rhel-10"
+      ],
+      "service_manager": "systemd-user",
+      "uname_machine": "x86_64"
+    },
+    {
+      "arch": "arm64",
+      "artifact_platform": "linux-arm64",
+      "distro": "rhel",
+      "distro_version": "10",
+      "id": "rhel-10-arm64",
+      "os": "linux",
+      "runner_labels": [
+        "self-hosted",
+        "linux",
+        "arm64",
+        "rhel-10"
+      ],
+      "service_manager": "systemd-user",
+      "uname_machine": "aarch64"
+    },
+    {
+      "arch": "x86_64",
+      "artifact_platform": "linux-x86_64",
+      "distro": "rocky",
+      "distro_version": "9",
+      "id": "rocky-9-x86_64",
+      "os": "linux",
+      "runner_labels": [
+        "self-hosted",
+        "linux",
+        "x64",
+        "rocky-9"
+      ],
+      "service_manager": "systemd-user",
+      "uname_machine": "x86_64"
+    },
+    {
+      "arch": "arm64",
+      "artifact_platform": "linux-arm64",
+      "distro": "rocky",
+      "distro_version": "9",
+      "id": "rocky-9-arm64",
+      "os": "linux",
+      "runner_labels": [
+        "self-hosted",
+        "linux",
+        "arm64",
+        "rocky-9"
+      ],
+      "service_manager": "systemd-user",
+      "uname_machine": "aarch64"
+    },
+    {
+      "arch": "x86_64",
+      "artifact_platform": "linux-x86_64",
+      "distro": "rocky",
+      "distro_version": "10",
+      "id": "rocky-10-x86_64",
+      "os": "linux",
+      "runner_labels": [
+        "self-hosted",
+        "linux",
+        "x64",
+        "rocky-10"
+      ],
+      "service_manager": "systemd-user",
+      "uname_machine": "x86_64"
+    },
+    {
+      "arch": "arm64",
+      "artifact_platform": "linux-arm64",
+      "distro": "rocky",
+      "distro_version": "10",
+      "id": "rocky-10-arm64",
+      "os": "linux",
+      "runner_labels": [
+        "self-hosted",
+        "linux",
+        "arm64",
+        "rocky-10"
+      ],
+      "service_manager": "systemd-user",
+      "uname_machine": "aarch64"
+    },
+    {
+      "arch": "x86_64",
+      "artifact_platform": "linux-x86_64",
+      "distro": "almalinux",
+      "distro_version": "9",
+      "id": "almalinux-9-x86_64",
+      "os": "linux",
+      "runner_labels": [
+        "self-hosted",
+        "linux",
+        "x64",
+        "almalinux-9"
+      ],
+      "service_manager": "systemd-user",
+      "uname_machine": "x86_64"
+    },
+    {
+      "arch": "arm64",
+      "artifact_platform": "linux-arm64",
+      "distro": "almalinux",
+      "distro_version": "9",
+      "id": "almalinux-9-arm64",
+      "os": "linux",
+      "runner_labels": [
+        "self-hosted",
+        "linux",
+        "arm64",
+        "almalinux-9"
+      ],
+      "service_manager": "systemd-user",
+      "uname_machine": "aarch64"
+    },
+    {
+      "arch": "x86_64",
+      "artifact_platform": "linux-x86_64",
+      "distro": "almalinux",
+      "distro_version": "10",
+      "id": "almalinux-10-x86_64",
+      "os": "linux",
+      "runner_labels": [
+        "self-hosted",
+        "linux",
+        "x64",
+        "almalinux-10"
+      ],
+      "service_manager": "systemd-user",
+      "uname_machine": "x86_64"
+    },
+    {
+      "arch": "arm64",
+      "artifact_platform": "linux-arm64",
+      "distro": "almalinux",
+      "distro_version": "10",
+      "id": "almalinux-10-arm64",
+      "os": "linux",
+      "runner_labels": [
+        "self-hosted",
+        "linux",
+        "arm64",
+        "almalinux-10"
+      ],
+      "service_manager": "systemd-user",
+      "uname_machine": "aarch64"
+    },
+    {
+      "arch": "x86_64",
+      "artifact_platform": "macos-x86_64",
+      "distro": "macos",
+      "distro_version": "13",
+      "id": "macos-13-x86_64",
+      "macos_version": "13.7",
+      "os": "macos",
+      "runner_labels": [
+        "self-hosted",
+        "macos",
+        "x64",
+        "macos-13"
+      ],
+      "service_manager": "launchd",
+      "uname_machine": "x86_64"
+    },
+    {
+      "arch": "arm64",
+      "artifact_platform": "macos-arm64",
+      "distro": "macos",
+      "distro_version": "13",
+      "id": "macos-13-arm64",
+      "macos_version": "13.7",
+      "os": "macos",
+      "runner_labels": [
+        "self-hosted",
+        "macos",
+        "arm64",
+        "macos-13"
+      ],
+      "service_manager": "launchd",
+      "uname_machine": "arm64"
+    }
+  ],
+  "release_matrix": "docs/superpowers/specs/2026-08-09-one-line-install-and-release-design.md#222-release-install-matrix",
+  "schema_version": 1
+}

--- a/tests/install_matrix/run_install_matrix.py
+++ b/tests/install_matrix/run_install_matrix.py
@@ -1,0 +1,842 @@
+#!/usr/bin/env python3
+"""Tier 1 install matrix 驱动器：本地离线证据、runner 标签导出与主机上实跑。
+
+本地 ``--local-offline`` 只用假 artifact 与注入的主机事实证明可以离线证明的性质，
+绝不假装完成 service、reboot、升级或回滚；这些用例如实标注 PENDING。
+``--all-cases`` 只在已注册的 Tier 1 自托管主机上运行，产出 Release evidence。
+
+诚实边界：本仓库当前没有任何自托管 runner，因此 ``--all-cases`` 从未被真实执行过。
+只有 ``cases.json`` 中带 ``live_command`` 的用例落地了 live 过程；其余用例带的是
+``live_pending_reason``，在主机上会被记为 PENDING 并让作业以非零码结束。换句话说，
+即使将来注册了 runner，剩余 live 过程补齐之前 stable 提升仍然被阻断——这是刻意的，
+不允许用"看起来绿"的假实现换取发布。
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import hashlib
+import io
+import json
+import os
+import platform as platform_module
+import pwd
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+from collections.abc import Callable
+from dataclasses import dataclass
+from email.message import Message
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_REPO_ROOT = _HERE.parents[1]
+_CASES = _HERE / "cases.json"
+_MANIFEST_FIXTURE = _REPO_ROOT / "tests" / "install" / "manifest_v1.json"
+_FEATURES = _REPO_ROOT / "release" / "features.json"
+_RUNTIME_VERSIONS = _REPO_ROOT / "release" / "runtime-versions.json"
+
+_UNSUPPORTED_HOSTS = (
+    ("alpine", 'NAME="Alpine"\nID=alpine\nVERSION_ID="3.20"\n', "musl"),
+    ("nixos", 'NAME="NixOS"\nID=nixos\nVERSION_ID="24.05"\n', "glibc"),
+    ("ubuntu-20.04", 'NAME="Ubuntu"\nID=ubuntu\nVERSION_ID="20.04"\n', "glibc"),
+    ("debian-11", 'NAME="Debian"\nID=debian\nVERSION_ID="11"\n', "glibc"),
+    ("rhel-8", 'NAME="RHEL"\nID=rhel\nVERSION_ID="8"\n', "glibc"),
+)
+
+_REJECTED_NODE = ((20, 19, 0), (22, 22, 2), (23, 0, 0), (25, 0, 0), (26, 1, 0))
+_ACCEPTED_NODE = ((22, 22, 3), (24, 15, 0), (24, 18, 0))
+
+_SECRET_ASSIGNMENT = re.compile(
+    r"(?i)\b(?:secret|token|api[_-]?key|apikey|password|passwd|credential|private[_-]?key)"
+    r"[\"']?\s*[:=]\s*[\"']?([A-Za-z0-9/+_.-]{16,})"
+)
+_SECRET_PLACEHOLDERS = re.compile(
+    r"(?i)^(?:x{4,}|a{4,}|0+|1+|f+|<[^>]+>|\$\{[^}]+\}|changeme|redacted|example|"
+    r"your[-_].*|placeholder|null|none|true|false)$"
+)
+_SECRET_SCAN_ROOTS = ("release", "deploy", ".github", "scripts", "tests/install_matrix")
+
+_INSTALLER_ERROR_EVENT = re.compile(
+    r'^\{"code":"[a-z_]+","detail":"[a-z_.]+","event":"install\.failed",'
+    r'"status":"error"\}\n$'
+)
+
+
+class MatrixError(RuntimeError):
+    """表示 matrix 定义、离线证据或主机执行不满足契约。"""
+
+
+@dataclass(frozen=True, slots=True)
+class Outcome:
+    """保存一个用例在当前执行模式下的结论。
+
+    Args:
+        case_id: cases.json 中的稳定用例标识。
+        status: ``PASS``、``PENDING`` 或 ``BLOCKED``。
+        detail: 一行无凭据、无主机身份的结论说明。
+    """
+
+    case_id: str
+    status: str
+    detail: str
+
+
+def load_document(path: Path = _CASES) -> dict[str, object]:
+    """加载并严格校验 install matrix 定义。
+
+    Args:
+        path: ``cases.json`` 路径。
+
+    Returns:
+        含 ``platforms`` 与 ``cases`` 的已校验文档。
+
+    Raises:
+        MatrixError: 结构、编号或平台字段不可信。
+    """
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise MatrixError("could not read the install matrix definition") from error
+    if type(document) is not dict or document.get("schema_version") != 1:
+        raise MatrixError("invalid install matrix definition")
+    platforms = document.get("platforms")
+    cases = document.get("cases")
+    if type(platforms) is not list or not platforms:
+        raise MatrixError("invalid platform set")
+    if type(cases) is not list or len(cases) != 15:
+        raise MatrixError("the matrix must declare exactly the fifteen design cases")
+    numbers = sorted(int(case["design_case"]) for case in cases)
+    if numbers != list(range(1, 16)):
+        raise MatrixError("design case numbers must be 1..15 without gaps")
+    return document
+
+
+def _account(uid: int) -> pwd.struct_passwd:
+    """返回不触碰真实账号数据库的 passwd 记录。"""
+    return pwd.struct_passwd(
+        ("builder", "x", uid, uid, "Matrix", f"/home/builder-{uid}", "/bin/sh")
+    )
+
+
+def _request(**changes: object):
+    """构造一个默认无特权、无系统包授权的安装请求。"""
+    from lobster0.install.models import InstallRequest
+
+    values: dict[str, object] = {
+        "action": "install",
+        "version": "0.7.0",
+        "channel": "stable",
+        "prefix": Path("/opt/lobster0"),
+        "state_home": Path("/var/lib/lobster0"),
+        "system_prefix": False,
+        "onboard": True,
+        "config_file": None,
+        "secrets_file": None,
+        "service": False,
+        "allow_system_packages": False,
+        "dry_run": True,
+        "json_output": False,
+        "verbose": False,
+        "purge_data": False,
+        "confirm_data_loss": False,
+    }
+    values.update(changes)
+    return InstallRequest(**values)  # type: ignore[arg-type]
+
+
+def _detect(entry: dict[str, object], **changes: object):
+    """按平台定义注入主机事实并执行 Tier 1 检测。"""
+    from lobster0.install.platforms import detect_platform
+
+    if entry["os"] == "macos":
+        return detect_platform(
+            _request(**changes),
+            system="Darwin",
+            machine=str(entry["uname_machine"]),
+            macos_version=str(entry["macos_version"]),
+            effective_uid=501,
+            getpwuid=_account,
+        )
+    return detect_platform(
+        _request(**changes),
+        system="Linux",
+        machine=str(entry["uname_machine"]),
+        os_release_text=(
+            f'NAME="Fixture"\nID={entry["distro"]}\n'
+            f'VERSION_ID="{entry["distro_version"]}"\n'
+        ),
+        libc="glibc",
+        wsl=False,
+        service_manager=str(entry["service_manager"]),
+        effective_uid=1000,
+        getpwuid=_account,
+    )
+
+
+def probe_tier1_platform_matrix(document: dict[str, object], workdir: Path) -> str:
+    """证明全部 Tier 1 组合被接受且非 Tier 1 主机被拒绝。"""
+    from lobster0.install.models import InstallError, PlatformKey
+    from lobster0.install.platforms import detect_platform
+
+    del workdir
+    for entry in document["platforms"]:
+        detected = _detect(entry, service=True)
+        expected = str(entry["artifact_platform"]).split("-", 1)
+        if detected.artifact_platform != PlatformKey(expected[0], expected[1]):
+            raise MatrixError(f"platform mapping drifted for {entry['id']}")
+    rejected = 0
+    for name, os_release, libc in _UNSUPPORTED_HOSTS:
+        try:
+            detect_platform(
+                _request(),
+                system="Linux",
+                machine="x86_64",
+                os_release_text=os_release,
+                libc=libc,
+                wsl=False,
+                service_manager="systemd-user",
+                effective_uid=1000,
+                getpwuid=_account,
+            )
+        except InstallError as error:
+            if error.code != "unsupported_platform":
+                raise MatrixError(f"{name} produced the wrong refusal") from error
+            rejected += 1
+        else:
+            raise MatrixError(f"{name} was accepted as a Tier 1 host")
+    for machine in ("i686", "armv7l"):
+        try:
+            detect_platform(
+                _request(),
+                system="Linux",
+                machine=machine,
+                os_release_text='NAME="F"\nID=ubuntu\nVERSION_ID="24.04"\n',
+                libc="glibc",
+                wsl=False,
+                service_manager="systemd-user",
+                effective_uid=1000,
+                getpwuid=_account,
+            )
+        except InstallError:
+            rejected += 1
+        else:
+            raise MatrixError(f"{machine} was accepted as a Tier 1 architecture")
+    count = len(document["platforms"])
+    return f"{count} Tier 1 hosts resolved, {rejected} out-of-tier hosts refused"
+
+
+def probe_managed_runtime_closure(document: dict[str, object], workdir: Path) -> str:
+    """证明受管 Node 策略封闭且每个平台都有自带 Node/TUI 组件。"""
+    from lobster0.install.platforms import node_version_supported
+
+    del workdir
+    for version in _REJECTED_NODE:
+        if node_version_supported(version):
+            raise MatrixError(f"node {version} must not be accepted")
+    for version in _ACCEPTED_NODE:
+        if not node_version_supported(version):
+            raise MatrixError(f"node {version} must be accepted")
+    pins = json.loads(_RUNTIME_VERSIONS.read_text(encoding="utf-8"))
+    for component in ("uv", "node"):
+        archives = pins[component]["archives"]
+        for entry in document["platforms"]:
+            key = str(entry["artifact_platform"])
+            if key not in archives or len(archives[key]["sha256"]) != 64:
+                raise MatrixError(f"missing pinned {component} archive for {key}")
+    return (
+        f"managed uv {pins['uv']['version']} / node {pins['node']['version']} pinned for "
+        f"4 platforms; {len(_REJECTED_NODE)} out-of-policy Node versions refused"
+    )
+
+
+def probe_privilege_fail_closed(document: dict[str, object], workdir: Path) -> str:
+    """证明默认安装既不请求提权也不会在提权身份不完整时继续。"""
+    from lobster0.install.models import InstallError
+    from lobster0.install.platforms import detect_platform
+
+    del workdir
+    default = _request()
+    if default.system_prefix or default.allow_system_packages:
+        raise MatrixError("the default request must not request elevated behaviour")
+    try:
+        _request(system_prefix=True, prefix=Path("/opt/lobster0"))
+    except InstallError as error:
+        if error.code != "request_invalid":
+            raise MatrixError("prefix conflict produced the wrong refusal") from error
+    else:
+        raise MatrixError("system prefix must conflict with an explicit prefix")
+    refusals = 0
+    for entry in document["platforms"]:
+        try:
+            _detect(entry, service=True)
+        except InstallError as error:  # pragma: no cover - defensive
+            raise MatrixError(f"{entry['id']} lost its unprivileged path") from error
+        try:
+            if entry["os"] == "macos":
+                detect_platform(
+                    _request(),
+                    system="Darwin",
+                    machine=str(entry["uname_machine"]),
+                    macos_version=str(entry["macos_version"]),
+                    effective_uid=0,
+                    getpwuid=_account,
+                )
+            else:
+                detect_platform(
+                    _request(),
+                    system="Linux",
+                    machine=str(entry["uname_machine"]),
+                    os_release_text=(
+                        f'NAME="Fixture"\nID={entry["distro"]}\n'
+                        f'VERSION_ID="{entry["distro_version"]}"\n'
+                    ),
+                    libc="glibc",
+                    wsl=False,
+                    service_manager=str(entry["service_manager"]),
+                    effective_uid=0,
+                    original_user="builder",
+                    original_uid=1000,
+                    getpwuid=_account,
+                    getpwnam=lambda _name: _account(4242),
+                )
+        except InstallError as error:
+            if error.code != "privilege_denied":
+                raise MatrixError(f"{entry['id']} produced the wrong refusal") from error
+            refusals += 1
+        else:
+            raise MatrixError(f"{entry['id']} accepted an unverified elevated identity")
+    return (
+        f"default request stays unprivileged; {refusals} hosts refused an unverified "
+        "elevated identity"
+    )
+
+
+def probe_dry_run_zero_writes(document: dict[str, object], workdir: Path) -> str:
+    """证明未验证 bootstrap 的 dry-run 立即失败、只发一条脱敏事件且零写入。"""
+    del document
+    root = workdir / "dry-run"
+    prefix = root / "prefix"
+    state = root / "state"
+    for directory in (prefix, state):
+        directory.mkdir(parents=True)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "lobster0.install",
+            "install",
+            "--dry-run",
+            "--json",
+            "--prefix",
+            str(prefix),
+            "--home",
+            str(state),
+            "--manifest-file",
+            str(root / "absent-release-manifest.json"),
+            "--manifest-sha256",
+            "1" * 64,
+            "--managed-uv",
+            str(root / "uv" / "uv"),
+            "--managed-python-root",
+            str(root / "python"),
+            "--managed-python-executable",
+            str(root / "python" / "bin" / "python3.12"),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(_REPO_ROOT),
+        stdin=subprocess.DEVNULL,
+        env={**os.environ, "PYTHONWARNINGS": "ignore"},
+        timeout=120,
+        check=False,
+    )
+    if result.returncode != 2:
+        raise MatrixError("an unverified bootstrap must fail closed with code 2")
+    if _INSTALLER_ERROR_EVENT.fullmatch(result.stdout) is None:
+        raise MatrixError("the installer emitted a non-canonical failure document")
+    if result.stderr:
+        raise MatrixError("JSON mode must keep stderr empty")
+    written = [path for path in root.rglob("*") if path.is_file()]
+    if written:
+        raise MatrixError("a refused dry-run must not persist any file")
+    return "unverified bootstrap refused with code 2, one redacted event and zero writes"
+
+
+def probe_json_boundary_fail_closed(document: dict[str, object], workdir: Path) -> str:
+    """证明非 TTY 的 ``--no-onboard`` 自动化路径不会带出导入路径或部分事件。"""
+    del document
+    from lobster0.install.__main__ import main as installer_main
+
+    internal = (
+        "--manifest-file",
+        str(workdir / "release-manifest.json"),
+        "--manifest-sha256",
+        "1" * 64,
+        "--managed-uv",
+        str(workdir / "uv" / "uv"),
+        "--managed-python-root",
+        str(workdir / "python"),
+        "--managed-python-executable",
+        str(workdir / "python" / "bin" / "python3.12"),
+    )
+    checks = (
+        (("--no-onboard", *internal), "silent"),
+        (("--json", "--no-onboard", *internal), "event"),
+        (
+            (
+                "--json",
+                "--onboard",
+                "--config",
+                "/tmp/MATRIX_SENTINEL-config.toml",
+                "--secrets-file",
+                "/tmp/MATRIX_SENTINEL-secrets.env",
+                *internal,
+            ),
+            "event",
+        ),
+    )
+    for argv, shape in checks:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            code = installer_main(argv, stdin_isatty=False)
+        if code != 2:
+            raise MatrixError("the automated install boundary did not fail closed")
+        emitted = stdout.getvalue()
+        if shape == "silent" and emitted:
+            raise MatrixError("a refused human-mode request must not write to stdout")
+        if shape == "event" and _INSTALLER_ERROR_EVENT.fullmatch(emitted) is None:
+            raise MatrixError("a refused JSON request must emit exactly one redacted event")
+        if "MATRIX_SENTINEL" in emitted + stderr.getvalue():
+            raise MatrixError("import source paths must never be echoed")
+    return (
+        "non-TTY automated install fails closed with exactly one redacted event and no "
+        "echoed import paths"
+    )
+
+
+def probe_feature_registry_closure(document: dict[str, object], workdir: Path) -> str:
+    """证明 manifest 声明的每个能力都真实可导入，Channel SDK 契约成立。"""
+    del document, workdir
+    import importlib
+
+    registry = json.loads(_FEATURES.read_text(encoding="utf-8"))
+    resolved = 0
+    for entry in registry["features"]:
+        module = importlib.import_module(str(entry["module"]))
+        if not hasattr(module, str(entry["attribute"])):
+            raise MatrixError(f"feature {entry['feature']} is declared but absent")
+        resolved += 1
+    for name in ("feishu", "telegram", "discord"):
+        importlib.import_module(f"lobster0.channels.{name}")
+    return f"{resolved} declared features resolve, 3 Channel adapters import"
+
+
+def probe_version_identity(document: dict[str, object], workdir: Path) -> str:
+    """证明 CLI 版本、版本常量与 manifest fixture 是同一个事实。"""
+    del document, workdir
+    from lobster0 import __version__
+
+    result = subprocess.run(
+        [sys.executable, "-m", "lobster0", "--version"],
+        capture_output=True,
+        text=True,
+        cwd=str(_REPO_ROOT),
+        stdin=subprocess.DEVNULL,
+        timeout=120,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise MatrixError("the CLI could not report its version")
+    reported = (result.stdout + result.stderr).strip()
+    if __version__ not in reported:
+        raise MatrixError("the CLI version drifted from the version constant")
+    fixture = json.loads(_MANIFEST_FIXTURE.read_text(encoding="utf-8"))
+    if fixture["version"] != __version__:
+        raise MatrixError("the manifest fixture drifted from the version constant")
+    return f"CLI, version constant and manifest agree on {__version__}"
+
+
+class _FakeResponse:
+    """提供 download_artifact 需要的最小 response 契约。"""
+
+    def __init__(self, payload: bytes, status: int = 200, location: str | None = None) -> None:
+        """记录响应体与固定 headers。"""
+        self.status = status
+        self._stream = io.BytesIO(payload)
+        self.headers = Message()
+        self.headers["Content-Length"] = str(len(payload))
+        if location is not None:
+            self.headers["Location"] = location
+
+    def read(self, size: int = -1) -> bytes:
+        """读取最多 size 字节。"""
+        return self._stream.read(size)
+
+    def close(self) -> None:
+        """关闭响应资源。"""
+        self._stream.close()
+
+
+class _FakeOpener:
+    """按 URL 返回预置的假 artifact 字节或 redirect。"""
+
+    def __init__(self, routes: dict[str, _Callable]) -> None:
+        """记录 URL 到响应工厂的固定映射。"""
+        self._routes = routes
+
+    def open(self, request: object, timeout: float | None = None) -> _FakeResponse:
+        """返回该 URL 的预置响应。"""
+        del timeout
+        url = request.full_url  # type: ignore[attr-defined]
+        if url not in self._routes:
+            raise OSError("offline matrix reached an unrouted URL")
+        return self._routes[url]()
+
+
+_Callable = Callable[[], _FakeResponse]
+
+
+def _fake_bundle(path: Path, kind: str) -> Path:
+    """生成一个有效或恶意的 tar.gz fixture。"""
+    with tarfile.open(path, "w:gz") as archive:
+        if kind == "valid":
+            member = tarfile.TarInfo("tui/dist/main.js")
+            payload = b"console.log('lobster0');\n"
+            member.size = len(payload)
+            member.mode = 0o644
+            archive.addfile(member, io.BytesIO(payload))
+        elif kind == "absolute":
+            member = tarfile.TarInfo("/escape")
+            member.size = 1
+            archive.addfile(member, io.BytesIO(b"x"))
+        elif kind == "dotdot":
+            member = tarfile.TarInfo("safe/../escape")
+            member.size = 1
+            archive.addfile(member, io.BytesIO(b"x"))
+        else:
+            member = tarfile.TarInfo("link")
+            member.type = tarfile.SYMTYPE
+            member.linkname = "/etc/passwd"
+            archive.addfile(member)
+    return path
+
+
+def probe_artifact_integrity_rejection(document: dict[str, object], workdir: Path) -> str:
+    """证明坏 hash、坏 size、跨 host redirect 与恶意 archive 都被拒绝。"""
+    del document
+    from lobster0.install.artifacts import ExtractionLimits, download_artifact, extract_tar_gz
+    from lobster0.install.models import Artifact, InstallError
+
+    root = workdir / "artifacts"
+    root.mkdir(parents=True)
+    payload = b"lobster0 offline matrix artifact\n" * 64
+    digest = hashlib.sha256(payload).hexdigest()
+    url = (
+        "https://github.com/NEDONION/lobster0/releases/download/v0.7.0/"
+        "lobster0-tui-0.7.0-linux-x86_64.tar.gz"
+    )
+    artifact = Artifact(
+        kind="tui",
+        filename="lobster0-tui-0.7.0-linux-x86_64.tar.gz",
+        url=url,
+        sha256=digest,
+        size=len(payload),
+        media_type="application/gzip",
+        platform=__import__(
+            "lobster0.install.models", fromlist=["PlatformKey"]
+        ).PlatformKey("linux", "x86_64"),
+        component_version="0.7.0",
+        source_repository="https://github.com/NEDONION/lobster0",
+        license_ref="MIT",
+        upstream_sha256=None,
+    )
+    download_artifact(
+        artifact,
+        root / "good.bin",
+        opener=_FakeOpener({url: lambda: _FakeResponse(payload)}),
+    )
+    if (root / "good.bin").read_bytes() != payload:
+        raise MatrixError("a verified download did not land intact")
+    refusals = 0
+    corrupted = bytearray(payload)
+    corrupted[0] ^= 0xFF
+    injections = (
+        ("bad-hash", lambda: _FakeResponse(bytes(corrupted))),
+        ("short-read", lambda: _FakeResponse(payload[:-8])),
+        (
+            "foreign-redirect",
+            lambda: _FakeResponse(b"", status=302, location="https://evil.example/x.tar.gz"),
+        ),
+        ("server-error", lambda: _FakeResponse(b"", status=503)),
+    )
+    for name, factory in injections:
+        try:
+            download_artifact(
+                artifact,
+                root / f"{name}.bin",
+                opener=_FakeOpener({url: factory}),
+            )
+        except InstallError as error:
+            if error.code not in {"artifact_hash_mismatch", "artifact_download_failed"}:
+                raise MatrixError(f"{name} produced the wrong refusal") from error
+            refusals += 1
+        else:
+            raise MatrixError(f"{name} was accepted as a trusted artifact")
+    limits = ExtractionLimits(max_entries=64, max_bytes=1 << 20)
+    extract_tar_gz(_fake_bundle(root / "valid.tar.gz", "valid"), root / "out", limits)
+    for kind in ("absolute", "dotdot", "symlink"):
+        try:
+            extract_tar_gz(
+                _fake_bundle(root / f"{kind}.tar.gz", kind),
+                root / f"out-{kind}",
+                limits,
+            )
+        except InstallError:
+            refusals += 1
+        else:
+            raise MatrixError(f"{kind} archive was extracted")
+    return f"1 verified artifact accepted, {refusals} corrupt or hostile inputs refused"
+
+
+def probe_secret_scan(document: dict[str, object], workdir: Path) -> str:
+    """对受管发布输入与 workflow 执行凭据扫描。"""
+    del document, workdir
+    scanned = 0
+    for relative in _SECRET_SCAN_ROOTS:
+        root = _REPO_ROOT / relative
+        if not root.is_dir():
+            continue
+        for path in sorted(root.rglob("*")):
+            if not path.is_file() or path.is_symlink():
+                continue
+            if path.suffix in {".png", ".gz", ".whl", ".pyz", ".zip"}:
+                continue
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            scanned += 1
+            for match in _SECRET_ASSIGNMENT.finditer(text):
+                value = match.group(1)
+                if _SECRET_PLACEHOLDERS.fullmatch(value):
+                    continue
+                if len(set(value)) <= 2 or value.startswith("sha256"):
+                    continue
+                if re.fullmatch(r"[0-9a-f]{40}|[0-9a-f]{64}", value):
+                    continue
+                raise MatrixError(f"possible credential literal in {path.name}")
+            scanned += 0
+    return f"{scanned} release-input files scanned, no credential literal found"
+
+
+_PROBES: dict[str, Callable[[dict[str, object], Path], str]] = {
+    "tier1_platform_matrix": probe_tier1_platform_matrix,
+    "managed_runtime_closure": probe_managed_runtime_closure,
+    "privilege_fail_closed": probe_privilege_fail_closed,
+    "dry_run_zero_writes": probe_dry_run_zero_writes,
+    "json_boundary_fail_closed": probe_json_boundary_fail_closed,
+    "feature_registry_closure": probe_feature_registry_closure,
+    "version_identity": probe_version_identity,
+    "artifact_integrity_rejection": probe_artifact_integrity_rejection,
+    "secret_scan": probe_secret_scan,
+}
+
+
+def run_local_offline(document: dict[str, object]) -> tuple[Outcome, ...]:
+    """按 cases.json 执行全部可离线证明的用例并如实标注其余用例。
+
+    Args:
+        document: 已校验的 install matrix 定义。
+
+    Returns:
+        与 cases.json 顺序一致的结论序列。
+    """
+    outcomes: list[Outcome] = []
+    workdir = Path(tempfile.mkdtemp(prefix="lobster0-install-matrix-"))
+    try:
+        for case in document["cases"]:
+            case_id = str(case["id"])
+            if str(case["local_offline"]).lower() != "true":
+                outcomes.append(Outcome(case_id, "PENDING", str(case["pending_reason"])))
+                continue
+            probe = _PROBES.get(str(case["probe"]))
+            if probe is None:
+                outcomes.append(
+                    Outcome(case_id, "BLOCKED", f"unknown probe {case['probe']}")
+                )
+                continue
+            scope = workdir / case_id
+            scope.mkdir(parents=True, exist_ok=True)
+            try:
+                detail = probe(document, scope)
+            except Exception as error:  # noqa: BLE001 - reported, never swallowed
+                outcomes.append(Outcome(case_id, "BLOCKED", f"{type(error).__name__}: {error}"))
+            else:
+                outcomes.append(Outcome(case_id, "PASS", detail))
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+    return tuple(outcomes)
+
+
+def _print_local_offline(document: dict[str, object], outcomes: tuple[Outcome, ...]) -> int:
+    """打印离线证据表并返回进程退出码。"""
+    platforms = len(document["platforms"])
+    print(
+        "lobster0 Tier 1 install matrix — local offline evidence "
+        "(fake artifacts, no network, no elevation, no service)"
+    )
+    print(f"tier1 host combinations resolved offline: {platforms}")
+    width = max(len(str(case["id"])) for case in document["cases"])
+    for outcome in outcomes:
+        print(f"{outcome.case_id.ljust(width)}  {outcome.status:<7}  {outcome.detail}")
+    passed = sum(1 for item in outcomes if item.status == "PASS")
+    pending = sum(1 for item in outcomes if item.status == "PENDING")
+    blocked = sum(1 for item in outcomes if item.status == "BLOCKED")
+    print(f"summary: pass={passed} pending={pending} blocked={blocked}")
+    print(
+        "PENDING cases can only reach LIVE PASS on a registered Tier 1 self-hosted host; "
+        "this local run is never sufficient for stable promotion."
+    )
+    return 1 if blocked else 0
+
+
+def _print_list(document: dict[str, object]) -> int:
+    """打印全部平台标签与用例。"""
+    print("platforms:")
+    for entry in document["platforms"]:
+        labels = ",".join(str(item) for item in entry["runner_labels"])
+        print(f"  {entry['id']}  {entry['artifact_platform']}  runs-on=[{labels}]")
+    print("cases:")
+    for case in document["cases"]:
+        offline = "offline" if str(case["local_offline"]).lower() == "true" else "-------"
+        live = "live" if "live_command" in case else "----"
+        print(f"  {case['design_case']:>2}  {case['id']}  [{offline}|{live}]  {case['title']}")
+    live_ready = sum(1 for case in document["cases"] if "live_command" in case)
+    print(
+        f"total: {len(document['platforms'])} platforms x {len(document['cases'])} cases = "
+        f"{len(document['platforms']) * len(document['cases'])} Tier 1 combinations"
+    )
+    print(
+        f"live procedures implemented: {live_ready}/{len(document['cases'])}; the remaining "
+        "cases report PENDING on a Tier 1 host and therefore block stable promotion"
+    )
+    return 0
+
+
+def _print_required_runner_labels(document: dict[str, object]) -> int:
+    """输出前置门禁使用的标签矩阵。"""
+    payload = [
+        {
+            "id": str(entry["id"]),
+            "artifact_platform": str(entry["artifact_platform"]),
+            "runner_labels": [str(item) for item in entry["runner_labels"]],
+        }
+        for entry in document["platforms"]
+    ]
+    print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+def _run_all_cases(document: dict[str, object], arguments: argparse.Namespace) -> int:
+    """在已注册的 Tier 1 自托管主机上执行全部用例并写出 evidence。
+
+    只有 ``live_command`` 已落地的用例才可能得到 LIVE PASS；其余用例如实记为
+    PENDING 并让整个作业以非零码结束，从而阻断 stable 提升——绝不假装通过。
+    """
+    entry = next(
+        (item for item in document["platforms"] if item["id"] == arguments.platform), None
+    )
+    if entry is None:
+        raise MatrixError(f"unknown Tier 1 platform {arguments.platform}")
+    host_os = "macos" if platform_module.system() == "Darwin" else "linux"
+    if host_os != entry["os"]:
+        raise MatrixError("the declared platform does not match this host")
+    if not arguments.launcher.is_file():
+        raise MatrixError("the managed launcher is missing on this host")
+    outcomes: list[Outcome] = []
+    for case in document["cases"]:
+        command = case.get("live_command")
+        if command is None:
+            outcomes.append(
+                Outcome(str(case["id"]), "PENDING", str(case["live_pending_reason"]))
+            )
+            continue
+        result = subprocess.run(
+            [str(arguments.launcher), *[str(item) for item in command]],
+            capture_output=True,
+            text=True,
+            stdin=subprocess.DEVNULL,
+            timeout=arguments.case_timeout,
+            check=False,
+        )
+        status = "PASS" if result.returncode == 0 else "BLOCKED"
+        outcomes.append(Outcome(str(case["id"]), status, f"exit={result.returncode}"))
+    blocked = [item for item in outcomes if item.status != "PASS"]
+    evidence = {
+        "schema_version": 1,
+        "platform": str(entry["id"]),
+        "artifact_platform": str(entry["artifact_platform"]),
+        "release_tag": arguments.release_tag,
+        "cases": [
+            {"id": item.case_id, "status": item.status, "detail": item.detail}
+            for item in outcomes
+        ],
+        "status": "PASS" if not blocked else "FAIL",
+    }
+    arguments.evidence_output.write_text(
+        json.dumps(evidence, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    for item in outcomes:
+        print(f"{item.case_id}  {item.status}  {item.detail}")
+    return 1 if blocked else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """解析 CLI 并执行选定的 install matrix 模式。"""
+    parser = argparse.ArgumentParser(description="Run the Lobster0 Tier 1 install matrix")
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--list", action="store_true", help="print platforms and cases")
+    mode.add_argument(
+        "--local-offline", action="store_true", help="run the offline fake-artifact evidence"
+    )
+    mode.add_argument(
+        "--required-runner-labels",
+        action="store_true",
+        help="print the self-hosted label matrix the release preflight requires",
+    )
+    mode.add_argument(
+        "--all-cases", action="store_true", help="run every case on a Tier 1 self-hosted host"
+    )
+    parser.add_argument("--platform", default=None)
+    parser.add_argument("--release-tag", default=None)
+    parser.add_argument(
+        "--launcher", type=Path, default=Path.home() / ".local" / "bin" / "lobster0"
+    )
+    parser.add_argument("--evidence-output", type=Path, default=Path("tier1-evidence.json"))
+    parser.add_argument("--case-timeout", type=int, default=1800)
+    arguments = parser.parse_args(argv)
+    try:
+        document = load_document()
+        if arguments.list:
+            return _print_list(document)
+        if arguments.required_runner_labels:
+            return _print_required_runner_labels(document)
+        if arguments.local_offline:
+            return _print_local_offline(document, run_local_offline(document))
+        if arguments.platform is None or arguments.release_tag is None:
+            raise MatrixError("--all-cases requires --platform and --release-tag")
+        return _run_all_cases(document, arguments)
+    except MatrixError as error:
+        print(f"install matrix error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_install_matrix_contract.py
+++ b/tests/test_install_matrix_contract.py
@@ -1,0 +1,753 @@
+"""CI/Release 工作流策略与 Tier 1 install matrix 的离线契约测试。
+
+这些测试是发布信任链的最后一道本地门禁：工作流 YAML 只有被这里断言到的行为才算数。
+特别是 Task 16 复核实测得到的三条发布期强制义务（native bundle 硬失败、wheel 摘要
+必传、wheel 必须先于镜像构建），以及"自托管 Tier 1 组合不可用必须阻断 stable 发布"。
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_WORKFLOW_DIR = _REPO_ROOT / ".github" / "workflows"
+_CI_WORKFLOW = _WORKFLOW_DIR / "ci.yml"
+_RELEASE_WORKFLOW = _WORKFLOW_DIR / "release.yml"
+_DEPENDABOT = _REPO_ROOT / ".github" / "dependabot.yml"
+_MATRIX_DIR = _REPO_ROOT / "tests" / "install_matrix"
+_MATRIX_RUNNER = _MATRIX_DIR / "run_install_matrix.py"
+_MATRIX_CASES = _MATRIX_DIR / "cases.json"
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+
+_PINNED_USES = re.compile(r"^[^@]+@[0-9a-f]{40}$")
+
+# 计划已审阅并固定的四个外部 Action commit；工作流不得引用任何其他 Action。
+_REVIEWED_ACTIONS = {
+    "actions/checkout": "de0fac2e4500dabe0009e67214ff5f5447ce83dd",
+    "actions/setup-python": "a309ff8b426b58ec0e2a45f0f869d46889d02405",
+    "actions/attest": "508db95dd578ae2727ebd6217d5ba78e4fbda05d",
+    "pypa/gh-action-pypi-publish": "cef221092ed1bacb1cc03d23a2d87d1d172e277b",
+}
+
+_REQUIRED_CI_JOBS = ("offline", "node-22", "node-24", "artifact-build")
+_REQUIRED_RELEASE_JOBS = ("tier1-install", "attestation", "publish")
+
+_ASSEMBLY_ORDER = (
+    "scripts/build_sbom.py",
+    "scripts/build_release_manifest.py",
+    "scripts/render_install_script.py",
+    "scripts/build_release_manifest.py",
+    "scripts/verify_release_artifacts.py",
+)
+
+_IMAGE_BUILD = re.compile(r"docker\s+(?:buildx\s+)?build\b")
+_WHEEL_DIGEST_EXPRESSION = "${{ needs.python-build.outputs.wheel_sha256 }}"
+_PUBLIC_INSTALL_URL = (
+    "https://github.com/NEDONION/lobster0/releases/latest/download/install.sh"
+)
+_DESIGN_CASE_COUNT = 15
+
+
+def _load(path: Path) -> dict[str, object]:
+    """用 BaseLoader 解析工作流，避免 YAML 1.1 把 ``on`` 折叠成布尔键。"""
+    document = yaml.load(path.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    if type(document) is not dict:
+        raise AssertionError(f"{path.name} is not a YAML mapping")
+    return document
+
+
+def _jobs(workflow: dict[str, object]) -> dict[str, dict[str, object]]:
+    """返回工作流的 job 映射。"""
+    jobs = workflow.get("jobs")
+    if type(jobs) is not dict:
+        raise AssertionError("workflow has no jobs mapping")
+    return jobs
+
+
+def _steps(job: dict[str, object]) -> list[dict[str, object]]:
+    """返回一个 job 的 step 列表。"""
+    steps = job.get("steps", [])
+    return list(steps) if type(steps) is list else []
+
+
+def _all_steps(workflow: dict[str, object]) -> list[tuple[str, dict[str, object]]]:
+    """返回 ``(job_id, step)`` 的扁平序列。"""
+    return [
+        (job_id, step)
+        for job_id, job in _jobs(workflow).items()
+        for step in _steps(job)
+    ]
+
+
+def _run_text(job: dict[str, object]) -> str:
+    """把一个 job 全部 ``run`` 脚本拼成可搜索文本。"""
+    return "\n".join(str(step.get("run", "")) for step in _steps(job))
+
+
+def _needs(job: dict[str, object]) -> tuple[str, ...]:
+    """把 ``needs`` 规范化为字符串元组。"""
+    needs = job.get("needs")
+    if needs is None:
+        return ()
+    if type(needs) is str:
+        return (needs,)
+    return tuple(str(item) for item in needs)
+
+
+def _reachable(jobs: dict[str, dict[str, object]], job_id: str) -> set[str]:
+    """返回一个 job 通过 ``needs`` 传递依赖到的全部 job。"""
+    seen: set[str] = set()
+    frontier = [job_id]
+    while frontier:
+        current = frontier.pop()
+        for parent in _needs(jobs.get(current, {})):
+            if parent not in seen:
+                seen.add(parent)
+                frontier.append(parent)
+    return seen
+
+
+class WorkflowPresenceTest(unittest.TestCase):
+    """要求 Task 17 的全部文件真实存在且可解析。"""
+
+    def test_workflow_and_matrix_files_exist(self) -> None:
+        """CI/Release 工作流、dependabot 与 install matrix 必须全部落地。"""
+        for path in (
+            _CI_WORKFLOW,
+            _RELEASE_WORKFLOW,
+            _DEPENDABOT,
+            _MATRIX_RUNNER,
+            _MATRIX_CASES,
+        ):
+            self.assertTrue(path.is_file(), f"missing {path}")
+            self.assertFalse(path.is_symlink(), f"{path} must be a regular file")
+
+    def test_dev_extra_pins_the_yaml_parser(self) -> None:
+        """PyYAML 只能进入既有 dev extra，不得进入运行时依赖。"""
+        text = _PYPROJECT.read_text(encoding="utf-8")
+        self.assertIn('"PyYAML>=6.0.2,<7"', text)
+        runtime = text.split("[project.optional-dependencies]", 1)[0]
+        self.assertNotIn("PyYAML", runtime)
+
+
+class ActionPinningTest(unittest.TestCase):
+    """外部 Action 只能是已审阅 commit 的固定引用。"""
+
+    def test_every_action_reference_is_a_reviewed_commit_sha(self) -> None:
+        """两个工作流的每个 ``uses`` 都必须是 40 位 commit 且在审阅名单内。"""
+        for path in (_CI_WORKFLOW, _RELEASE_WORKFLOW):
+            workflow = _load(path)
+            for job_id, step in _all_steps(workflow):
+                if "uses" not in step:
+                    continue
+                reference = str(step["uses"])
+                with self.subTest(workflow=path.name, job=job_id, uses=reference):
+                    self.assertRegex(reference, _PINNED_USES)
+                    name, digest = reference.split("@", 1)
+                    self.assertIn(name, _REVIEWED_ACTIONS)
+                    self.assertEqual(digest, _REVIEWED_ACTIONS[name])
+
+    def test_no_job_uses_a_reusable_workflow_or_container_shortcut(self) -> None:
+        """禁止 job 级 ``uses``/``container`` 绕过被审阅的 Action 名单。"""
+        for path in (_CI_WORKFLOW, _RELEASE_WORKFLOW):
+            for job_id, job in _jobs(_load(path)).items():
+                with self.subTest(workflow=path.name, job=job_id):
+                    self.assertNotIn("uses", job)
+                    self.assertNotIn("container", job)
+
+
+class GateIntegrityTest(unittest.TestCase):
+    """任何门禁都不得被静默弱化。"""
+
+    def test_no_workflow_weakens_a_gate(self) -> None:
+        """禁止 ``continue-on-error``、``if: false`` 与 ``always()`` 类逃逸。"""
+        for path in (_CI_WORKFLOW, _RELEASE_WORKFLOW):
+            text = path.read_text(encoding="utf-8")
+            with self.subTest(workflow=path.name):
+                self.assertNotIn("continue-on-error", text)
+                self.assertNotIn("if: false", text)
+                self.assertNotIn("|| true", text)
+            workflow = _load(path)
+            for job_id, job in _jobs(workflow).items():
+                condition = str(job.get("if", ""))
+                if job_id in {"demote-release", "public-smoke"}:
+                    continue
+                with self.subTest(workflow=path.name, job=job_id):
+                    self.assertNotIn("always(", condition)
+            for job_id, step in _all_steps(workflow):
+                with self.subTest(workflow=path.name, job=job_id):
+                    self.assertNotIn("always(", str(step.get("if", "")))
+
+    def test_top_level_permissions_are_read_only(self) -> None:
+        """默认 token 权限必须是最小只读，写权限只能逐 job 声明。"""
+        for path in (_CI_WORKFLOW, _RELEASE_WORKFLOW):
+            workflow = _load(path)
+            with self.subTest(workflow=path.name):
+                self.assertEqual(workflow.get("permissions"), {"contents": "read"})
+
+    def test_no_workflow_carries_a_long_lived_publishing_token(self) -> None:
+        """除 ``GITHUB_TOKEN`` 外不得出现任何 secrets 引用或明文密码字段。"""
+        for path in (_CI_WORKFLOW, _RELEASE_WORKFLOW):
+            text = path.read_text(encoding="utf-8")
+            references = set(re.findall(r"secrets\.([A-Za-z0-9_]+)", text))
+            with self.subTest(workflow=path.name):
+                self.assertLessEqual(references, {"GITHUB_TOKEN"})
+                self.assertNotIn("PYPI_API_TOKEN", text)
+                self.assertNotIn("TWINE_PASSWORD", text)
+                self.assertNotIn("password:", text)
+                self.assertNotIn("--password ", text)
+                for line in text.splitlines():
+                    if "docker login" in line:
+                        self.assertIn("--password-stdin", line)
+
+
+class ContinuousIntegrationWorkflowTest(unittest.TestCase):
+    """CI 工作流必须提供计划要求的四个必需检查。"""
+
+    def setUp(self) -> None:
+        """加载 CI 工作流。"""
+        self.workflow = _load(_CI_WORKFLOW)
+        self.jobs = _jobs(self.workflow)
+
+    def test_required_checks_exist(self) -> None:
+        """必需检查 job id 必须与计划完全一致。"""
+        for job_id in _REQUIRED_CI_JOBS:
+            self.assertIn(job_id, self.jobs)
+
+    def test_ci_never_triggers_on_a_release_tag(self) -> None:
+        """CI 只在 push/pull_request 上运行，绝不响应 ``v*`` tag。"""
+        triggers = self.workflow.get("on")
+        self.assertEqual(set(triggers), {"push", "pull_request"})
+        self.assertNotIn("tags", triggers["push"])
+
+    def test_offline_job_runs_the_full_local_gate(self) -> None:
+        """offline 检查必须真实执行全量 unittest、Ruff 与文档校验。"""
+        text = _run_text(self.jobs["offline"])
+        self.assertIn("unittest discover -s tests", text)
+        self.assertIn("ruff check .", text)
+        self.assertIn("scripts/validate_docs.py", text)
+        self.assertIn("tests.test_install_matrix_contract", text)
+
+    def test_node_jobs_pin_both_accepted_runtimes(self) -> None:
+        """node-22/node-24 必须固定到策略允许的精确版本。"""
+        self.assertIn("22.22.3", _run_text(self.jobs["node-22"]))
+        self.assertIn("24.18.0", _run_text(self.jobs["node-24"]))
+
+    def test_artifact_build_proves_reproducibility(self) -> None:
+        """artifact-build 必须两次构建 installer 并比较摘要。"""
+        text = _run_text(self.jobs["artifact-build"])
+        self.assertIn("scripts/build_installer_zipapp.py", text)
+        self.assertIn("sha256sum", text)
+        self.assertIn("--local-offline", text)
+
+
+class ReleaseTriggerTest(unittest.TestCase):
+    """Release 只能由受保护的版本 tag 触发。"""
+
+    def setUp(self) -> None:
+        """加载 Release 工作流。"""
+        self.workflow = _load(_RELEASE_WORKFLOW)
+        self.jobs = _jobs(self.workflow)
+
+    def test_release_only_triggers_on_version_tags(self) -> None:
+        """禁止 branch push、手动派发或定时任务进入发布路径。"""
+        triggers = self.workflow.get("on")
+        self.assertEqual(set(triggers), {"push"})
+        self.assertEqual(triggers["push"], {"tags": ["v*"]})
+
+    def test_release_serializes_and_never_cancels_itself(self) -> None:
+        """发布必须串行且不得被后续运行取消到一半。"""
+        concurrency = self.workflow.get("concurrency")
+        self.assertEqual(concurrency.get("cancel-in-progress"), "false")
+
+    def test_guard_binds_the_tag_to_the_version_constant(self) -> None:
+        """guard 必须把 tag、``_version.py`` 与 commit 绑成一个事实。"""
+        text = _run_text(self.jobs["guard"])
+        self.assertIn("_version.py", text)
+        self.assertIn("SOURCE_DATE_EPOCH", text)
+        self.assertIn("git status --porcelain", text)
+
+    def test_required_release_jobs_exist(self) -> None:
+        """tier1-install、attestation、publish 必须真实存在。"""
+        for job_id in _REQUIRED_RELEASE_JOBS:
+            self.assertIn(job_id, self.jobs)
+
+
+class ReleaseObligationTest(unittest.TestCase):
+    """Task 16 复核实测得到的三条发布期强制义务。"""
+
+    def setUp(self) -> None:
+        """加载 Release 工作流并定位镜像构建步骤。"""
+        self.workflow = _load(_RELEASE_WORKFLOW)
+        self.jobs = _jobs(self.workflow)
+        self.image_steps = [
+            (job_id, step)
+            for job_id, step in _all_steps(self.workflow)
+            if _IMAGE_BUILD.search(str(step.get("run", "")))
+        ]
+
+    def _runtime_image_commands(self) -> list[tuple[str, str]]:
+        """返回每一条使用 ``deploy/Dockerfile`` 的 docker build 命令。"""
+        commands: list[tuple[str, str]] = []
+        for job_id, step in self.image_steps:
+            for command in re.split(
+                r"(?=docker\s+(?:buildx\s+)?build\b)", str(step["run"])
+            )[1:]:
+                if "deploy/Dockerfile" in command:
+                    commands.append((job_id, command))
+        return commands
+
+    def test_only_the_two_reviewed_dockerfiles_are_built(self) -> None:
+        """发布只允许构建 Runtime 与 Sandbox 两个已审阅 Dockerfile。"""
+        self.assertTrue(self.image_steps)
+        built = set()
+        for _job_id, step in self.image_steps:
+            built.update(re.findall(r"--file (\S+)", str(step["run"])))
+        self.assertEqual(built, {"deploy/Dockerfile", "deploy/sandbox.Dockerfile"})
+        self.assertTrue(self._runtime_image_commands())
+
+    def test_obligation_one_every_runtime_image_requires_native_bundles(self) -> None:
+        """义务一：Runtime 镜像构建必须传 ``LOBSTER0_REQUIRE_NATIVE_BUNDLES=1``。"""
+        for job_id, command in self._runtime_image_commands():
+            with self.subTest(job=job_id):
+                self.assertIn("--build-arg LOBSTER0_REQUIRE_NATIVE_BUNDLES=1", command)
+                self.assertNotIn("LOBSTER0_REQUIRE_NATIVE_BUNDLES=0", command)
+
+    def test_obligation_two_every_runtime_image_pins_the_wheel_digest(self) -> None:
+        """义务二：Runtime 镜像构建必须传非空 wheel 摘要，且来自 wheel 构建 job 的输出。"""
+        commands = self._runtime_image_commands()
+        self.assertTrue(commands)
+        for job_id, command in commands:
+            with self.subTest(job=job_id):
+                self.assertIn(
+                    f"--build-arg LOBSTER0_WHEEL_SHA256={_WHEEL_DIGEST_EXPRESSION}",
+                    command,
+                )
+                self.assertNotIn('LOBSTER0_WHEEL_SHA256=""', command)
+                digests = re.findall(r"LOBSTER0_WHEEL_SHA256=(\S*)", command)
+                self.assertTrue(digests)
+                for digest in digests:
+                    self.assertEqual(digest, "${{")
+
+    def test_obligation_two_wheel_digest_output_is_declared(self) -> None:
+        """被引用的 wheel 摘要必须是 python-build 真实声明的 job 输出。"""
+        python_build = self.jobs["python-build"]
+        outputs = python_build.get("outputs")
+        self.assertEqual(type(outputs), dict)
+        self.assertIn("wheel_sha256", outputs)
+        self.assertIn("sha256sum", _run_text(python_build))
+
+    def test_obligation_three_images_are_built_after_the_wheel(self) -> None:
+        """义务三：每个镜像构建 job 必须在依赖图上排在 wheel 构建之后。"""
+        for job_id, _step in self.image_steps:
+            with self.subTest(job=job_id):
+                self.assertIn("python-build", _reachable(self.jobs, job_id))
+
+    def test_obligation_three_image_job_consumes_only_the_fresh_wheel(self) -> None:
+        """镜像 job 必须重新取回本次 wheel 并按 job 输出摘要校验后才构建。"""
+        for job_id, _step in self.image_steps:
+            text = _run_text(self.jobs[job_id])
+            with self.subTest(job=job_id):
+                self.assertIn("gh release download", text)
+                self.assertIn(_WHEEL_DIGEST_EXPRESSION, text)
+                self.assertIn("sha256sum -c -", text)
+                self.assertNotIn("--cache-from", text)
+
+    def test_wheel_job_does_not_depend_on_any_image_job(self) -> None:
+        """wheel 构建不得反向依赖镜像，避免顺序义务被环状依赖抹平。"""
+        image_jobs = {job_id for job_id, _step in self.image_steps}
+        self.assertFalse(image_jobs & _reachable(self.jobs, "python-build"))
+
+
+class ReleaseAssemblyOrderTest(unittest.TestCase):
+    """装配顺序必须与计划固定的信任链一致。"""
+
+    def setUp(self) -> None:
+        """加载 Release 工作流的装配 job。"""
+        self.workflow = _load(_RELEASE_WORKFLOW)
+        self.jobs = _jobs(self.workflow)
+        self.assemble = self.jobs["assemble"]
+
+    def test_assembly_steps_run_in_the_fixed_order(self) -> None:
+        """SBOM → manifest → install.sh → checksums → verify 顺序不可交换。"""
+        commands: list[str] = []
+        for step in _steps(self.assemble):
+            for line in str(step.get("run", "")).splitlines():
+                for script in set(_ASSEMBLY_ORDER):
+                    if script in line:
+                        commands.append(script)
+        manifest_calls = [
+            index
+            for index, name in enumerate(commands)
+            if name == "scripts/build_release_manifest.py"
+        ]
+        self.assertEqual(len(manifest_calls), 2)
+        self.assertEqual(commands[0], "scripts/build_sbom.py")
+        self.assertEqual(commands[-1], "scripts/verify_release_artifacts.py")
+        render = commands.index("scripts/render_install_script.py")
+        self.assertLess(manifest_calls[0], render)
+        self.assertLess(render, manifest_calls[1])
+
+    def test_manifest_and_checksums_use_the_declared_subcommands(self) -> None:
+        """两次 manifest 调用必须分别是 ``manifest`` 与 ``checksums`` 子命令。"""
+        text = _run_text(self.assemble)
+        self.assertIn("manifest --release-inputs-output", text)
+        self.assertIn("checksums --manifest", text)
+        self.assertIn("--install-script", text)
+
+    def test_assembly_depends_on_every_artifact_producer(self) -> None:
+        """装配必须等待 wheel、Node bundle、TUI bundle 与镜像全部完成。"""
+        needs = set(_needs(self.assemble))
+        self.assertLessEqual(
+            {"python-build", "node-bundles", "tui-bundles", "images"}, needs
+        )
+
+    def test_nothing_is_attested_or_published_before_verification(self) -> None:
+        """attestation 与 publish 必须传递依赖于 assemble。"""
+        for job_id in ("attestation", "publish"):
+            with self.subTest(job=job_id):
+                self.assertIn("assemble", _reachable(self.jobs, job_id))
+
+
+class Tier1BlockingTest(unittest.TestCase):
+    """自托管 Tier 1 组合不可用必须真实阻断 stable 发布。"""
+
+    def setUp(self) -> None:
+        """加载 Release 工作流与 install matrix 定义。"""
+        self.workflow = _load(_RELEASE_WORKFLOW)
+        self.jobs = _jobs(self.workflow)
+        self.cases = json.loads(_MATRIX_CASES.read_text(encoding="utf-8"))
+
+    def test_publish_directly_needs_tier1_install(self) -> None:
+        """publish 的 ``needs`` 必须字面包含 tier1-install。"""
+        self.assertIn("tier1-install", _needs(self.jobs["publish"]))
+
+    def test_publish_has_no_condition_that_survives_a_skipped_tier1(self) -> None:
+        """publish 不得带任何在上游 skip 时仍会执行的条件。"""
+        self.assertNotIn("if", self.jobs["publish"])
+
+    def test_tier1_install_is_gated_by_a_runner_preflight(self) -> None:
+        """tier1-install 必须依赖一个会在 runner 缺失时失败的前置门禁。"""
+        preflight = "tier1-runner-preflight"
+        self.assertIn(preflight, self.jobs)
+        self.assertIn(preflight, _needs(self.jobs["tier1-install"]))
+        text = _run_text(self.jobs[preflight])
+        self.assertIn("actions/runners", text)
+        self.assertIn("PENDING", text)
+        self.assertIn("exit 1", text)
+
+    def test_preflight_enumerates_every_required_platform(self) -> None:
+        """前置门禁必须从 cases.json 读取需要的全部标签组合。"""
+        text = _run_text(self.jobs["tier1-runner-preflight"])
+        self.assertIn("tests/install_matrix/run_install_matrix.py", text)
+        self.assertIn("--required-runner-labels", text)
+        self.assertIn("cases.json", _MATRIX_RUNNER.read_text(encoding="utf-8"))
+        self.assertEqual(
+            len(self.cases["platforms"]),
+            len(json.loads(_MATRIX_CASES.read_text(encoding="utf-8"))["platforms"]),
+        )
+
+    def test_tier1_runs_on_self_hosted_labels_only(self) -> None:
+        """tier1-install 必须跑在自托管标签上，不得回落到 GitHub 托管 runner。"""
+        runs_on = str(self.jobs["tier1-install"].get("runs-on"))
+        self.assertIn("matrix.platform.runner_labels", runs_on)
+        self.assertNotIn("ubuntu-latest", runs_on)
+
+    def test_tier1_matrix_covers_exactly_the_declared_platforms(self) -> None:
+        """矩阵必须由 cases.json 的平台集合生成，不允许手写子集。"""
+        strategy = self.jobs["tier1-install"].get("strategy")
+        self.assertEqual(type(strategy), dict)
+        self.assertEqual(strategy.get("fail-fast"), "true")
+        matrix = strategy.get("matrix")
+        self.assertEqual(type(matrix), dict)
+        self.assertIn("needs.tier1-runner-preflight.outputs.platforms", str(matrix))
+
+    def test_tier1_executes_every_design_case(self) -> None:
+        """tier1-install 必须运行全部 15 个设计用例，不得挑选子集。"""
+        text = _run_text(self.jobs["tier1-install"])
+        self.assertIn("tests/install_matrix/run_install_matrix.py", text)
+        self.assertIn("--all-cases", text)
+        self.assertNotIn("--case ", text)
+
+    def test_tier1_has_a_bounded_timeout(self) -> None:
+        """缺 runner 时 tier1-install 必须超时失败，而不是无限排队。"""
+        for job_id in ("tier1-install", "tier1-runner-preflight"):
+            with self.subTest(job=job_id):
+                self.assertIn("timeout-minutes", self.jobs[job_id])
+
+    def test_evidence_records_pending_rather_than_pass(self) -> None:
+        """release evidence 必须能如实记录 PENDING 状态。"""
+        text = _run_text(self.jobs["tier1-runner-preflight"])
+        self.assertIn("release-evidence.json", text)
+
+
+class PublishTrustTest(unittest.TestCase):
+    """publish 只能在全部证据齐备后提升 stable。"""
+
+    def setUp(self) -> None:
+        """加载 Release 工作流。"""
+        self.workflow = _load(_RELEASE_WORKFLOW)
+        self.jobs = _jobs(self.workflow)
+        self.publish = self.jobs["publish"]
+
+    def test_publish_requests_oidc_and_registry_write_only(self) -> None:
+        """publish 权限必须精确到 OIDC、Release 写与 GHCR 写。"""
+        permissions = self.publish.get("permissions")
+        self.assertEqual(type(permissions), dict)
+        self.assertEqual(permissions["id-token"], "write")
+        self.assertEqual(permissions["contents"], "write")
+        self.assertEqual(permissions["packages"], "write")
+
+    def test_publish_runs_inside_a_protected_environment(self) -> None:
+        """PyPI 提升必须经过受保护 environment。"""
+        self.assertEqual(self.publish.get("environment"), "pypi")
+
+    def test_pypi_publish_uses_trusted_publishing(self) -> None:
+        """PyPI 只能走 OIDC Trusted Publishing。"""
+        uses = [str(step.get("uses", "")) for step in _steps(self.publish)]
+        self.assertTrue(
+            any(item.startswith("pypa/gh-action-pypi-publish@") for item in uses)
+        )
+        for step in _steps(self.publish):
+            if str(step.get("uses", "")).startswith("pypa/gh-action-pypi-publish@"):
+                self.assertNotIn("password", step.get("with", {}))
+
+    def test_publish_reverifies_before_promoting(self) -> None:
+        """publish 必须重新校验 checksums 与 attestation 后才提升 Release。"""
+        text = _run_text(self.publish)
+        self.assertIn("sha256sum -c", text)
+        self.assertIn("gh attestation verify", text)
+        self.assertIn("--draft=false", text)
+
+    def test_only_the_publish_job_can_reach_pypi_or_stable_tags(self) -> None:
+        """除 publish 外任何 job 都不得发布 PyPI 或打上稳定镜像 tag。"""
+        for job_id, job in self.jobs.items():
+            if job_id == "publish":
+                continue
+            text = _run_text(job)
+            uses = "\n".join(str(step.get("uses", "")) for step in _steps(job))
+            with self.subTest(job=job_id):
+                self.assertNotIn("gh-action-pypi-publish", uses)
+                self.assertNotIn("twine upload", text)
+                self.assertNotIn("--draft=false", text)
+                self.assertNotIn("imagetools create", text)
+
+    def test_images_are_pushed_by_digest_before_the_gates(self) -> None:
+        """门禁前镜像只能以 digest 形态存在，不得占用可解析 tag。"""
+        text = _run_text(self.jobs["images"])
+        self.assertIn("push-by-digest=true", text)
+        self.assertNotIn(":latest", text)
+
+    def test_attestation_covers_every_release_subject(self) -> None:
+        """attestation 必须对 manifest、checksums、install.sh 与全部 artifact 生效。"""
+        attestation = self.jobs["attestation"]
+        permissions = attestation.get("permissions")
+        self.assertEqual(permissions["id-token"], "write")
+        self.assertEqual(permissions["attestations"], "write")
+        with_blocks = [
+            step.get("with", {})
+            for step in _steps(attestation)
+            if str(step.get("uses", "")).startswith("actions/attest@")
+        ]
+        self.assertTrue(with_blocks)
+        subjects = "\n".join(str(block.get("subject-path", "")) for block in with_blocks)
+        for name in ("release-manifest.json", "SHA256SUMS", "install.sh"):
+            self.assertIn(name, subjects)
+
+
+class PostPublishSmokeTest(unittest.TestCase):
+    """提升后的公共 URL smoke 与失败回收路径。"""
+
+    def setUp(self) -> None:
+        """加载 Release 工作流。"""
+        self.workflow = _load(_RELEASE_WORKFLOW)
+        self.jobs = _jobs(self.workflow)
+
+    def test_public_smoke_uses_the_stable_latest_url(self) -> None:
+        """提升后必须从公开 ``latest/download/install.sh`` 再装一次。"""
+        text = _run_text(self.jobs["public-smoke"])
+        self.assertIn(_PUBLIC_INSTALL_URL, text)
+        self.assertIn("--proto '=https'", text)
+        self.assertIn("--tlsv1.2", text)
+
+    def test_failed_public_smoke_returns_the_release_to_draft(self) -> None:
+        """公共 smoke 失败必须立即把 Release 退回 draft 并记录 FAIL。"""
+        demote = self.jobs["demote-release"]
+        condition = str(demote.get("if", ""))
+        self.assertIn("failure()", condition)
+        self.assertIn("public-smoke", condition)
+        text = _run_text(demote)
+        self.assertIn("--draft=true", text)
+        self.assertIn("FAIL", text)
+        self.assertNotIn("yank", text)
+        self.assertNotIn("pypi", text.lower())
+
+
+class DependabotTest(unittest.TestCase):
+    """依赖更新必须覆盖 Action 与 Python 生态。"""
+
+    def test_dependabot_watches_actions_and_python(self) -> None:
+        """dependabot 必须同时监控 github-actions 与 pip。"""
+        document = _load(_DEPENDABOT)
+        self.assertEqual(document.get("version"), "2")
+        ecosystems = {
+            str(entry.get("package-ecosystem")) for entry in document.get("updates", [])
+        }
+        self.assertLessEqual({"github-actions", "pip"}, ecosystems)
+
+
+class InstallMatrixDefinitionTest(unittest.TestCase):
+    """install matrix 的用例与平台定义必须与设计文档一致。"""
+
+    def setUp(self) -> None:
+        """加载 cases.json。"""
+        self.document = json.loads(_MATRIX_CASES.read_text(encoding="utf-8"))
+
+    def test_exactly_the_fifteen_design_cases_are_declared(self) -> None:
+        """15 条设计用例必须一条不多、一条不少且编号连续。"""
+        cases = self.document["cases"]
+        self.assertEqual(len(cases), _DESIGN_CASE_COUNT)
+        numbers = sorted(int(case["design_case"]) for case in cases)
+        self.assertEqual(numbers, list(range(1, _DESIGN_CASE_COUNT + 1)))
+        identifiers = [str(case["id"]) for case in cases]
+        self.assertEqual(len(set(identifiers)), _DESIGN_CASE_COUNT)
+
+    def test_every_case_declares_its_local_evidence_or_a_pending_reason(self) -> None:
+        """本地无法证明的用例必须写明 PENDING 理由，不得静默跳过。"""
+        for case in self.document["cases"]:
+            with self.subTest(case=case["id"]):
+                if case["local_offline"] == "true" or case["local_offline"] is True:
+                    self.assertTrue(str(case.get("probe", "")))
+                else:
+                    self.assertTrue(str(case.get("pending_reason", "")))
+
+    def test_every_case_declares_a_live_command_or_a_live_pending_reason(self) -> None:
+        """主机上无法执行的用例必须写明 live PENDING 理由，绝不静默视为通过。"""
+        for case in self.document["cases"]:
+            with self.subTest(case=case["id"]):
+                command = case.get("live_command")
+                if command is None:
+                    self.assertTrue(str(case.get("live_pending_reason", "")))
+                else:
+                    self.assertIsInstance(command, list)
+                    self.assertTrue(command)
+                    self.assertNotIn("live_pending_reason", case)
+
+    def test_live_commands_only_use_verified_cli_subcommands(self) -> None:
+        """live 过程只能调用真实存在的 CLI 子命令。"""
+        verified = {"install-smoke", "doctor", "service", "update", "uninstall"}
+        for case in self.document["cases"]:
+            command = case.get("live_command")
+            if command is None:
+                continue
+            with self.subTest(case=case["id"]):
+                self.assertIn(str(command[0]), verified)
+
+    def test_platforms_match_the_tier_one_support_matrix(self) -> None:
+        """平台集合必须精确覆盖 Tier 1 的 OS/版本/架构组合。"""
+        platforms = self.document["platforms"]
+        expected = set()
+        for distro, versions in (
+            ("ubuntu", ("22.04", "24.04")),
+            ("debian", ("12", "13")),
+            ("rhel", ("9", "10")),
+            ("rocky", ("9", "10")),
+            ("almalinux", ("9", "10")),
+        ):
+            for version in versions:
+                for arch in ("x86_64", "arm64"):
+                    expected.add((distro, version, arch))
+        for arch in ("x86_64", "arm64"):
+            expected.add(("macos", "13", arch))
+        actual = {
+            (str(item["distro"]), str(item["distro_version"]), str(item["arch"]))
+            for item in platforms
+        }
+        self.assertEqual(actual, expected)
+
+    def test_every_platform_requires_self_hosted_labels(self) -> None:
+        """每个平台的 runner 标签必须含 self-hosted 且唯一。"""
+        seen: set[tuple[str, ...]] = set()
+        for platform in self.document["platforms"]:
+            labels = tuple(str(item) for item in platform["runner_labels"])
+            with self.subTest(platform=platform["id"]):
+                self.assertIn("self-hosted", labels)
+                self.assertNotIn(labels, seen)
+                self.assertIn(
+                    str(platform["artifact_platform"]),
+                    {"linux-x86_64", "linux-arm64", "macos-x86_64", "macos-arm64"},
+                )
+            seen.add(labels)
+
+
+class InstallMatrixRunnerTest(unittest.TestCase):
+    """``run_install_matrix.py`` 必须离线、stdlib-only 且如实报告。"""
+
+    def _run(self, *arguments: str) -> subprocess.CompletedProcess[str]:
+        """在仓库根目录执行 matrix runner。"""
+        return subprocess.run(
+            [sys.executable, str(_MATRIX_RUNNER), *arguments],
+            capture_output=True,
+            text=True,
+            cwd=_REPO_ROOT,
+            timeout=600,
+            check=False,
+        )
+
+    def test_runner_imports_only_the_standard_library(self) -> None:
+        """matrix runner 不得依赖任何第三方包。"""
+        text = _MATRIX_RUNNER.read_text(encoding="utf-8")
+        self.assertNotIn("import yaml", text)
+        self.assertNotIn("import requests", text)
+        self.assertNotIn("import httpx", text)
+
+    def test_list_prints_every_platform_and_case(self) -> None:
+        """``--list`` 必须打印全部平台标签与用例。"""
+        result = self._run("--list")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        document = json.loads(_MATRIX_CASES.read_text(encoding="utf-8"))
+        for platform in document["platforms"]:
+            self.assertIn(str(platform["id"]), result.stdout)
+        for case in document["cases"]:
+            self.assertIn(str(case["id"]), result.stdout)
+
+    def test_local_offline_matrix_passes_without_network_or_sudo(self) -> None:
+        """``--local-offline`` 必须在假 artifact 上全绿并如实标注 PENDING。"""
+        result = self._run("--local-offline")
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        self.assertIn("PASS", result.stdout)
+        self.assertNotIn("FAIL", result.stdout)
+        self.assertNotIn("sudo", result.stdout)
+
+    def test_local_offline_never_reports_host_bound_cases_as_pass(self) -> None:
+        """service/reboot 类用例在本地只能是 PENDING。"""
+        result = self._run("--local-offline")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        document = json.loads(_MATRIX_CASES.read_text(encoding="utf-8"))
+        for case in document["cases"]:
+            if str(case["local_offline"]).lower() == "true":
+                continue
+            for line in result.stdout.splitlines():
+                if line.split()[:1] == [str(case["id"])]:
+                    self.assertIn("PENDING", line)
+
+    def test_required_runner_labels_are_derivable_for_the_preflight(self) -> None:
+        """``--required-runner-labels`` 必须输出前置门禁使用的标签矩阵。"""
+        result = self._run("--required-runner-labels")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        document = json.loads(_MATRIX_CASES.read_text(encoding="utf-8"))
+        self.assertEqual(len(payload), len(document["platforms"]))
+        for entry in payload:
+            self.assertIn("self-hosted", entry["runner_labels"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -466,6 +466,59 @@ wheels = [
 ]
 
 [[package]]
+name = "lobster0-agent"
+source = { editable = "." }
+dependencies = [
+    { name = "croniter" },
+    { name = "httpx" },
+    { name = "textual" },
+]
+
+[package.optional-dependencies]
+all = [
+    { name = "discord-py" },
+    { name = "lark-channel-sdk" },
+    { name = "python-telegram-bot" },
+]
+channels = [
+    { name = "discord-py" },
+    { name = "lark-channel-sdk" },
+    { name = "python-telegram-bot" },
+]
+dev = [
+    { name = "pyyaml" },
+    { name = "ruff" },
+]
+discord = [
+    { name = "discord-py" },
+]
+feishu = [
+    { name = "lark-channel-sdk" },
+]
+telegram = [
+    { name = "python-telegram-bot" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "croniter", specifier = ">=6.2,<7" },
+    { name = "discord-py", marker = "extra == 'all'", specifier = ">=2.4,<3" },
+    { name = "discord-py", marker = "extra == 'channels'", specifier = ">=2.4,<3" },
+    { name = "discord-py", marker = "extra == 'discord'", specifier = ">=2.4,<3" },
+    { name = "httpx", specifier = ">=0.28,<1" },
+    { name = "lark-channel-sdk", marker = "extra == 'all'", specifier = ">=1.2,<2" },
+    { name = "lark-channel-sdk", marker = "extra == 'channels'", specifier = ">=1.2,<2" },
+    { name = "lark-channel-sdk", marker = "extra == 'feishu'", specifier = ">=1.2,<2" },
+    { name = "python-telegram-bot", marker = "extra == 'all'", specifier = ">=21,<23" },
+    { name = "python-telegram-bot", marker = "extra == 'channels'", specifier = ">=21,<23" },
+    { name = "python-telegram-bot", marker = "extra == 'telegram'", specifier = ">=21,<23" },
+    { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.2,<7" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9" },
+    { name = "textual", specifier = ">=8.2,<9" },
+]
+provides-extras = ["dev", "feishu", "telegram", "discord", "channels", "all"]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -502,57 +555,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec9
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
-
-[[package]]
-name = "lobster0-agent"
-source = { editable = "." }
-dependencies = [
-    { name = "croniter" },
-    { name = "httpx" },
-    { name = "textual" },
-]
-
-[package.optional-dependencies]
-all = [
-    { name = "discord-py" },
-    { name = "lark-channel-sdk" },
-    { name = "python-telegram-bot" },
-]
-channels = [
-    { name = "discord-py" },
-    { name = "lark-channel-sdk" },
-    { name = "python-telegram-bot" },
-]
-dev = [
-    { name = "ruff" },
-]
-discord = [
-    { name = "discord-py" },
-]
-feishu = [
-    { name = "lark-channel-sdk" },
-]
-telegram = [
-    { name = "python-telegram-bot" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "croniter", specifier = ">=6.2,<7" },
-    { name = "discord-py", marker = "extra == 'all'", specifier = ">=2.4,<3" },
-    { name = "discord-py", marker = "extra == 'channels'", specifier = ">=2.4,<3" },
-    { name = "discord-py", marker = "extra == 'discord'", specifier = ">=2.4,<3" },
-    { name = "httpx", specifier = ">=0.28,<1" },
-    { name = "lark-channel-sdk", marker = "extra == 'all'", specifier = ">=1.2,<2" },
-    { name = "lark-channel-sdk", marker = "extra == 'channels'", specifier = ">=1.2,<2" },
-    { name = "lark-channel-sdk", marker = "extra == 'feishu'", specifier = ">=1.2,<2" },
-    { name = "python-telegram-bot", marker = "extra == 'all'", specifier = ">=21,<23" },
-    { name = "python-telegram-bot", marker = "extra == 'channels'", specifier = ">=21,<23" },
-    { name = "python-telegram-bot", marker = "extra == 'telegram'", specifier = ">=21,<23" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9" },
-    { name = "textual", specifier = ">=8.2,<9" },
-]
-provides-extras = ["dev", "feishu", "telegram", "discord", "channels", "all"]
 
 [[package]]
 name = "multidict"
@@ -818,6 +820,52 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ba/77/153517bb1ac1bba670c6fb1dbf09e1fd0730494b1705934e715391413a0d/python_telegram_bot-22.8.tar.gz", hash = "sha256:f9d3847fcb23ee603477e442800b33bb4adf851a73e0619d2050be879decf1ef", size = 1551700, upload-time = "2026-06-12T08:10:29.1Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/7c/ed7d4dd94280bd434173cae9f7a7aedaaab9af128ae4f494423a5687c820/python_telegram_bot-22.8-py3-none-any.whl", hash = "sha256:42373918097f1b837cc4e717d588c19ea79651497ec712bb5b0c76e5e63c50e1", size = 769397, upload-time = "2026-06-12T08:10:27.066Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Milestone 9 / Task 17:CI 与受保护的发布提升流程——**安装包项目的最后一个 Milestone**。

- `.github/workflows/ci.yml` —— 全量 unittest / Ruff / docs / build、Node 22.22.3 与 24.18.0 双版本、安装器对抗性测试与产物可复现性。
- `.github/workflows/release.yml` —— 仅 `v*` 受保护 tag 触发,严格按计划规定的装配顺序:Python/Node/TUI/镜像/pyz → `build_sbom.py` → `manifest` → `render_install_script.py` → `checksums` → `verify_release_artifacts.py` → 逐 subject attest → 建草稿 Release → Tier 1 门禁 → 才允许发布。
- `tests/install_matrix/` + `tests/test_install_matrix_contract.py` —— 22 个 Tier 1 平台 × 15 个用例 = 330 组合的矩阵定义与契约测试。
- 所有 Action 固定到 40 位 commit SHA(计划已给出的四个已审阅 SHA);OIDC trusted publishing,工作流中无任何长期有效 token。

## 三条发布期强制义务的落实与守护

这三条来自 Task 16 复核时**实际构建容器踩到**的问题,若不强制会静默发出不完整或未校验的产物。每条都既写进 YAML,又有契约测试盯住(只写 YAML 不算数):

1. **`--build-arg LOBSTER0_REQUIRE_NATIVE_BUNDLES=1`**(release.yml:366)—— 由 `test_obligation_one_...` 守护:拆解每条 `docker build` 命令、筛出引用 `deploy/Dockerfile` 的、断言该参数存在且 `=0` 从不出现。另有 `test_only_the_two_reviewed_dockerfiles_are_built` 把可构建镜像集钉死为两个,防止新增镜像路径绕过检查。
2. **`--build-arg LOBSTER0_WHEEL_SHA256=<digest>`**(release.yml:367)—— 值必须literally 是 `${{ needs.python-build.outputs.wheel_sha256 }}`;`=""` 被拒;并断言 `python-build` 确实声明了该 output 且用 `sha256sum` 计算。
3. **wheel 先于镜像** —— 结构性保证:`images.needs` 含 `python-build`,且 `images` 从草稿 Release 重新下载 wheel 并 `sha256sum -c -` 比对该 job 输出的摘要后才构建(release.yml:340)。由传递依赖闭包测试 + 禁止 `--cache-from` + 禁止反向依赖成环共同守护。

## 零自托管 runner → 真正阻断正式发布

`tier1-runner-preflight` 从矩阵推导出 22 组必需 label,查询 `actions/runners`,要求每组都是某个**在线** runner label 的子集;不满足则写出 `status: PENDING` 的 `release-evidence.json`、镜像到 step summary,然后 `exit 1`。

**独立复核实测验证**(非纸面断言):
- 解析 YAML 得出 `publish` 的依赖闭包为 `publish ← tier1-install ← tier1-runner-preflight`,阻断链真实存在。
- `publish` **没有任何 `if:` 子句**,因此依赖被跳过时它必然被跳过。
- 全文检索两个工作流,`continue-on-error` / `if: false` / `|| true` / `always()` **零命中**,不存在让门禁假装通过的写法。
- 另一重保障:`GITHUB_TOKEN` 本身无权限列举 runner,该 API 调用失败被当作"无法证明可用性",同样计为 PENDING。

## Verification

- 焦点契约测试 **57/57**(RED 先行确认:改动前 5 failures + 49 errors)。
- `run_install_matrix.py --list`:exit 0,输出 `22 platforms x 15 cases = 330 Tier 1 combinations`。
- `run_install_matrix.py --local-offline`:exit 0,`pass=9 pending=6 blocked=0`。9 项 PASS 是针对安装器公开 API 的真实探测(22 台 Tier 1 主机解析 + 7 台越界拒绝、Node 策略闭包、未验证提权身份拒绝、未验证 bootstrap 以 code 2 拒绝且零写入、非 TTY JSON 边界 fail-closed、14 项声明能力可解析、版本一致性、1 个合法产物接受 + 7 个损坏/敌意输入拒绝、29 个发布输入文件的密钥扫描)。6 项 PENDING 各带明确原因,**从不标为 PASS**。
- 全量 1604 项,除已知的 4 项既有失败(本机 Node/pnpm 门槛、新工作区缺 `browser-worker/dist`)外无新增失败。
- Ruff、docs validator 合并 main 后重跑均 PASS。

## 复核记录的遗留缺口(如实标注)

**15 个 Tier 1 live 用例中仅 4 个已实现执行步骤**,其余 11 个带 `live_pending_reason` 并使 `--all-cases` 报 PENDING 且非零退出。开发者选择如实标注而非编造未经测试的执行步骤——这意味着**即使将来注册了 runner,正式发布仍会被阻断,直到这些步骤补齐**。这是当前最大的遗留缺口,已记入台账。

另有两项本地无法验证、需首次真实 tag 运行才能证实:`uv export --format cyclonedx1.5`(本机 uv 0.8.0 不支持该格式,工作流会安装 pinned 的 0.12.0)、以及 `actions/attest` 的输入参数名与 PyPI OIDC 路径。

## Checklist

- [x] 变更聚焦既定范围。
- [x] 已运行相关检查,含依赖闭包与门禁绕过写法的独立核验。
- [x] 未弱化任何门禁;PENDING 一律如实标注。
- [x] 工作流中无长期有效 token,未包含密钥或个人数据。
