### PR TITLE
fix(test): fixture 按产品规则筛选 symlink

### DIFF
--- a/tests/test_install_runtime.py
+++ b/tests/test_install_runtime.py
@@ -328,22 +328,44 @@ class InstallRuntimeTests(unittest.TestCase):
 
     @staticmethod
     def _prune_dangling_symlinks(root: Path) -> None:
-        """反复删除悬空 symlink，直到 tree 里只剩指向自身内部的有效 alias。
+        """反复删除 installer 不会接受的 symlink，直到只剩合法的内部 alias。
 
-        丢弃 casefold 重复项会顺带带走某些 terminfo alias 的目标，剩下的 symlink
-        就成了悬空链接，而 installer 只接受 non-dangling 的 root 内相对 alias。
-        循环是为了处理 alias 链：一次删除可能让下一层也变成悬空。
+        判定标准直接对齐 ``_safe_internal_symlink`` 的产品规则：target 必须是
+        相对路径、不悬空、且解析后仍落在 root 内。三类会被丢弃：
+
+        - 悬空链接：丢弃 casefold 重复项会顺带带走某些 terminfo alias 的目标；
+        - 绝对链接：宿主 CPython（尤其 GitHub runner 的 hostedtoolcache）常带
+          指向 tree 之外真实文件的绝对 symlink，它们不悬空，躲得过纯 dangling
+          检查；
+        - 逃逸链接：形如 ``../../usr/lib/x`` 的相对链接同样会解析到 root 之外。
+
+        按产品规则筛而不是逐条枚举已知形态，fixture 才不会随宿主布局变化再次
+        失效。循环是为了处理 alias 链：一次删除可能让下一层也变成悬空。
         """
+        resolved_root = root.resolve(strict=True)
+
+        def unacceptable(item: Path) -> bool:
+            """复刻 _safe_internal_symlink 的接受条件。"""
+            if not item.is_symlink():
+                return False
+            target = os.readlink(item)
+            if os.path.isabs(target):
+                return True
+            try:
+                return not item.resolve(strict=True).is_relative_to(resolved_root)
+            except (OSError, RuntimeError):
+                return True
+
         while True:
-            dangling = [
+            rejected = [
                 Path(current) / name
                 for current, directories, files in os.walk(root)
                 for name in (*directories, *files)
-                if (Path(current) / name).is_symlink() and not (Path(current) / name).exists()
+                if unacceptable(Path(current) / name)
             ]
-            if not dangling:
+            if not rejected:
                 return
-            for item in dangling:
+            for item in rejected:
                 item.unlink()
 
     @staticmethod


### PR DESCRIPTION
上一次只跳过绝对 symlink **并未修好 CI**——宿主 CPython 里还有形如 `../../usr/lib/x` 的**相对逃逸链接**:它们既不悬空、也不是绝对路径,躲过了已有的两道筛子,却会被 `_safe_internal_symlink` 正确拒绝。

改为直接**对齐产品规则**:target 必须相对、不悬空、解析后仍落在 root 内,三者有一不满足即丢弃。按规则筛而不是逐条枚举已知形态,fixture 才不会随宿主布局变化再次失效。

**容器内构造复现验证**:在解释器 prefix 里故意植入绝对链接与相对逃逸链接后重跑,失败点从 `runtime.py:2125`(symlink 校验)移出,证明该层已通过。

macOS `tests.test_install_runtime` 85/85(2 项按平台跳过),Ruff PASS。