### PR TITLE
fix(install): 大小写冲突改为按目标文件系统判定

### DIFF
--- a/src/lobster0/install/runtime.py
+++ b/src/lobster0/install/runtime.py
@@ -1293,14 +1293,24 @@ def _preflight(
         )
     if inputs.node.name != "node" or inputs.tui.name != "tui":
         _runtime_failed()
-    _validate_source_tree(inputs.node, {"bin/node"})
-    _validate_source_tree(inputs.tui, set())
+    # 预检与后续复制必须用同一个目标事实：探测安装 prefix 所在文件系统。
+    # 目录不存在或探测失败时保守视为大小写不敏感（fail closed）。
+    case_insensitive = _case_insensitive_directory(
+        _nearest_existing_directory(inputs.layout.program_prefix)
+    )
+    _validate_source_tree(
+        inputs.node, {"bin/node"}, case_insensitive_destination=case_insensitive
+    )
+    _validate_source_tree(
+        inputs.tui, set(), case_insensitive_destination=case_insensitive
+    )
     tokens["uv"] = _verify_private_file(inputs.uv, expected_mode=0o700)
     _validate_source_tree(
         inputs.managed_python_root,
         {"bin/python3.12"},
         allow_internal_symlinks=True,
         allow_public_read=True,
+        case_insensitive_destination=case_insensitive,
     )
     python_mode = stat.S_IMODE(inputs.managed_python_executable.lstat().st_mode)
     if python_mode not in {0o700, 0o755}:
@@ -1898,14 +1908,64 @@ def _safe_archive_name(value: str) -> bool:
     )
 
 
+def _nearest_existing_directory(path: Path) -> Path:
+    """返回 path 自身或其最近的已存在祖先目录，用于探测目标文件系统。"""
+    current = path
+    while True:
+        if current.is_dir():
+            return current
+        parent = current.parent
+        if parent == current:
+            return current
+        current = parent
+
+
+def _case_insensitive_directory(directory: Path) -> bool:
+    """探测 directory 所在文件系统是否大小写不敏感。
+
+    大小写折叠后重复的条目只有在**目标**文件系统大小写不敏感时才会互相
+    静默覆盖；在大小写敏感的文件系统上它们是两个独立文件，可以共存。
+    因此归属判断必须看目标而不是一刀切拒绝。
+
+    Args:
+        directory: 已存在、当前用户可写的目录。
+
+    Returns:
+        大小写不敏感为 True；无法判定时保守返回 True（按更严格处理）。
+    """
+    probe = None
+    try:
+        descriptor, name = tempfile.mkstemp(prefix=".lobster0-CASE", dir=directory)
+        os.close(descriptor)
+        probe = Path(name)
+        return probe.with_name(probe.name.replace("CASE", "case")).exists()
+    except OSError:
+        return True
+    finally:
+        if probe is not None:
+            try:
+                probe.unlink()
+            except OSError:
+                pass
+
+
 def _validate_source_tree(
     root: Path,
     required_executables: set[str],
     *,
     allow_internal_symlinks: bool = False,
     allow_public_read: bool = False,
+    case_insensitive_destination: bool = True,
 ) -> dict[str, tuple[tuple[int, ...], str | None]]:
-    """完整扫描 safe-extracted tree，仅按需允许 root 内部相对 alias link。"""
+    """完整扫描 safe-extracted tree，仅按需允许 root 内部相对 alias link。
+
+    ``case_insensitive_destination`` 为 True（默认，fail closed）时拒绝任何
+    大小写折叠后重复的相对路径，避免复制到大小写不敏感的目标时条目被静默
+    合并。目标经探测确认大小写敏感时可以放行：此时两个条目在目标上是独立
+    文件，不存在合并风险。Linux 上 uv 提供的 CPython 自带 `share/terminfo`，
+    其中就有仅大小写不同的条目（`A`/`a` 等），一刀切拒绝会让每一次 Linux
+    一行安装都以 `runtime_install_failed` 失败。
+    """
     seen: set[str] = set()
     entries = 0
     total = 0
@@ -1922,7 +1982,7 @@ def _validate_source_tree(
                 _runtime_failed()
             path = current / name
             relative = path.relative_to(root).as_posix()
-            if relative.casefold() in seen:
+            if case_insensitive_destination and relative.casefold() in seen:
                 _runtime_failed()
             seen.add(relative.casefold())
             metadata = path.lstat()
@@ -1966,11 +2026,14 @@ def _copy_verified_tree(
     if program_mode not in {0o700, 0o755}:
         _runtime_failed()
     data_mode = 0o644 if program_mode == 0o755 else 0o600
+    # 目标目录尚未创建，探测其父目录所在的同一文件系统。
+    case_insensitive = _case_insensitive_directory(destination.parent)
     manifest = _validate_source_tree(
         source,
         required,
         allow_internal_symlinks=allow_internal_symlinks,
         allow_public_read=allow_public_read,
+        case_insensitive_destination=case_insensitive,
     )
     os.mkdir(destination, program_mode)
     for directory, names, files in os.walk(source, topdown=True, followlinks=False):
@@ -2036,6 +2099,7 @@ def _copy_verified_tree(
         required,
         allow_internal_symlinks=allow_internal_symlinks,
         allow_public_read=allow_public_read,
+        case_insensitive_destination=case_insensitive,
     ):
         _runtime_failed()
 

--- a/tests/test_install_runtime.py
+++ b/tests/test_install_runtime.py
@@ -132,6 +132,70 @@ class FakeRunner:
         return CommandResult(0, b"", b"")
 
 
+
+class CaseCollisionDestinationTests(unittest.TestCase):
+    """验证大小写冲突判定看的是目标文件系统，而不是一刀切拒绝。
+
+    Linux 上 uv 提供的 CPython 自带 `share/terminfo`，其中存在仅大小写不同
+    的条目（实测 cpython-3.12.13-linux 有 33 处）。此前无条件拒绝会让每一次
+    Linux 一行安装都以 `runtime_install_failed` 失败；而在大小写不敏感的目标
+    上这些条目会互相静默覆盖，必须继续拒绝。
+    """
+
+    def setUp(self) -> None:
+        """建一棵含真实大小写冲突条目的源树。"""
+        self.root = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+        self.source = self.root / "src"
+        (self.source / "share").mkdir(mode=0o700, parents=True)
+        self.source.chmod(0o700)
+        (self.source / "share").chmod(0o700)
+
+    def _write(self, name: str) -> None:
+        """写入一个 owner-only 普通文件。"""
+        target = self.source / "share" / name
+        target.write_bytes(b"x")
+        target.chmod(0o600)
+
+    def test_case_sensitive_destination_accepts_case_only_duplicates(self) -> None:
+        """目标大小写敏感时，仅大小写不同的条目是两个独立文件，必须放行。"""
+        self._write("A")
+        try:
+            self._write("a")
+        except OSError:
+            self.skipTest("本机文件系统大小写不敏感，无法构造该场景")
+        if (self.source / "share" / "A").read_bytes() != b"x" or len(
+            list((self.source / "share").iterdir())
+        ) != 2:
+            self.skipTest("本机文件系统大小写不敏感，无法构造该场景")
+        manifest = runtime_module._validate_source_tree(
+            self.source, set(), case_insensitive_destination=False
+        )
+        self.assertIn("share/A", manifest)
+        self.assertIn("share/a", manifest)
+
+    def test_case_insensitive_destination_still_rejects_duplicates(self) -> None:
+        """目标大小写不敏感时必须继续拒绝，否则条目会被静默覆盖。"""
+        self._write("A")
+        try:
+            self._write("a")
+        except OSError:
+            self.skipTest("本机文件系统大小写不敏感，无法构造该场景")
+        if len(list((self.source / "share").iterdir())) != 2:
+            self.skipTest("本机文件系统大小写不敏感，无法构造该场景")
+        with self.assertRaises(InstallError):
+            runtime_module._validate_source_tree(
+                self.source, set(), case_insensitive_destination=True
+            )
+
+    def test_probe_reports_this_filesystem_consistently(self) -> None:
+        """探测结果必须与该目录能否共存同名异例文件一致。"""
+        probed = runtime_module._case_insensitive_directory(self.source)
+        (self.source / "PROBE").write_bytes(b"x")
+        coexist = not (self.source / "probe").exists()
+        self.assertEqual(probed, not coexist)
+
+
 class InstallRuntimeTests(unittest.TestCase):
     """覆盖 Runtime 构建的信任边界、原子切换和 retention。"""
 


### PR DESCRIPTION
## 解除 Linux 一行安装的第一个阻塞项

**实测确认**(在真实容器里跑,不是推测):Linux 上 uv 提供的 CPython 自带 `share/terminfo`,其中存在仅大小写不同的条目——`cpython-3.12-linux-aarch64-gnu` 共 **4730 个条目、33 处折叠冲突**(如 `share/terminfo/A` 与 `share/terminfo/a`)。

而 `_validate_source_tree` **无条件**拒绝任何折叠后重复的相对路径,导致**每一次 Linux 一行安装都会以 `runtime_install_failed` 失败**。macOS 逃过一劫:其 python-build-standalone 链接系统 ncurses 不带 terminfo,且这类条目在大小写不敏感的文件系统上本就无法共存。

### 修法:探测目标,而不是一刀切

该检查真正要防的是"复制到大小写不敏感的目标时条目被静默合并"——这**只在目标文件系统不敏感时**才会发生。所以改为探测目标文件系统:

- 目标不敏感 → **继续拒绝**(原有安全属性完整保留)
- 确认目标敏感 → 放行(此时两个条目在目标上是独立文件,不存在合并风险)
- 探测失败或目录不存在 → 保守按不敏感处理,**fail closed**

探测点与目标严格一致:`_copy_verified_tree` 探测 `destination.parent`;`_preflight` 探测 `layout.program_prefix` 最近的已存在祖先,确保预检与后续复制用**同一个目标事实**,不会出现预检放行、复制时才发现不一致。

## Verification

新增三条测试,**在真实 Linux 容器里双向验证**:

| 测试 | Linux | macOS |
|---|---|---|
| 目标敏感时放行仅大小写不同的条目 | 通过 | 正确跳过(本机不敏感,无法构造) |
| 目标不敏感时**仍然拒绝** | 通过 | 正确跳过 |
| 探测结果与该目录实际能否共存同名异例文件一致 | 通过 | 通过 |

`tests.test_install_runtime` 全模块 85/85 通过(2 项按平台跳过),Ruff PASS。

## ⚠️ 还有第二个阻塞项(本 PR 未覆盖)

同一轮实测中发现:即使 bootstrap 脚本设了 `umask 077`,**uv 仍会把 Python 根目录创建为 `0777`(组和全局可写)**——它显式设置该权限,无视 umask。而祖先链检查与目录 mode 白名单都会拒绝全局可写的目录。

**安装器拒绝它是正确的**:全局可写的解释器根目录意味着同机任何本地用户都能篡改将要被执行的 Python。这不该通过放宽检查来"修好"。

**推荐修法**:让 `release/install.sh.tmpl` 在 `uv python install 3.12` 之后、交接给 pyz 之前,把 managed Python 根目录 `chmod` 收紧到 0700。这样既保留安全属性,又解除阻塞。

在这一项也修掉之前,Linux 一行安装仍然不可用。