### PR TITLE
ci(release): 桌面包改为可选产物,不再阻断 install.sh 产出

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -384,10 +384,15 @@ jobs:
     needs: [guard, offline-gate, draft-release]
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
+    # 桌面包是 Release 的可选产物，不是安装器输入：一行安装链路交付的是
+    # CLI、TUI 与 Gateway，`.dmg`/`.AppImage` 的构建失败不应连带把整条
+    # Release 拖垮。这里只让"缺席"成为允许的结果——凡是真的产出了的桌面包，
+    # attestation 与 publish 仍会逐个复核摘要并验证 attestation，一个都不放过。
+    continue-on-error: true
     permissions:
       contents: write
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           # Electron 的每个架构都是官方预编译产物，本应用又没有任何需要
@@ -720,7 +725,11 @@ jobs:
           # 否则下一步就会给一份没被任何门禁看过的产物签发 attestation。
           desktop=(subjects/lobster0-desktop-*.dmg subjects/lobster0-desktop-*.zip \
             subjects/lobster0-desktop-*.AppImage)
-          test "${#desktop[@]}" -eq 6
+          # 桌面包是可选产物：它不是安装器输入，CLI/TUI/Gateway 的一行安装链路
+          # 不依赖它，因此其构建失败不应连带阻断整个 Release。数量不写死，但
+          # **实际存在的每一个**仍必须逐一通过 sidecar 复核才会被签名——可选的是
+          # "有没有"，不是"要不要验"。publish 会重新核对同一份清单。
+          printf 'desktop artifacts present: %s\n' "${#desktop[@]}"
           for artifact in "${desktop[@]}"; do
             printf '%s  %s\n' "$(cat "${artifact}.sha256")" "${artifact}" | sha256sum -c -
           done
@@ -932,7 +941,9 @@ jobs:
           shopt -s nullglob
           desktop=(candidate/lobster0-desktop-*.dmg candidate/lobster0-desktop-*.zip \
             candidate/lobster0-desktop-*.AppImage)
-          test "${#desktop[@]}" -eq 6
+          # 桌面包可选，见 attestation 作业同处注释：数量不写死，但实际存在的
+          # 每一个都必须重新通过摘要校验。
+          printf 'desktop artifacts present: %s\n' "${#desktop[@]}"
           for artifact in "${desktop[@]}"; do
             printf '%s  %s\n' "$(cat "${artifact}.sha256")" "${artifact}" | sha256sum -c -
           done
@@ -946,7 +957,8 @@ jobs:
           shopt -s nullglob
           desktop=(candidate/lobster0-desktop-*.dmg candidate/lobster0-desktop-*.zip \
             candidate/lobster0-desktop-*.AppImage)
-          test "${#desktop[@]}" -eq 6
+          # 桌面包可选；实际存在的每一个仍必须逐一通过 attestation 验证。
+          printf 'desktop artifacts to verify: %s\n' "${#desktop[@]}"
           for subject in candidate/release-manifest.json candidate/SHA256SUMS \
               candidate/install.sh "candidate/${WHEEL}" "candidate/${SDIST}" \
               "${desktop[@]}"; do

--- a/tests/test_install_matrix_contract.py
+++ b/tests/test_install_matrix_contract.py
@@ -169,13 +169,29 @@ class GateIntegrityTest(unittest.TestCase):
     """任何门禁都不得被静默弱化。"""
 
     def test_no_workflow_weakens_a_gate(self) -> None:
-        """禁止 ``continue-on-error``、``if: false`` 与 ``always()`` 类逃逸。"""
+        """禁止 ``if: false``、``|| true`` 与 ``always()`` 类逃逸。
+
+        ``continue-on-error`` 只允许出现在 ``desktop-bundles``：桌面包是
+        Release 的可选产物而非安装器输入，一行安装链路交付的是 CLI/TUI/
+        Gateway，`.dmg`/`.AppImage` 构建失败不应连带拖垮整条 Release。
+        可选的只是"有没有"——凡真的产出了的桌面包，attestation 与 publish
+        仍逐个复核 sidecar 摘要并验证 attestation（见
+        ``test_optional_desktop_artifacts_are_still_fully_verified``）。
+        任何其他作业出现该键都必须失败。
+        """
         for path in (_CI_WORKFLOW, _RELEASE_WORKFLOW):
             text = path.read_text(encoding="utf-8")
             with self.subTest(workflow=path.name):
-                self.assertNotIn("continue-on-error", text)
                 self.assertNotIn("if: false", text)
                 self.assertNotIn("|| true", text)
+            for job_id, job in _jobs(_load(path)).items():
+                with self.subTest(workflow=path.name, job=job_id, key="continue-on-error"):
+                    if job_id == "desktop-bundles":
+                        self.assertEqual(job.get("continue-on-error"), "true")
+                    else:
+                        self.assertNotIn("continue-on-error", job)
+                    for step in job.get("steps", []):
+                        self.assertNotIn("continue-on-error", step)
             workflow = _load(path)
             for job_id, job in _jobs(workflow).items():
                 condition = str(job.get("if", ""))
@@ -186,6 +202,21 @@ class GateIntegrityTest(unittest.TestCase):
             for job_id, step in _all_steps(workflow):
                 with self.subTest(workflow=path.name, job=job_id):
                     self.assertNotIn("always(", str(step.get("if", "")))
+
+    def test_optional_desktop_artifacts_are_still_fully_verified(self) -> None:
+        """桌面包可缺席，但存在的每一个仍必须过 sidecar 摘要与 attestation。
+
+        这条是上面放宽 ``continue-on-error`` 的对价：不再断言恰好 6 个产物，
+        因此必须改由这里保证"存在即验证"，否则可选就退化成了免检。
+        """
+        jobs = _jobs(_load(_RELEASE_WORKFLOW))
+        for job_id in ("attestation", "publish"):
+            text = _run_text(jobs[job_id])
+            with self.subTest(job=job_id):
+                self.assertIn("lobster0-desktop-", text)
+                self.assertIn('"${artifact}.sha256"', text)
+                self.assertIn("sha256sum -c -", text)
+        self.assertIn("gh attestation verify", _run_text(jobs["publish"]))
 
     def test_top_level_permissions_are_read_only(self) -> None:
         """默认 token 权限必须是最小只读，写权限只能逐 job 声明。"""
@@ -624,10 +655,16 @@ class DesktopReleaseArtifactTest(unittest.TestCase):
         )
 
     def test_desktop_job_covers_both_supported_desktop_operating_systems(self) -> None:
-        """桌面打包必须在 macOS 与 Linux 各自的托管 runner 上真实构建。"""
+        """桌面打包必须在 macOS 与 Linux 各自的托管 runner 上真实构建。
+
+        ``fail-fast`` 必须为 ``false``：两个平台互不依赖，Linux 构建失败没有
+        理由连带取消已经在跑的 macOS 构建——首次真实发布时就正是这样白白丢掉
+        了一个本可成功的 macOS 产物。让每个平台各自跑完，才能一次看清到底哪些
+        平台真的能出包。
+        """
         strategy = self.desktop.get("strategy")
         self.assertEqual(type(strategy), dict)
-        self.assertEqual(strategy.get("fail-fast"), "true")
+        self.assertEqual(strategy.get("fail-fast"), "false")
         include = strategy["matrix"]["include"]
         self.assertEqual(
             {str(entry["runner"]) for entry in include}, {"macos-14", "ubuntu-24.04"}


### PR DESCRIPTION
## 让 `install.sh` 能真正产出

首次真实发布暴露:桌面包 **Linux 构建失败**,连带 `fail-fast` 取消了**正在跑的 macOS 构建**,并挡住 `attestation` —— 结果 `assemble` 明明已经生成了 `install.sh`,却永远发不出去。

但桌面包**不是安装器输入**:一行安装链路交付的是 CLI / TUI / Gateway,`.dmg`/`.AppImage` 构建失败没有理由拖垮整条 Release。而且它现在即使构建成功也用不了(不含 Python Core,双击报配置缺失,此前已实测记录)。

## 改动

- `desktop-bundles` 加 `continue-on-error`;`fail-fast` 改 `false`(两平台互不依赖,Linux 失败不该取消已在跑的 macOS 构建)。
- `attestation` 与 `publish` 不再断言恰好 6 个桌面产物,改为**存在多少验多少**。

**可选的只是「有没有」,不是「要不要验」**:真的产出的每一个桌面包,仍逐一通过 sidecar 摘要复核与 `gh attestation verify`。

## 契约测试:收窄而非放宽

- `test_no_workflow_weakens_a_gate` 改为**逐 job 判定**:只有 `desktop-bundles` 允许 `continue-on-error`,其余作业与**所有 step** 一律禁止。原来是全文搜索,现在更精确。
- 新增 `test_optional_desktop_artifacts_are_still_fully_verified` 作为放宽的**对价**,保证「存在即验证」不退化成免检。

**反向验证**:删掉 `attestation` 里的 sidecar 复核后,新测试确实失败;恢复后通过——不是摆设。

68/68 契约测试通过,Ruff 与 docs validator PASS。
