### PR TITLE
ci(release): 增加受守卫的手动发布按钮

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,12 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: '要发布的版本号，必须与 src/lobster0/_version.py 完全一致，例如 0.7.0'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -43,7 +49,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
-      contents: read
+      contents: write
     outputs:
       version: ${{ steps.facts.outputs.version }}
       tag: ${{ steps.facts.outputs.tag }}
@@ -56,12 +62,36 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
-          persist-credentials: false
-      - name: Bind the tag, the version constant and the commit into one fact
-        id: facts
+          persist-credentials: ${{ github.event_name == 'workflow_dispatch' }}
+      # 手动派发只是把"创建 tag"这一步搬进流水线，绝不放宽发布前提：
+      # 仍然要求在默认分支、工作树干净、版本号与 _version.py 完全一致，
+      # 并在继续之前把 tag 真实创建出来，使后续所有作业与 tag-push 路径
+      # 绑定到同一个不可变事实上。既有 tag 与当前 HEAD 不符即失败。
+      - name: Create the release tag for a manual dispatch
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          tag="${GITHUB_REF_NAME}"
+          test "${GITHUB_REF_NAME}" = "${{ github.event.repository.default_branch }}"
+          printf '%s' "${INPUT_VERSION}" | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+          constant="$(python3 -c "import re,pathlib;print(re.search(r'__version__:\s*str\s*=\s*\"([^\"]+)\"',pathlib.Path('src/lobster0/_version.py').read_text(encoding='utf-8')).group(1))")"
+          test "${INPUT_VERSION}" = "${constant}"
+          test -z "$(git status --porcelain)"
+          tag="v${INPUT_VERSION}"
+          if git rev-parse --verify --quiet "refs/tags/${tag}" >/dev/null; then
+            test "$(git rev-parse --verify "${tag}^{commit}")" = "$(git rev-parse HEAD)"
+          else
+            git tag "${tag}" "$(git rev-parse HEAD)"
+            git push origin "refs/tags/${tag}"
+          fi
+      - name: Bind the tag, the version constant and the commit into one fact
+        id: facts
+        env:
+          DISPATCH_TAG: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', inputs.version) || '' }}
+        run: |
+          set -euo pipefail
+          tag="${DISPATCH_TAG:-${GITHUB_REF_NAME}}"
           version="${tag#v}"
           constant="$(python3 -c "import re,pathlib;print(re.search(r'__version__:\s*str\s*=\s*\"([^\"]+)\"',pathlib.Path('src/lobster0/_version.py').read_text(encoding='utf-8')).group(1))")"
           test "${version}" = "${constant}"

--- a/tests/test_install_matrix_contract.py
+++ b/tests/test_install_matrix_contract.py
@@ -256,11 +256,47 @@ class ReleaseTriggerTest(unittest.TestCase):
         self.workflow = _load(_RELEASE_WORKFLOW)
         self.jobs = _jobs(self.workflow)
 
-    def test_release_only_triggers_on_version_tags(self) -> None:
-        """禁止 branch push、手动派发或定时任务进入发布路径。"""
+    def test_release_only_triggers_on_version_tags_or_guarded_dispatch(self) -> None:
+        """只允许 ``v*`` tag 与受守卫的手动派发，禁止 branch push 与定时任务。
+
+        手动派发把"创建 tag"搬进流水线，方便在 GitHub UI 上点按钮发布；
+        它不放宽任何发布前提，仍由 guard 在继续之前真实创建 tag（见
+        ``test_dispatch_path_cannot_bypass_the_tag_binding``）。
+        """
         triggers = self.workflow.get("on")
-        self.assertEqual(set(triggers), {"push"})
+        self.assertEqual(set(triggers), {"push", "workflow_dispatch"})
         self.assertEqual(triggers["push"], {"tags": ["v*"]})
+        self.assertNotIn("branches", triggers["push"])
+        self.assertEqual(set(triggers["workflow_dispatch"]["inputs"]), {"version"})
+        self.assertEqual(triggers["workflow_dispatch"]["inputs"]["version"]["required"], "true")
+
+    def test_dispatch_path_cannot_bypass_the_tag_binding(self) -> None:
+        """手动派发必须与 tag-push 路径等价：默认分支、干净、版本一致、真建 tag。
+
+        这条测试是手动派发按钮的安全代价所在。若它被削弱，就可能从任意
+        分支、任意版本号发布一个没有不可变 tag 支撑的正式版。
+        """
+        text = _run_text(self.jobs["guard"])
+        self.assertIn("github.event.repository.default_branch", text)
+        self.assertIn("_version.py", text)
+        self.assertIn("git status --porcelain", text)
+        self.assertIn("git tag ", text)
+        self.assertIn("git push origin ", text)
+        self.assertIn("rev-parse --verify", text)
+
+    def test_only_the_guard_job_may_push_a_git_ref(self) -> None:
+        """只有 guard 允许推送 git 引用，杜绝第二处能创建或移动 tag 的地方。
+
+        多个作业持有 ``contents: write`` 是为了往草稿 Release 上传产物（草稿
+        即产物传递通道）。真正需要收紧的不是写权限本身，而是"谁能动 tag"：
+        tag 是发布产物绑定的不可变事实，只能由 guard 在校验通过后创建一次。
+        """
+        for job_id, job in self.jobs.items():
+            if job_id == "guard":
+                continue
+            text = _run_text(job)
+            self.assertNotIn("git push", text, f"{job_id} 不得推送任何 git 引用")
+            self.assertNotIn("git tag", text, f"{job_id} 不得创建或移动 tag")
 
     def test_release_serializes_and_never_cancels_itself(self) -> None:
         """发布必须串行且不得被后续运行取消到一半。"""


### PR DESCRIPTION
## Summary

在 GitHub UI 上加一个"发布"按钮,不必手敲 `git tag`。

**关键点:这不是放宽发布门禁,而是把"创建 tag"这一步搬进流水线。**

原契约测试 `test_release_only_triggers_on_version_tags` 明确禁止手动派发(测试名直译:"禁止 branch push、手动派发或定时任务进入发布路径"),因为计划要求发布产物必须绑定到不可变 tag。直接加 `workflow_dispatch` 会丢掉这个保证。

现在的做法:`workflow_dispatch` 只接受一个 `version` 输入,`guard` 作业在继续之前必须校验——

1. 运行在**默认分支**上;
2. 版本号与 `src/lobster0/_version.py` **完全一致**;
3. 工作树**干净**;
4. 然后**真实创建并推送 tag**。

之后所有作业与原 tag-push 路径绑定到同一个不可变事实。若同名 tag 已存在但指向的不是当前 HEAD,直接失败。

## 契约测试同步收紧(而非放宽)

- 触发器断言改为精确的 `{push(tags v*), workflow_dispatch(version required)}`,仍拒绝 branch push 与定时任务。
- 新增 `test_dispatch_path_cannot_bypass_the_tag_binding`,盯住上述四项前提。**经反向验证**:删掉分支校验后该测试失败,恢复后通过——不是摆设。
- 新增 `test_only_the_guard_job_may_push_a_git_ref`。复核中发现有 8 个作业持有 `contents: write`,但逐一核查后确认都是为了往草稿 Release 上传产物(Task 17 刻意用草稿作为产物传递通道以压缩 Action 白名单)。所以真正该收紧的不是写权限本身,而是**"谁能动 tag"**——断言只有 `guard` 可以 `git push` / `git tag`。

## Verification

- 契约测试 **59/59**(原 57 条全部保留 + 新增 2 条)。
- 反向验证新守卫测试确实有效(见上)。
- Ruff、docs validator 均 PASS。
- 未触碰 `pyproject.toml` / `uv.lock`。

## 用法

合并后:GitHub → Actions → "release" → Run workflow → 填版本号(如 `0.7.0`)→ 点绿色按钮。

原有的 `git tag v0.7.0 && git push origin v0.7.0` 方式**继续有效**,两条路径等价。