### PR TITLE
fix(bootstrap): 解析并收紧 managed Python,打通 Linux 一行安装

### DIFF
--- a/release/install.sh.tmpl
+++ b/release/install.sh.tmpl
@@ -54,6 +54,7 @@ need_cmd mkdir
 need_cmd chmod
 need_cmd rm
 need_cmd wc
+need_cmd find
 if ! command -v sha256sum >/dev/null 2>&1 && ! command -v shasum >/dev/null 2>&1; then
   fail "missing required command: sha256sum or shasum"
 fi
@@ -182,6 +183,26 @@ case "$managed_python" in
   *) fail "unexpected managed Python layout" ;;
 esac
 managed_python_root=${managed_python%/bin/python3.12}
+# `uv python find` 返回的是形如 cpython-3.12-<platform> 的软链接别名，而安装器
+# 以 no-follow 语义逐段校验祖先链，软链接组件会被直接拒绝。先解析成物理路径
+# 再交接，才是安装器真正会校验的那棵树。
+managed_python_root=$(cd "$managed_python_root" && pwd -P) \
+  || fail "could not resolve managed Python root"
+managed_python="$managed_python_root/bin/python3.12"
+[ -f "$managed_python" ] && [ -x "$managed_python" ] \
+  || fail "resolved managed Python is not executable"
+# uv 显式把 managed Python 目录建成 0777，无视 umask；全局可写的解释器目录
+# 意味着同机任何本地用户都能篡改即将被执行的 Python，安装器因此（正确地）
+# 拒绝它。这里在交接前把整棵树收回 owner-only，而不是去放宽那些检查。
+# 安装器只接受 {0600,0644,0700,0755} 这几种 file mode，而真实 Python 发行版里
+# 混有 0444/0555 等只读条目。统一归一化成 owner-only：目录 0700、可执行文件
+# 0700、其余文件 0600，既满足白名单又不放宽任何检查。
+find "$managed_python_root" -type d -exec chmod 0700 {} + \
+  || fail "could not restrict managed Python directories"
+find "$managed_python_root" -type f -perm -u+x -exec chmod 0700 {} + \
+  || fail "could not restrict managed Python executables"
+find "$managed_python_root" -type f ! -perm -u+x -exec chmod 0600 {} + \
+  || fail "could not restrict managed Python files"
 
 # 8/9. Hand off to the stdlib-only installer, forwarding the internal
 # bootstrap flags plus every original public flag unchanged, and let the

--- a/tests/test_install_bootstrap.py
+++ b/tests/test_install_bootstrap.py
@@ -33,7 +33,7 @@ _UV_ARCHIVE_NAMES = {
     "macos-x86_64": "uv-x86_64-apple-darwin.tar.gz",
     "macos-arm64": "uv-aarch64-apple-darwin.tar.gz",
 }
-_PASSTHROUGH_COMMANDS = ("mktemp", "mkdir", "chmod", "rm")
+_PASSTHROUGH_COMMANDS = ("mktemp", "mkdir", "chmod", "rm", "find")
 _PROFILE_NAMES = (".profile", ".bashrc", ".bash_profile", ".zshrc")
 
 
@@ -326,6 +326,33 @@ class InstallBootstrapTest(unittest.TestCase):
         self.assertNotEqual(completed.returncode, 0)
         self.assertEqual(self._calls("curl"), [])
         self.assertFalse(any(self.tmp_root.iterdir()))
+
+    def test_managed_python_is_resolved_and_restricted_before_handoff(self) -> None:
+        """交接前必须解析软链接并把 managed Python 收紧成 owner-only。
+
+        实测依据（真实 uv 安装的 Linux CPython）：
+        1. `uv python find` 返回 cpython-3.12-<platform> 软链接别名，而安装器
+           以 no-follow 语义校验祖先链，软链接组件会被直接拒绝；
+        2. uv 显式把该目录建成 0777，无视 umask，全局可写的解释器目录会被
+           安装器（正确地）拒绝；
+        3. 发行版内混有 0444/0555 等只读文件，不在安装器的 file mode 白名单内。
+
+        三者任缺其一，Linux 一行安装都会以 runtime_install_failed 失败。
+        """
+        script = render_install_script(
+            self.release_inputs,
+            runtime_versions=self.runtime_versions_path,
+            template=_TEMPLATE,
+        )
+        self.assertIn("pwd -P", script)
+        self.assertIn("could not resolve managed Python root", script)
+        for fragment in (
+            'find "$managed_python_root" -type d -exec chmod 0700',
+            'find "$managed_python_root" -type f -perm -u+x -exec chmod 0700',
+            'find "$managed_python_root" -type f ! -perm -u+x -exec chmod 0600',
+        ):
+            self.assertIn(fragment, script)
+        self.assertIn("need_cmd find", script)
 
     def test_missing_wc_fails_closed(self) -> None:
         """缺少 wc 必须在创建任何私有目录前失败，而不是在中途报 could-not-size。"""


### PR DESCRIPTION
## 打通 Linux 一行安装的最后三层

承接上一个 PR 的大小写修复,继续在**真实 Linux 容器里实测**,发现一行安装在 Linux 上还有三层阻塞,任缺其一都会以 `runtime_install_failed` 失败:

| # | 阻塞原因 | 修法 |
|---|---|---|
| 1 | `uv python find` 返回的是 `cpython-3.12-<platform>` **软链接别名**,而安装器以 no-follow 语义逐段校验祖先链,软链接组件直接被拒 | `pwd -P` 解析成物理路径后再交接 |
| 2 | uv **显式**把 managed Python 目录建成 `0777`,无视 bootstrap 的 `umask 077` | 交接前收紧 |
| 3 | 真实 Python 发行版内混有 `0444`/`0555` 等只读文件,不在安装器的 file mode 白名单内 | 统一归一化 |

**关键取舍**:第 2 项里安装器拒绝全局可写的解释器目录是**正确的**——那意味着同机任何本地用户都能篡改即将被执行的 Python。所以修的是 bootstrap(交接前把树收紧成 owner-only),**而不是放宽安装器的检查**。归一化后:目录 0700、可执行文件 0700、其余文件 0600,既满足白名单又不损失任何一项安全检查。

`find` 随之加入基础命令预检,缺失时与其他依赖一样干净地 fail closed,而不是中途报错。

## 端到端实测

Docker `python:3.12-slim`,非 root uid 1001,**真实 uv 安装的 `cpython-3.12.13-linux-aarch64-gnu`(4730 个条目)**:

```
目标大小写敏感   -> 通过 (条目 4730)     ← 三层修复齐备后打通
目标大小写不敏感 -> 仍拒绝 (符合预期)    ← 安全属性完整保留
```

排查过程是逐层剥开的:先修大小写,发现仍被拒 → 定位到祖先链软链接 → 解析后仍被拒 → 定位到 0777 权限 → 收紧后仍被拒 → 定位到 file mode 白名单。每一层都用真实产物验证,没有靠推测跳步。

## Verification

- `tests.test_install_bootstrap` **26/26**(含新增的回归测试,盯住三层修复与 `need_cmd find`)。
- `tests.test_install_runtime` **85/85**(2 项按平台跳过)。
- 渲染后脚本 `sh -n` / `bash -n` 语法均通过。
- Ruff、docs validator 均 PASS。

## 说明

测试沙箱改为透传真实 `find` 而非使用假件——这样测试跑的是真实命令行为,更接近生产。