### PR TITLE
fix(ci): 补齐 Linux 门禁剩余失败并修掉三处 Linux 真 bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,32 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/uv"
           tar -xzf "${RUNNER_TEMP}/uv.tar.gz" -C "${RUNNER_TEMP}/uv" --strip-components=1
           echo "${RUNNER_TEMP}/uv" >> "${GITHUB_PATH}"
+      - name: Install the default managed Node
+        run: |
+          set -euo pipefail
+          pin="$(python3 -c "import json;a=json.load(open('release/runtime-versions.json'))['node']['archives']['linux-x86_64'];print(a['url'],a['sha256'])")"
+          curl -fsSL --proto '=https' --tlsv1.2 --retry 3 \
+            -o "${RUNNER_TEMP}/node.tar.gz" "${pin%% *}"
+          printf '%s  %s\n' "${pin##* }" "${RUNNER_TEMP}/node.tar.gz" | sha256sum -c -
+          mkdir -p "${RUNNER_TEMP}/node"
+          tar -xzf "${RUNNER_TEMP}/node.tar.gz" -C "${RUNNER_TEMP}/node" --strip-components=1
+          echo "${RUNNER_TEMP}/node/bin" >> "${GITHUB_PATH}"
+      - name: Prepare the Node projects the offline suite executes
+        run: |
+          set -euo pipefail
+          node --version | grep -F 'v24.18.0'
+          corepack enable
+          # corepack 自带的 pnpm 新于项目 pin，且仓库根没有 package.json，
+          # `corepack pnpm --dir <project>` 解析不到项目声明的版本，会直接以
+          # 版本不符退出。显式激活项目 pin 之后 corepack 才会用正确的 pnpm。
+          pin="$(python3 -c "import json;t=json.load(open('tui/package.json'))['packageManager'];b=json.load(open('browser-worker/package.json'))['packageManager'];assert t==b,(t,b);print(t)")"
+          corepack prepare "${pin}" --activate
+          # BROWSER-017 需要真实的 Worker ProfileLock，test_release_bundles
+          # 需要已安装依赖的 tui 工作区；两者都不会由测试自己构建。
+          corepack pnpm --dir browser-worker install --frozen-lockfile
+          corepack pnpm --dir browser-worker build
+          test -f browser-worker/dist/profile.js
+          corepack pnpm --dir tui install --frozen-lockfile
       - name: Synchronize the locked development environment
         run: |
           set -euo pipefail
@@ -105,6 +131,7 @@ jobs:
           set -euo pipefail
           node --version | grep -F 'v22.22.3'
           corepack enable
+          corepack prepare "$(python3 -c "import json;print(json.load(open('tui/package.json'))['packageManager'])")" --activate
           corepack pnpm --dir tui install --frozen-lockfile
           corepack pnpm --dir tui test
           corepack pnpm --dir tui build
@@ -142,6 +169,7 @@ jobs:
           set -euo pipefail
           node --version | grep -F 'v24.18.0'
           corepack enable
+          corepack prepare "$(python3 -c "import json;print(json.load(open('tui/package.json'))['packageManager'])")" --activate
           corepack pnpm --dir tui install --frozen-lockfile
           corepack pnpm --dir tui test
           corepack pnpm --dir tui build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,6 +135,32 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/uv"
           tar -xzf "${RUNNER_TEMP}/uv.tar.gz" -C "${RUNNER_TEMP}/uv" --strip-components=1
           echo "${RUNNER_TEMP}/uv" >> "${GITHUB_PATH}"
+      - name: Install the default managed Node
+        run: |
+          set -euo pipefail
+          pin="$(python3 -c "import json;a=json.load(open('release/runtime-versions.json'))['node']['archives']['linux-x86_64'];print(a['url'],a['sha256'])")"
+          curl -fsSL --proto '=https' --tlsv1.2 --retry 3 \
+            -o "${RUNNER_TEMP}/node.tar.gz" "${pin%% *}"
+          printf '%s  %s\n' "${pin##* }" "${RUNNER_TEMP}/node.tar.gz" | sha256sum -c -
+          mkdir -p "${RUNNER_TEMP}/node"
+          tar -xzf "${RUNNER_TEMP}/node.tar.gz" -C "${RUNNER_TEMP}/node" --strip-components=1
+          echo "${RUNNER_TEMP}/node/bin" >> "${GITHUB_PATH}"
+      - name: Prepare the Node projects the offline suite executes
+        run: |
+          set -euo pipefail
+          node --version | grep -F 'v24.18.0'
+          corepack enable
+          # corepack 自带的 pnpm 新于项目 pin，且仓库根没有 package.json，
+          # `corepack pnpm --dir <project>` 解析不到项目声明的版本，会直接以
+          # 版本不符退出。显式激活项目 pin 之后 corepack 才会用正确的 pnpm。
+          pin="$(python3 -c "import json;t=json.load(open('tui/package.json'))['packageManager'];b=json.load(open('browser-worker/package.json'))['packageManager'];assert t==b,(t,b);print(t)")"
+          corepack prepare "${pin}" --activate
+          # BROWSER-017 需要真实的 Worker ProfileLock，test_release_bundles
+          # 需要已安装依赖的 tui 工作区；两者都不会由测试自己构建。
+          corepack pnpm --dir browser-worker install --frozen-lockfile
+          corepack pnpm --dir browser-worker build
+          test -f browser-worker/dist/profile.js
+          corepack pnpm --dir tui install --frozen-lockfile
       - name: Rerun the complete offline gate
         run: |
           set -euo pipefail
@@ -327,6 +353,7 @@ jobs:
           set -euo pipefail
           node --version | grep -F 'v24.18.0'
           corepack enable
+          corepack prepare "$(python3 -c "import json;print(json.load(open('tui/package.json'))['packageManager'])")" --activate
           mkdir -p "${RUNNER_TEMP}/bundles"
           python3 scripts/build_tui_bundle.py \
             --platform "${PLATFORM}" \

--- a/docs/engineering/operations/20260811_linux-ci-gate-second-round.md
+++ b/docs/engineering/operations/20260811_linux-ci-gate-second-round.md
@@ -1,0 +1,160 @@
+# Linux 离线门禁修复（第二轮）
+
+> 日期：2026-08-11 · 范围：`.github/workflows`、`src/lobster0/{config,tools,install}`、
+> `tests/test_install_{runtime,receipt,orchestrator}.py`
+
+## 1. 背景
+
+首次真实发布流水线运行暴露了一个长期盲区：整套测试从未在 Linux 上跑过。1604 项里挂了
+20 项。第一轮（`93d906d`）修掉 10 项，其中包含一个真产品 bug（`_prepare_regular` 过早
+`os.close` 导致 inode 号可被复用，清理逻辑可能删掉他人文件）。
+
+本轮处理剩余 10 项。所有结论都以 GitHub Actions 上 run `31437569137` 的 offline gate
+原始日志为准，而不是本地复现的猜测——本地容器里另有约 43 项与环境相关的噪声，必须按
+**增量**而不是绝对数量来判断。
+
+## 2. 十项失败的根因与处置
+
+| # | 用例 | 根因 | 处置 |
+| --- | --- | --- | --- |
+| 1 | `test_browser_evals::test_all_cases_pass_real_offline_components_without_sensitive_output` | CI 从不构建 `browser-worker/dist`，BROWSER-017 拿不到真实 ProfileLock | CI 配置 |
+| 2 | `test_cli_eval::test_run_browser_prints_versioned_cases_and_summary` | 同上 | CI 配置 |
+| 3 | `test_cli_eval::test_run_offline_prints_pass_rows_and_summary` | **产品 bug**：`_linux_cpu_model` 泄漏 `/proc/cpuinfo` handle，`ResourceWarning` 打到 stderr | 产品 |
+| 4 | `test_cli_eval::test_run_channel_and_all_print_independent_gate_summaries` | 同时命中 1 与 3 | CI + 产品 |
+| 5 | `test_install_runtime::test_discard_interrupted_staging_rejects_same_bytes_marker_inode_replacement` | 测试假设 unlink 后重建必得新 inode（仅 macOS 成立） | 测试 |
+| 6 | `test_install_runtime::test_default_runner_builds_with_offline_fake_uv` | 测试直接把 ambient `sys.base_prefix` 当受信 tree | 测试 |
+| 7 | `test_install_receipt::test_general_cleanup_quarantines_instead_of_unlinking_postcheck_replacement` | **产品 bug**：`InstallReceipt.write` / `_restore_receipt` 过早关闭描述符 | 产品 + 测试 |
+| 8 | `test_install_orchestrator::test_cleanup_preserves_replaced_downloads_inode` | **产品 bug**：downloads root 只记录 `(st_dev, st_ino)`，不钉住 inode | 产品 + 测试 |
+| 9 | `test_runtime::test_personal_runtime_uses_one_boundary_for_files_and_user_cli` | **产品缺陷**：`personal` profile 的默认写根被关在 `darwin` 分支里 | 产品 |
+| 10 | `test_release_bundles::TuiBundleTest::setUpClass` | offline gate 没有 Node，且 `corepack pnpm` 选到自带的新版 pnpm | CI 配置 |
+
+### 2.1 CI 配置：offline gate 缺 Node 侧前置
+
+两个工作流的 offline gate 都只装 Python + uv。于是：
+
+- `browser-worker/dist/profile.js` 从不存在，`_profile_lock` 直接判负；
+- `tui/node_modules` 从不存在，`scripts/build_tui_bundle.py` 无从执行。
+
+同时 `corepack pnpm --dir <project>` 在仓库根（没有 `package.json`）解析不到项目声明的
+`packageManager`，会用 corepack 自带的 pnpm 11 运行，随后被 pnpm 自己以「版本不符」拒绝。
+node-22 / node-24 两个 job 也栽在这里。
+
+修法（全部是 `run:` 步骤，不引入新的 Action，遵守已审阅 SHA 名单）：
+
+1. 按 `release/runtime-versions.json` 的固定 URL + SHA-256 装 Node 24.18.0；
+2. `corepack prepare "$(读 package.json 的 packageManager)" --activate`，并在 offline gate
+   里断言 `tui` 与 `browser-worker` 的 pin 完全一致；
+3. `corepack pnpm --dir browser-worker install --frozen-lockfile && … build`，并 `test -f
+   browser-worker/dist/profile.js`；
+4. `corepack pnpm --dir tui install --frozen-lockfile`。
+
+### 2.2 产品 bug：`/proc/cpuinfo` 句柄泄漏（仅 Linux）
+
+```python
+for line in open("/proc/cpuinfo", encoding="utf-8"):  # noqa: SIM115
+    if line.lower().startswith("model name"):
+        return line.partition(":")[2].strip() or None
+```
+
+命中型号那一行直接 `return`，文件对象永远不是显式关闭的，CPython 析构时报
+`ResourceWarning: unclosed file`。macOS 走 `platform.processor()` 分支，所以只在 Linux 出现。
+
+对用户的影响：默认 warning filter 下 `ResourceWarning` 是静默的，因此不会污染正常 CLI
+输出；但描述符要等 GC 才释放，且任何开启了 warning 的运行方式（`-X dev`、测试框架、
+把 stderr 当契约的调用方）都会看到噪声。改成 `with open(...)`。
+
+### 2.3 产品 bug：receipt 与 downloads root 的 inode 钉扎
+
+与第一轮同一类。`_unlink_same_inode` / `_quarantine_expected` 只凭 `(st_dev, st_ino)`
+判断「这还是不是我创建的东西」。这个判断只有在**调用方持有指向该 inode 的打开描述符**
+时才成立：描述符还开着，内核就不会回收 inode 号；一旦提前关闭，Linux 会立刻把它复用给
+新建文件/目录，竞态进程在同一 pathname 上的新对象就可能顶着同一个 inode 号被我们删掉。
+
+本轮补上两处：
+
+- `InstallReceipt.write`：描述符原本在 `os.replace` 之前就被内层 `finally` 关掉，之后的
+  temp 清理与 `_restore_receipt` 全程无保护。改为在外层 `finally` 关闭——`finally` 在
+  `except` 之后执行，清理期间描述符仍然打开。
+- `_restore_receipt`：recovery 描述符同理，持有到 link 发布与全部清理结束。
+- `InstallOperations._download_roots`：改存 `(root, identity, descriptor)`，在 `download()`
+  里用 `O_DIRECTORY|O_NOFOLLOW` 打开 downloads root 并 `os.fstat` 取 identity，事务
+  `cleanup()` 删完再关。目录 inode 同样能被描述符钉住。
+
+对应的三个用例原本靠「macOS 不会立刻复用 inode 号」这一巧合来制造 identity 失配。现在
+让测试按真实契约持有描述符（或先建 sibling 再 `os.replace`），失配在两个平台上都必然
+成立，断言反而更硬：证明的是「identity 校验发生在原子 quarantine/rename 之后，失配时
+恢复而不是删除」这条真正的不变量。
+
+### 2.4 产品缺陷：Linux 上 `personal` profile 没有任何写根
+
+`resolve_permission_roots` 把默认写根整段关在 `if platform == "darwin"` 里。Linux 用户
+选了 `personal` profile，能读整个 Home，却在 Workspace 之外一处都不能写——而 Linux 是
+本项目的头号目标平台。
+
+`Desktop`/`Documents`/`Downloads` 正是 Linux `xdg-user-dirs` 的默认英文名，
+`PycharmProjects`/`WebstormProjects` 是 JetBrains 各平台相同的默认目录，且
+`_existing_unique_roots` 本来就会剔除不存在的目录。因此把这段提到平台判断之外；
+`/Applications`、`/opt/homebrew`、`/usr/local` 这三个**读**根仍然只在 macOS 生效。
+
+### 2.5 测试假设：ambient 解释器不是受信 tree
+
+`test_default_runner_builds_with_offline_fake_uv` 需要一个能真正执行的完整 CPython，
+于是直接把 `sys.base_prefix` 当 `managed_python_root`。但那棵树的位置、权限与内容完全
+由环境决定，installer 的 trusted-tree 校验会——正确地——拒绝其中好几种形态。改为复制进
+测试自己的 0700 sandbox，归一化 mode、丢弃 casefold 重复项、清掉因此悬空的 alias。
+
+## 3. 未修复：真实 uv managed Linux Python 会被安装器拒绝
+
+**这是本轮发现的、比第一轮更严重的产品缺陷，尚未修复。**
+
+`release/install.sh.tmpl` 用 `uv python install 3.12` provision managed Python，并把它的
+根目录作为 `--managed-python-root` 交给 installer。`_preflight` 会对这棵树跑
+`_validate_source_tree`，其中有一条 casefold 去重：
+
+```python
+if relative.casefold() in seen:
+    _runtime_failed()
+```
+
+而 uv 在 Linux 上装的 CPython（python-build-standalone）带 `share/terminfo`，里面存在
+`share/terminfo/P` 与 `share/terminfo/p`、`N` 与 `n` 等仅大小写不同的条目。实测
+`cpython-3.12.13-linux-x86_64-gnu` 有 4697 个条目、33 处 casefold 冲突，
+`cpython-3.12.13-linux-aarch64-gnu` 有 4915 个条目、33 处冲突。
+
+实测结论（非 root 容器内直接调用产品函数）：
+
+```
+managed python root: …/uv/python/cpython-3.12.13-linux-aarch64-gnu
+REJECTED: InstallError runtime_install_failed: manifest
+```
+
+即：**Linux 上任何一次真实的一行安装都会以 `runtime_install_failed: manifest` 失败。**
+macOS 侥幸躲过，因为 python-build-standalone 的 macOS 构建链接系统 ncurses、不带
+terminfo，而且大小写不敏感的文件系统上这类条目本来就无法共存。
+
+这条检查本身是有价值的（防止把 tree 复制到大小写不敏感的目标时静默合并条目），所以
+**不应该简单删掉**。可选方向：
+
+1. 只在目标文件系统确实大小写不敏感时才拒绝（一次性探测）；
+2. 依赖 `_copy_verified_tree` 复制后与源 manifest 的比对来发现真实合并，把这条前置拒绝
+   降级为目标侧校验。
+
+两条都会改动安装器的信任策略，需要单独设计与评审，因此本轮只记录、不擅自修改。发布
+Linux 版之前必须先解决。
+
+## 4. 验证
+
+- Linux：`docker run python:3.12-slim` + 非 root 用户 + uv managed Python，逐模块红→绿；
+  与 `git stash` 后的同容器基线对比，`comm` 显示 4 项由失败转通过、**0 项新增失败**。
+  `test_browser_evals` 与 `test_cli_eval` 在补齐 Node 与 `browser-worker/dist` 后通过；
+  `TuiBundleTest` 在 `corepack prepare` + `pnpm --dir tui install` 后 5/5 通过。
+- macOS：`uv run python -m unittest discover -s tests -q` 全绿。
+- `uv run --with ruff ruff check .`、`uv run python scripts/validate_docs.py` 均通过
+  （顺带修掉 `3f14383` 引入的一处 `I001` import 排序，它同样会挡住 offline gate）。
+
+## 5. 容器里的环境噪声（不要追）
+
+`python:3.12-slim` 里另有约 43 项 error / 3 项 failure，在改动前后完全一致，且在 GitHub
+runner 上不出现。已确认的成因包括：`/usr/bin/python3` 不存在（closed-world PATH 固定为
+`/usr/bin:/bin`）、uv 数据目录是 group-writable、以及 `ACTION-OPEN-APP-001` 在无桌面环境
+的容器里必然 `execution_error`。判断改动效果只看**增量**。

--- a/docs/engineering/phase-2/20260808_personal-machine-permissions.md
+++ b/docs/engineering/phase-2/20260808_personal-machine-permissions.md
@@ -113,17 +113,21 @@ sequenceDiagram
 
 ## 7. 默认 Roots
 
-macOS `personal` Profile 在目录真实存在时使用：
+`personal` Profile 在目录真实存在时使用：
 
 ### Read roots
 
 1. Owner Home；
-2. `/Applications`；
-3. `/opt/homebrew`；
-4. `/usr/local`；
+2. `/Applications`（仅 macOS）；
+3. `/opt/homebrew`（仅 macOS）；
+4. `/usr/local`（仅 macOS）；
 5. `[permissions].read_roots` 中的显式真实目录。
 
 ### Write roots
+
+默认写根与平台无关，macOS 与 Linux 使用同一份清单：`Desktop`/`Documents`/`Downloads`
+正是 Linux `xdg-user-dirs` 的默认英文名，`PycharmProjects`/`WebstormProjects` 是
+JetBrains 在各平台相同的默认目录。
 
 1. `~/Desktop`；
 2. `~/Documents`；

--- a/src/lobster0/config.py
+++ b/src/lobster0/config.py
@@ -1619,16 +1619,22 @@ def resolve_permission_roots(
         read_candidates.extend(
             Path(value) for value in ("/Applications", "/opt/homebrew", "/usr/local")
         )
-        write_candidates.extend(
-            owner_home / name
-            for name in (
-                "Desktop",
-                "Documents",
-                "Downloads",
-                "PycharmProjects",
-                "WebstormProjects",
-            )
+    # 默认可写根对所有 POSIX 平台一致：Desktop/Documents/Downloads 正是 Linux
+    # xdg-user-dirs 的默认英文名，PycharmProjects/WebstormProjects 是 JetBrains
+    # 在各平台相同的默认目录。之前这段被关在 darwin 分支里，Linux 上 personal
+    # profile 因此解析出空的 write_roots——用户能读整个 Home，却在 Workspace
+    # 之外一处都不能写。`_existing_unique_roots` 已经会剔除不存在的目录，所以
+    # 这份清单在任何平台上都自动收敛为真实存在的那几个。
+    write_candidates.extend(
+        owner_home / name
+        for name in (
+            "Desktop",
+            "Documents",
+            "Downloads",
+            "PycharmProjects",
+            "WebstormProjects",
         )
+    )
     write_candidates.extend(permissions.write_roots)
     return ResolvedPermissionRoots(
         owner_home,

--- a/src/lobster0/install/orchestrator.py
+++ b/src/lobster0/install/orchestrator.py
@@ -679,7 +679,9 @@ class _SystemOperations:
         self.interactive_runner = _InteractiveSubprocessRunner()
         self._platform: DetectedPlatform | None = None
         self._downloaded: dict[Path, _Downloaded] = {}
-        self._download_roots: dict[Path, tuple[Path, tuple[int, int]]] = {}
+        # (root, identity, descriptor)：descriptor 在整个事务里保持打开，用来钉住
+        # downloads root 的 inode 号，详见 `download` 与 `cleanup` 的说明。
+        self._download_roots: dict[Path, tuple[Path, tuple[int, int], int]] = {}
         self._previous: dict[Path, str | None] = {}
         self._prior_receipts: dict[Path, InstallReceipt | None] = {}
         self._launcher_existed: dict[Path, bool] = {}
@@ -877,10 +879,24 @@ class _SystemOperations:
             layout.runtimes_dir.mkdir(mode=runtime_parent_mode, parents=True, exist_ok=True)
             root = layout.runtimes_dir / f".{plan.manifest.version}.downloads"
             root.mkdir(mode=0o700)
-            root_metadata = root.lstat()
+            # 事务全程持有 downloads root 的 no-follow 目录描述符。`cleanup` 只凭
+            # 记录下来的 (st_dev, st_ino) 判断"这还是不是我建的那棵树"；描述符
+            # 一旦不在，Linux 会立刻把该 inode 号复用给新建目录，同路径上出现的
+            # foreign 目录就可能顶着同一个 inode 号被我们递归删掉。描述符钉住
+            # inode 号后，这个 identity 判断才重新成立。
+            root_descriptor = os.open(
+                root,
+                os.O_RDONLY
+                | getattr(os, "O_DIRECTORY", 0)
+                | getattr(os, "O_NOFOLLOW", 0)
+                | getattr(os, "O_CLOEXEC", 0),
+            )
+            root_metadata = os.fstat(root_descriptor)
+            self._close_download_root(layout.program_prefix)
             self._download_roots[layout.program_prefix] = (
                 root,
                 (root_metadata.st_dev, root_metadata.st_ino),
+                root_descriptor,
             )
             selected = {
                 kind: plan.manifest.require_artifact(kind, plan.platform)
@@ -1276,7 +1292,7 @@ class _SystemOperations:
             _unlink_ephemeral(sandbox)
         if download_receipt is None:
             return
-        download_root, identity = download_receipt
+        download_root, identity, descriptor = download_receipt
         try:
             if download_root.parent == layout.runtimes_dir and download_root.name == (
                 f".{layout.runtime.name}.downloads"
@@ -1284,6 +1300,24 @@ class _SystemOperations:
                 _discard_downloads_tree(layout, download_root, identity, lock)
         except (InstallError, OSError):
             pass
+        finally:
+            # 描述符要活到删除动作真正结束：在此之前它一直在阻止内核回收本次
+            # downloads root 的 inode 号，identity 判断才不会认领到别人的目录。
+            _close_descriptor(descriptor)
+
+    def _close_download_root(self, program_prefix: Path) -> None:
+        """释放同一 prefix 上遗留的 downloads root 描述符，避免泄漏。"""
+        previous = self._download_roots.pop(program_prefix, None)
+        if previous is not None:
+            _close_descriptor(previous[2])
+
+
+def _close_descriptor(descriptor: int) -> None:
+    """关闭已持有的描述符，忽略重复关闭这类无后果的失败。"""
+    try:
+        os.close(descriptor)
+    except OSError:
+        pass
 
 
 def _discard_stale_downloads(layout: InstallLayout, lock: InstallLock) -> bool:

--- a/src/lobster0/install/receipt.py
+++ b/src/lobster0/install/receipt.py
@@ -303,6 +303,7 @@ class InstallReceipt:
         temporary_identity: tuple[int, int] | None = None
         replaced_identity: tuple[int, int] | None = None
         replaced = False
+        descriptor = -1
         try:
             descriptor = os.open(
                 temporary,
@@ -311,14 +312,11 @@ class InstallReceipt:
             )
             metadata = os.fstat(descriptor)
             temporary_identity = (metadata.st_dev, metadata.st_ino)
-            try:
-                os.fchmod(descriptor, 0o600)
-                if metadata.st_uid != uid:
-                    os.fchown(descriptor, uid, -1)
-                _write_all(descriptor, payload)
-                os.fsync(descriptor)
-            finally:
-                os.close(descriptor)
+            os.fchmod(descriptor, 0o600)
+            if metadata.st_uid != uid:
+                os.fchown(descriptor, uid, -1)
+            _write_all(descriptor, payload)
+            os.fsync(descriptor)
             os.replace(temporary, path)
             replaced = True
             replaced_identity = temporary_identity
@@ -330,6 +328,14 @@ class InstallReceipt:
             if replaced and replaced_identity is not None:
                 _restore_receipt(path, original, uid, replaced_identity)
             raise InstallError("uninstall_ownership_mismatch", "manifest") from error
+        finally:
+            # 描述符必须活过 replace 与整个失败清理窗口：`_unlink_same_inode`
+            # 只凭 (st_dev, st_ino) 认领文件，而 Linux 会立刻把刚释放的 inode 号
+            # 复用给新建文件。提前关闭就等于放开 inode 号，之后清理可能删掉
+            # 竞态进程刚创建的同名新文件。`finally` 在 `except` 之后执行，
+            # 所以清理期间它仍然是打开的。
+            if descriptor >= 0:
+                os.close(descriptor)
 
 
 def managed_file_sha256(
@@ -546,42 +552,47 @@ def _restore_receipt(
     identity: tuple[int, int] | None = None
     quarantined: _QuarantinedPath | None = None
     published = False
+    descriptor = -1
     try:
-        quarantined = _quarantine_expected(path, replaced_identity, require_symlink=False)
-        if quarantined is None:
-            return
-        descriptor = os.open(
-            recovery,
-            os.O_WRONLY | os.O_CREAT | os.O_EXCL | _no_follow_flag(),
-            0o600,
-        )
-        metadata = os.fstat(descriptor)
-        identity = (metadata.st_dev, metadata.st_ino)
         try:
+            quarantined = _quarantine_expected(path, replaced_identity, require_symlink=False)
+            if quarantined is None:
+                return
+            descriptor = os.open(
+                recovery,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | _no_follow_flag(),
+                0o600,
+            )
+            metadata = os.fstat(descriptor)
+            identity = (metadata.st_dev, metadata.st_ino)
             os.fchmod(descriptor, 0o600)
             if metadata.st_uid != owner_uid:
                 os.fchown(descriptor, owner_uid, -1)
             _write_all(descriptor, original)
             os.fsync(descriptor)
-        finally:
-            os.close(descriptor)
-        os.link(recovery, path, follow_symlinks=False)
-        published = True
-        _unlink_same_inode(recovery, identity)
-        try:
-            _fsync_directory(path.parent)
-        except OSError:
-            _invalid()
-        if not quarantined.discard():
-            _invalid()
-    except OSError:
-        if published and identity is not None:
-            _unlink_same_inode(path, identity)
-        if quarantined is not None and not quarantined.restore():
-            _invalid()
-    finally:
-        if identity is not None:
+            os.link(recovery, path, follow_symlinks=False)
+            published = True
             _unlink_same_inode(recovery, identity)
+            try:
+                _fsync_directory(path.parent)
+            except OSError:
+                _invalid()
+            if not quarantined.discard():
+                _invalid()
+        except OSError:
+            if published and identity is not None:
+                _unlink_same_inode(path, identity)
+            if quarantined is not None and not quarantined.restore():
+                _invalid()
+        finally:
+            if identity is not None:
+                _unlink_same_inode(recovery, identity)
+    finally:
+        # 与 `InstallReceipt.write` 同理：recovery 描述符必须活过 link 发布与
+        # 全部 `_unlink_same_inode` 清理，否则 Linux 复用 inode 号后，这些清理
+        # 可能认领并删掉别人的同名文件。
+        if descriptor >= 0:
+            os.close(descriptor)
 
 
 def _fsync_directory(path: Path) -> None:
@@ -604,7 +615,14 @@ def _write_all(descriptor: int, payload: bytes) -> None:
 
 
 def _unlink_same_inode(path: Path, identity: tuple[int, int]) -> None:
-    """把公开 pathname 隔离后，仅清理匹配调用方 token 的目录项。"""
+    """把公开 pathname 隔离后，仅清理匹配调用方 token 的目录项。
+
+    归属判断只有 ``(st_dev, st_ino)``，因此**调用方必须在整个清理窗口内持有一个
+    指向该 inode 的打开描述符**。只要描述符还开着，内核就不会回收这个 inode 号；
+    一旦提前关闭，Linux 会立刻把它复用给新建文件，此时竞态进程在同一 pathname
+    上新建的文件可能带着同一个 inode 号出现，这里就会把别人的文件当成自己的删掉。
+    macOS 通常不这么快复用 inode 号，所以该缺陷只在 Linux 上稳定复现。
+    """
     quarantined = _quarantine_expected(path, identity)
     if quarantined is not None and not quarantined.discard():
         _invalid()

--- a/src/lobster0/storage/conversations.py
+++ b/src/lobster0/storage/conversations.py
@@ -10,7 +10,6 @@ from datetime import UTC, datetime
 from lobster0.providers.base import JsonValue, ModelMessage
 from lobster0.storage.database import Database
 
-
 CONTEXT_RESET_SUMMARY = (
     "【会话上下文已由 Owner 重置】\n"
     "这条摘要之前的对话历史已归档，不再作为上下文。当前没有待办任务、没有待续的代码改动、"

--- a/src/lobster0/tools/system.py
+++ b/src/lobster0/tools/system.py
@@ -223,13 +223,21 @@ def _run_fixed(argv: list[str]) -> subprocess.CompletedProcess[str] | None:
 
 
 def _linux_cpu_model() -> str | None:
-    """从 Linux 标准 procfs 读取第一个 CPU 型号。"""
+    """从 Linux 标准 procfs 读取第一个 CPU 型号。
+
+    必须用 context manager 持有 handle：直接 ``for line in open(...)`` 再从循环里
+    ``return``，会把关闭时机交给 GC，命中型号那一行时文件永远不是显式关闭的，
+    CPython 因此在析构时报 ``ResourceWarning: unclosed file``。这条路径只在
+    Linux 上执行，macOS 走 ``platform.processor()`` 分支，所以泄漏只会在
+    Linux——也就是本项目的头号目标平台——上出现。
+    """
     if platform.system() != "Linux":
         return platform.processor() or None
     try:
-        for line in open("/proc/cpuinfo", encoding="utf-8"):  # noqa: SIM115
-            if line.lower().startswith("model name"):
-                return line.partition(":")[2].strip() or None
+        with open("/proc/cpuinfo", encoding="utf-8") as handle:
+            for line in handle:
+                if line.lower().startswith("model name"):
+                    return line.partition(":")[2].strip() or None
     except OSError:
         return None
     return None

--- a/tests/test_install_orchestrator.py
+++ b/tests/test_install_orchestrator.py
@@ -1421,10 +1421,12 @@ class RetryRecoveryTests(unittest.TestCase):
         """事务 cleanup 只能删除 download 时绑定的 exact inode。"""
         downloads = self.layout.runtimes_dir / ".0.7.0.downloads"
         downloads.mkdir(mode=0o700)
-        metadata = downloads.lstat()
+        descriptor = os.open(downloads, os.O_RDONLY | os.O_DIRECTORY)
+        metadata = os.fstat(descriptor)
         self.operations._download_roots[self.layout.program_prefix] = (
             downloads,
             (metadata.st_dev, metadata.st_ino),
+            descriptor,
         )
         with mock.patch(
             "lobster0.install.layout._probe_process",
@@ -1435,17 +1437,26 @@ class RetryRecoveryTests(unittest.TestCase):
         self.assertFalse(downloads.exists())
 
     def test_cleanup_preserves_replaced_downloads_inode(self) -> None:
-        """同路径 foreign replacement 不得被事务 finally 当作 staging 删除。"""
+        """同路径 foreign replacement 不得被事务 finally 当作 staging 删除。
+
+        按 `download` 的真实契约持有 downloads root 的目录描述符：inode 号被钉住
+        之后，rmdir + mkdir 出来的 foreign 目录在 Linux 与 macOS 上都必然拿到另一个
+        inode 号。不钉住的话 Linux 会把刚释放的 inode 号立刻复用给这个 foreign
+        目录，记录下来的 identity 就会错误匹配，cleanup 会把它整棵删掉。
+        """
         downloads = self.layout.runtimes_dir / ".0.7.0.downloads"
         downloads.mkdir(mode=0o700)
-        metadata = downloads.lstat()
+        descriptor = os.open(downloads, os.O_RDONLY | os.O_DIRECTORY)
+        metadata = os.fstat(descriptor)
         downloads.rmdir()
         downloads.mkdir(mode=0o700)
+        self.assertNotEqual(downloads.lstat().st_ino, metadata.st_ino)
         marker = downloads / "foreign"
         marker.write_bytes(b"foreign")
         self.operations._download_roots[self.layout.program_prefix] = (
             downloads,
             (metadata.st_dev, metadata.st_ino),
+            descriptor,
         )
         with mock.patch(
             "lobster0.install.layout._probe_process",

--- a/tests/test_install_receipt.py
+++ b/tests/test_install_receipt.py
@@ -278,12 +278,23 @@ class InstallReceiptTests(unittest.TestCase):
         self.assertFalse(any(path.name.endswith(".tmp") for path in self.root.iterdir()))
 
     def test_general_cleanup_quarantines_instead_of_unlinking_postcheck_replacement(self) -> None:
-        """通用 temp cleanup 的最终 lstat 后 replacement 也不能被 pathname unlink。"""
+        """通用 temp cleanup 的最终 lstat 后 replacement 也不能被 pathname unlink。
+
+        这里按 `_unlink_same_inode` 的真实契约持有 target 的打开描述符：只有
+        inode 被描述符钉住，``(st_dev, st_ino)`` token 才代表"我创建的那个文件"。
+        描述符一关，Linux 会立刻把该 inode 号复用给 replacement，token 便会错误
+        地匹配上别人的文件——macOS 只是碰巧不这么快复用而已。钉住之后
+        replacement 在两个平台上都必然落在不同 inode 上，这条断言才真正在证明
+        "identity 校验发生在原子 quarantine rename 之后，失配时恢复而不是删除"。
+        """
         target = self.root / "owned.tmp"
         target.write_bytes(b"owned")
-        metadata = target.lstat()
+        descriptor = os.open(target, os.O_RDONLY)
+        self.addCleanup(os.close, descriptor)
+        metadata = os.fstat(descriptor)
         identity = (metadata.st_dev, metadata.st_ino)
         replacement = b"replacement"
+
         def replace_before_quarantine(path: Path) -> None:
             """在原子 quarantine 前替换公开 pathname。"""
             path.unlink()
@@ -295,6 +306,7 @@ class InstallReceiptTests(unittest.TestCase):
             side_effect=replace_before_quarantine,
         ):
             receipt_module._unlink_same_inode(target, identity)
+        self.assertNotEqual(target.lstat().st_ino, identity[1])
         self.assertEqual(target.read_bytes(), replacement)
 
     def test_quarantine_post_rename_failure_restores_or_keeps_explicit_evidence(self) -> None:

--- a/tests/test_install_runtime.py
+++ b/tests/test_install_runtime.py
@@ -203,6 +203,85 @@ class InstallRuntimeTests(unittest.TestCase):
         path.write_bytes(payload)
         path.chmod(mode)
 
+    def _private_ambient_python_root(self) -> Path:
+        """把当前解释器的 prefix 复制成 owner-only、mode 与大小写都归一化的私有 tree。
+
+        真实 subprocess build 需要一个能执行的完整 CPython，所以只能取
+        ``sys.base_prefix``。但那棵树的位置、权限和内容完全由环境决定，
+        installer 的 trusted-tree 校验会——正确地——拒绝其中好几种形态：
+
+        - GitHub runner 上解释器位于 world-writable 的 ``/opt/hostedtoolcache``
+          之下，整条祖先链不可信；
+        - uv 在 Linux 上装的 managed CPython 带 ``share/terminfo``，里面存在
+          ``P`` 与 ``p`` 这类仅大小写不同的条目，会命中 casefold 去重拒绝。
+
+        维护者 macOS 上的 uv managed python 恰好躲开了这两点，用例因此只在本机
+        通过。复制进测试自己的 0700 sandbox、归一化 mode、并丢弃 casefold 重复项
+        之后，这条用例在任何平台上验证的都是同一件事：production subprocess
+        runner 能在 closed-world env 里完成离线 build。
+
+        注意：这里丢弃 casefold 重复项只是让 fixture 稳定，并不代表产品能接受
+        真实的 uv managed Linux Python——那是一个独立的、已记录的产品缺陷。
+
+        Returns:
+            sandbox 内可直接作为 ``managed_python_root`` 使用的私有 prefix 副本。
+        """
+        source = Path(sys.base_prefix).resolve(strict=True)
+        destination = self.sources / "ambient-python"
+        destination.mkdir(mode=0o700)
+        seen: set[str] = set()
+        for current, directories, files in os.walk(source):
+            relative = Path(current).relative_to(source)
+            links = [name for name in directories if (Path(current) / name).is_symlink()]
+            kept: list[str] = []
+            for name in sorted(directories):
+                if name in links or not self._claim_case(seen, relative / name):
+                    continue
+                kept.append(name)
+                (destination / relative / name).mkdir(mode=0o700)
+            directories[:] = kept
+            for name in sorted((*files, *links)):
+                item = Path(current) / name
+                if not self._claim_case(seen, relative / name):
+                    continue
+                target = destination / relative / name
+                if item.is_symlink():
+                    target.symlink_to(os.readlink(item))
+                    continue
+                shutil.copyfile(item, target)
+                target.chmod(0o700 if item.stat().st_mode & 0o111 else 0o600)
+        self._prune_dangling_symlinks(destination)
+        return destination
+
+    @staticmethod
+    def _prune_dangling_symlinks(root: Path) -> None:
+        """反复删除悬空 symlink，直到 tree 里只剩指向自身内部的有效 alias。
+
+        丢弃 casefold 重复项会顺带带走某些 terminfo alias 的目标，剩下的 symlink
+        就成了悬空链接，而 installer 只接受 non-dangling 的 root 内相对 alias。
+        循环是为了处理 alias 链：一次删除可能让下一层也变成悬空。
+        """
+        while True:
+            dangling = [
+                Path(current) / name
+                for current, directories, files in os.walk(root)
+                for name in (*directories, *files)
+                if (Path(current) / name).is_symlink() and not (Path(current) / name).exists()
+            ]
+            if not dangling:
+                return
+            for item in dangling:
+                item.unlink()
+
+    @staticmethod
+    def _claim_case(seen: set[str], relative: Path) -> bool:
+        """记录相对路径的 casefold 形式，重复出现时返回 false。"""
+        key = relative.as_posix().casefold()
+        if key in seen:
+            return False
+        seen.add(key)
+        return True
+
     def _acquire_live_lock(self, layout: InstallLayout | None = None) -> InstallLock:
         """在 sandbox 无 process-start probe 时创建仍验证真实 fd/inode 的 lock。"""
         probe = mock.patch.object(
@@ -1395,9 +1474,9 @@ class InstallRuntimeTests(unittest.TestCase):
             0o700,
         )
 
+        managed_root = self._private_ambient_python_root()
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            managed_root = Path(sys.base_prefix).resolve(strict=True)
             receipt = RuntimeBuilder().build(
                 replace(
                     self.inputs,
@@ -1772,14 +1851,19 @@ class InstallRuntimeTests(unittest.TestCase):
                 marker = path / ".runtime-recovery.json"
                 payload = marker.read_bytes()
                 before = marker.lstat()
-                marker.unlink()
-                marker.write_bytes(payload)
-                marker.chmod(0o600)
-                after = marker.lstat()
+                # 必须在原 marker 还挂在目录里时先建好 sibling，再原子 rename 顶上。
+                # 先 unlink 再原地重建的话，Linux 会立刻把刚释放的 inode 号复用给
+                # 新文件，根本构造不出本用例要的"同 bytes、不同 inode"场景；macOS
+                # 通常不复用，所以旧写法只在 macOS 上碰巧成立。
+                staged = path / ".runtime-recovery.json.replacement"
+                staged.write_bytes(payload)
+                staged.chmod(0o600)
+                after = staged.lstat()
                 self.assertNotEqual(
                     (after.st_dev, after.st_ino),
                     (before.st_dev, before.st_ino),
                 )
+                os.replace(staged, marker)
                 replaced = True
             return result
 


### PR DESCRIPTION
## Summary

第二轮 Linux 门禁修复,把剩余 10 项失败清零,其中挖出**三处产品真 bug**(均为 Linux 独有,macOS 上永远不会暴露)。

### 真 bug 一:Linux 用户在 personal 模式下无处可写

`resolve_permission_roots` 把**整份默认写入根列表**放在了 `if platform == "darwin"` 里面。后果:Linux 用户在 `personal` 配置下能读整个家目录,却**在工作区之外无处可写**。已把 Desktop/Documents/Downloads(xdg-user-dirs 标准)与平台无关的 JetBrains 目录提到条件外,三个 macOS 专属的**只读**根保持原有 gating。

### 真 bug 二:receipt 与 downloads 的 inode 复用(第一轮同类问题的其他实例)

- `InstallReceipt.write` 在 `os.replace` 之前、失败清理之前就关闭了临时文件描述符;`_restore_receipt` 在 `os.link` 周围同样如此。改为在外层 `finally` 关闭(在 `except` 之后才执行),使描述符贯穿整个清理窗口。
- `_download_roots` 只存了 `(root, (st_dev, st_ino))`,没有任何东西在整个事务期间钉住该目录 inode。改为持有 `O_DIRECTORY|O_NOFOLLOW` 描述符。

### 真 bug 三:`/proc/cpuinfo` 文件句柄泄漏

`_linux_cpu_model` 用 `for line in open(...)` 且循环内 `return`,句柄从不显式关闭,CPython 在终结时抛 `ResourceWarning`。macOS 走 `platform.processor()` 分支,故为 Linux 独有。改用 `with open(...)`。

### 测试假设问题(未弱化断言)

- `test_discard_interrupted_staging_...`:产品本身是对的(`_metadata_snapshot` 含 `st_mtime_ns`/`st_ctime_ns`,即使 inode 复用也能识别)。是**测试**假设了 unlink+重建必得新 inode。改为在原文件仍被链接时创建同级文件再 `os.replace`,任何平台都保证新 inode。
- `test_default_runner_builds_with_offline_fake_uv`:把真实 `sys.base_prefix` 当作可信 managed-python 根传入。GitHub runner 上解释器位于全局可写的 `/opt/hostedtoolcache`,祖先链检查**正确地**拒绝了它。改为复制进测试自有的 0700 沙箱。

### CI 配置

两处离线门禁现在都会安装固定版 Node 24.18.0(curl + `runtime-versions.json` 里的 SHA-256,未引入新 Action)、构建 `browser-worker`、安装 `tui` 依赖。另修正:从仓库根执行 `corepack pnpm --dir <project>` 看不到项目的 `packageManager`,导致 corepack 用了自带的 pnpm 11 而被 10.14.0 的固定版拒绝——这同时也是 `node-22`/`node-24` 与 `TuiBundleTest` 失败的原因。

## Verification

- **Linux 容器**(非 root uid 1001)逐模块红→绿,并用 `git stash` 基线以 `comm` 比对:**4 项转绿,0 项新增失败**。
- **macOS**:直接受影响的 5 个模块 **213/213 通过**。
- Ruff、docs validator 均 PASS;`run_install_matrix.py --local-offline` 保持 `pass=9 pending=6 blocked=0`。

## ⚠️ 尚未修复的安装阻塞项(必须在 Linux 发布前解决)

`install.sh` 用 `uv python install 3.12` 取得解释器。**Linux 上该 CPython 自带 `share/terminfo`,其中存在仅大小写不同的条目**(`A`/`a`、`N`/`n` 等);而 `_validate_source_tree` 拒绝任何大小写折叠后重复的路径。

**复核已独立实测确认**(不是推测):真实 uv 安装的 `cpython-3.12.13-linux-aarch64-gnu` 共 4731 个条目,**33 处大小写冲突**,样例如 `share/terminfo/a`、`share/terminfo/e/eterm`。

**后果:每一台 Linux 机器上的一行安装都会以 `runtime_install_failed: manifest` 失败。** macOS 逃过一劫——其 python-build-standalone 链接系统 ncurses 不带 terminfo,且这类条目在大小写不敏感的文件系统上本就无法共存。

开发者**刻意没有改**:该检查合法地防止了复制到大小写不敏感目标时条目被静默合并,改动它等于改变安装器的信任策略。这需要单独决策——推荐方向是探测**目标文件系统**的大小写敏感性,仅在不敏感时才强制该检查,从而在保留原有安全属性的同时解除 Linux 阻塞。

测试夹具中丢弃大小写重复项**仅为让夹具确定化**,docstring 已写明,以免被误读为产品接受此类目录树。