### PR TITLE
fix(install): 修复 Linux 上 inode 号复用导致误删他人文件

### DIFF
--- a/src/lobster0/install/layout.py
+++ b/src/lobster0/install/layout.py
@@ -1176,23 +1176,32 @@ def _ensure_safe_directory(path: Path, expected_uid: int, *, create_mode: int) -
 
 
 def _create_regular(path: Path, payload: bytes, mode: int) -> tuple[int, int]:
-    """先完整持久化私有 temp，再以 hardlink O_EXCL 发布 regular file。"""
-    temporary, identity = _prepare_regular(path, payload, mode)
+    """先完整持久化私有 temp，再以 hardlink O_EXCL 发布 regular file。
+
+    整个发布与失败清理过程中都持有 `_prepare_regular` 返回的描述符不放，
+    直到清理结束才关闭。这样内核无法回收本次 inode 号，`_unlink_same_inode`
+    的 ``(st_dev, st_ino)`` 归属判断才真正成立；否则竞态进程新建的文件可能
+    落在被复用的同一个 inode 号上，导致我们把别人的文件当成自己的删掉。
+    """
+    temporary, identity, descriptor = _prepare_regular(path, payload, mode)
     published = False
     try:
-        os.link(temporary, path, follow_symlinks=False)
-        published = True
-        _unlink_same_inode(temporary, identity)
-        metadata = path.lstat()
-        if (metadata.st_dev, metadata.st_ino) != identity or metadata.st_nlink != 1:
-            _ownership_invalid()
-        _fsync_directory(path.parent)
-        return identity
-    except BaseException:
-        if published:
-            _unlink_same_inode(path, identity)
-        _unlink_same_inode(temporary, identity)
-        raise
+        try:
+            os.link(temporary, path, follow_symlinks=False)
+            published = True
+            _unlink_same_inode(temporary, identity)
+            metadata = path.lstat()
+            if (metadata.st_dev, metadata.st_ino) != identity or metadata.st_nlink != 1:
+                _ownership_invalid()
+            _fsync_directory(path.parent)
+            return identity
+        except BaseException:
+            if published:
+                _unlink_same_inode(path, identity)
+            _unlink_same_inode(temporary, identity)
+            raise
+    finally:
+        os.close(descriptor)
 
 
 def _create_symlink(path: Path, target: str) -> tuple[int, int]:
@@ -1217,8 +1226,19 @@ def _create_symlink(path: Path, target: str) -> tuple[int, int]:
         raise
 
 
-def _prepare_regular(path: Path, payload: bytes, mode: int) -> tuple[Path, tuple[int, int]]:
-    """在目标同目录用 O_EXCL temp 完整写入、chmod 并 fsync regular bytes。"""
+def _prepare_regular(
+    path: Path, payload: bytes, mode: int
+) -> tuple[Path, tuple[int, int], int]:
+    """在目标同目录用 O_EXCL temp 完整写入、chmod 并 fsync regular bytes。
+
+    Returns:
+        temp 路径、``(st_dev, st_ino)`` 归属 token，以及**仍然打开**的描述符。
+
+    调用方必须持有该描述符直到本次发布的清理窗口结束，再自行关闭：只要它
+    还开着，内核就不会把这个 inode 号回收给别人。描述符一旦提前关闭，
+    inode 号立即可被复用，此后单靠 ``(st_dev, st_ino)`` 判断"这还是不是我
+    创建的文件"就不再成立——见 `_unlink_same_inode` 的说明。
+    """
     descriptor, temporary_name = tempfile.mkstemp(
         prefix=f".{path.name}.",
         suffix=".tmp",
@@ -1232,13 +1252,12 @@ def _prepare_regular(path: Path, payload: bytes, mode: int) -> tuple[Path, tuple
         os.fchmod(descriptor, mode)
         _write_all(descriptor, payload)
         os.fsync(descriptor)
-        return temporary, identity
+        return temporary, identity, descriptor
     except BaseException:
+        os.close(descriptor)
         if identity is not None:
             _unlink_same_inode(temporary, identity)
         raise
-    finally:
-        os.close(descriptor)
 
 
 def _write_all(descriptor: int, payload: bytes) -> None:

--- a/tests/test_desktop_launcher.py
+++ b/tests/test_desktop_launcher.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 from collections.abc import Mapping
@@ -13,6 +14,13 @@ from types import TracebackType
 
 REPOSITORY_ROOT = Path(__file__).resolve().parent.parent
 LAUNCHER_SOURCE = REPOSITORY_ROOT / "start-desktop.command"
+# `start-desktop.command` 是 macOS 专属入口：`.command` 后缀依赖 Finder 双击
+# 打开 Terminal 执行，脚本本身也固定 `#!/bin/zsh`。Linux 既没有该约定也没有
+# `/bin/zsh`，因此这些用例在非 macOS 上精确跳过，而不是把断言改宽。
+_MACOS_ONLY = unittest.skipUnless(
+    sys.platform == "darwin",
+    "start-desktop.command 是 macOS 专属入口（.command + /bin/zsh）",
+)
 
 
 class LauncherSandbox:
@@ -273,6 +281,7 @@ chmod 755 .venv/bin/python .venv/bin/lobster0
         target.chmod(0o755)
 
 
+@_MACOS_ONLY
 class DesktopLauncherTest(unittest.TestCase):
     """验证 Desktop 一键入口只执行受控且稳定的启动步骤。"""
 


### PR DESCRIPTION
## 这是一个真实的产品 bug,不是测试问题

首次真实跑发布流水线时暴露:**整套测试从未在 Linux 上运行过**,1604 项里挂了 20 项。逐一排查后确认,安装器崩溃窗口测试的失败是**产品代码在 Linux 上的真 bug**。

### 根因

`_prepare_regular` 在 `finally` 里提前 `os.close(descriptor)`,文件此后只由 pathname 持有,inode 号失去保护。**Linux 会立即把刚释放的 inode 号复用给新建文件,macOS 通常不会**——所以 macOS 上一直通过是侥幸。

### 后果

安装中途失败清理时,`_unlink_same_inode` 仅凭 `(st_dev, st_ino)` 判断"这还是不是我创建的文件"。若竞态进程此刻删掉我们的文件并新建一个自己的,新文件可能落在**被复用的同一 inode 号**上,且 uid/mode/nlink 恰好一致——清理逻辑就会把**别人的文件当成自己的删掉**。

而 Linux 正是这个安装器的**头号目标平台**。

### 修法

把描述符持有到发布与清理窗口结束再关闭。只要它还开着,内核就不会回收该 inode 号,现有的 `(st_dev, st_ino)` 归属判断随之重新成立——**无需改动比较逻辑本身**,也就不必在安全关键路径上做大改。

调用面很窄(`_prepare_regular` 与 `_create_regular` 各一处调用),改动风险可控。

### 另一类:macOS 专属功能

`test_desktop_launcher` 的 9 项失败源于硬编码 `/bin/zsh`。`start-desktop.command` 是 `.command` + `#!/bin/zsh` 的 **macOS 专属入口**(Finder 双击约定),Linux 既无该约定也无 `/bin/zsh`。按平台精确跳过并写明原因,而不是放宽断言或删除测试。

## Verification

- **Docker `python:3.12-slim` 非 root 用户下真实复现红→绿**(不是靠推测):`test_install_layout` 在 Linux 由 3 失败转为 **31/31 全通过**。
- **同容器基线对比**:未修改代码 5 failures + 45 errors,修改后 4 failures + 45 errors——修好 1 个,**未引入任何新失败**。那 45 个 errors 是本地容器缺少 CI 才有的构建产物,与代码无关。
- **macOS 无回归**:相关 5 个模块 **210/210 全通过**。
- Ruff PASS。

## 复核者应重点看

持有描述符会在发布窗口内多占用一个 fd。考虑到该窗口极短且每次安装只涉及少量文件,这个代价是值得的;但如果将来有批量创建大量文件的路径复用 `_create_regular`,需要重新评估。