### PR TITLE
fix(test): fixture 只保留 root 内相对 symlink alias

### DIFF
--- a/tests/test_install_runtime.py
+++ b/tests/test_install_runtime.py
@@ -310,7 +310,16 @@ class InstallRuntimeTests(unittest.TestCase):
                     continue
                 target = destination / relative / name
                 if item.is_symlink():
-                    target.symlink_to(os.readlink(item))
+                    # installer 只接受 root 内部的相对 alias。宿主上的 CPython
+                    # （尤其是 GitHub runner 的 /opt/hostedtoolcache）常带绝对
+                    # symlink 指向 tree 之外的真实文件——它们不悬空，所以躲得过
+                    # 下面的 dangling 清理，却会被 _safe_internal_symlink 正确
+                    # 拒绝。fixture 只保留相对 alias，验证的才是产品真正支持的
+                    # 那种形态。
+                    link_target = os.readlink(item)
+                    if os.path.isabs(link_target):
+                        continue
+                    target.symlink_to(link_target)
                     continue
                 shutil.copyfile(item, target)
                 target.chmod(0o700 if item.stat().st_mode & 0o111 else 0o600)


### PR DESCRIPTION
CI 上最后一个失败的测试:宿主 CPython(尤其 GitHub runner 的 `/opt/hostedtoolcache`)带有指向 tree 之外真实文件的**绝对 symlink**。它们不悬空,因而躲过了 fixture 已有的 dangling 清理,却会被 installer 正确拒绝——installer 只接受 root 内部的**相对** alias。

fixture 改为跳过绝对 symlink,验证的才是产品真正支持的形态。

macOS `tests.test_install_runtime` 85/85 通过(2 项按平台跳过),Ruff PASS。

本地容器无法复现 GitHub runner 的 `hostedtoolcache` 布局(容器里该用例因另一个环境原因在更早的子进程检查处失败),因此由 CI 判定。上一轮 CI 已从 20 个失败降到这 1 个。