### PR TITLE
fix(deps): 补 tzdata,修复纯净 Linux 服务器上 init 必然失败

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,11 @@ authors = [{ name = "Lobster0 contributors" }]
 dependencies = [
   "croniter>=6.2,<7",
   "httpx>=0.28,<1",
+  # uv 提供的 python-build-standalone 解释器不自带时区数据库，也不会回退去读
+  # 系统的 /usr/share/zoneinfo。纯净 Linux 服务器上 `lobster0 init` 因此会以
+  # "heartbeat.timezone must be a valid IANA timezone" 直接失败——即使系统本身
+  # 装了 tzdata 也一样。zoneinfo 会自动回退到这个纯 Python 包，故必须显式依赖。
+  "tzdata>=2025.1",
   "textual>=8.2,<9",
 ]
 

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -1,5 +1,6 @@
 """验证 Lobster0 的 Python 分发元数据契约。"""
 
+import re
 import tomllib
 import unittest
 from pathlib import Path
@@ -23,6 +24,35 @@ class PackageMetadataTest(unittest.TestCase):
             "lobster0._version.__version__",
         )
         self.assertEqual(__version__, "0.7.0")
+
+    def test_timezone_database_is_a_runtime_dependency(self) -> None:
+        """必须显式依赖 tzdata，否则纯净 Linux 服务器上 init 会直接失败。
+
+        uv 提供的 python-build-standalone 解释器不自带时区数据库，也不会回退
+        去读系统的 /usr/share/zoneinfo：即便宿主装了系统 tzdata，
+        ``ZoneInfo("Asia/Shanghai")`` 仍抛 ZoneInfoNotFoundError，
+        ``lobster0 init`` 因此以 "heartbeat.timezone must be a valid IANA
+        timezone" 退出。实测于纯净 ubuntu:24.04 + uv managed CPython 3.12。
+        zoneinfo 会自动回退到这个纯 Python 包，所以它必须是运行时依赖，
+        不能只依赖宿主系统。
+        """
+        document = tomllib.loads(
+            Path("pyproject.toml").read_text(encoding="utf-8")
+        )
+        dependencies = document["project"]["dependencies"]
+        self.assertTrue(
+            any(str(entry).startswith("tzdata") for entry in dependencies),
+            "tzdata 必须留在运行时依赖里；移除它会让纯净 Linux 服务器无法完成 init",
+        )
+
+    def test_default_config_timezone_resolves_with_the_declared_dependency(self) -> None:
+        """init 模板写入的时区必须能被当前解释器真实解析。"""
+        from zoneinfo import ZoneInfo
+
+        source = Path("src/lobster0/bootstrap.py").read_text(encoding="utf-8")
+        match = re.search(r"timezone = .([A-Za-z]+/[A-Za-z_]+)", source)
+        self.assertIsNotNone(match, "未能在 init 模板中定位 timezone 默认值")
+        ZoneInfo(match.group(1))
 
     def test_public_names_and_complete_extras_do_not_change(self) -> None:
         """CLI 名称和完整渠道依赖集合应保持公开兼容。"""

--- a/uv.lock
+++ b/uv.lock
@@ -472,6 +472,7 @@ dependencies = [
     { name = "croniter" },
     { name = "httpx" },
     { name = "textual" },
+    { name = "tzdata" },
 ]
 
 [package.optional-dependencies]
@@ -515,6 +516,7 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.2,<7" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9" },
     { name = "textual", specifier = ">=8.2,<9" },
+    { name = "tzdata", specifier = ">=2025.1" },
 ]
 provides-extras = ["dev", "feishu", "telegram", "discord", "channels", "all"]
 
@@ -966,6 +968,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 纯净 Linux 服务器上 `init` 必然失败

在真实 `ubuntu:24.04` 容器里**实地走完**部署流程时发现的:

```
[1] uv 安装        ok
[2] 代码拉取        ok
[3] 依赖同步        ok
[4] CLI 可用 0.7.0  ok
[5] init 失败       heartbeat.timezone must be a valid IANA timezone
```

## 根因

一开始怀疑是服务器没设时区,实测**否定**了——系统时区数据库完好,系统 `python3` 能正常解析 `Asia/Shanghai`。

真正原因:**uv 提供的 python-build-standalone 解释器不自带时区数据库,也不会回退去读系统的 `/usr/share/zoneinfo`**。

| 解释器 | `ZoneInfo("Asia/Shanghai")` |
|---|---|
| 系统 python3 | OK |
| **uv 管理的 Python** | **ZoneInfoNotFoundError** |

而龙虾正是跑在 uv 管理的 Python 上 —— 所以**任何纯净 Linux 服务器都装不起来**。macOS 因环境不同从未暴露。

## 修复

`zoneinfo` 会自动回退到纯 Python 的 `tzdata` 包,补为运行时依赖即可。

**实测对比**(同一镜像):
- 修复前:`init` 报错退出
- 修复后:`init` 退出码 **0**,`config.toml` 正常生成

## 回归测试

补了两条,防止以后被当作"无用依赖"清理掉:
1. 断言 `tzdata` 留在运行时依赖里;
2. 断言 init 模板写入的时区能被**当前解释器**真实解析——这条能直接复现今天这个 bug。

`tests.test_package_metadata` 4/4 通过;改动文件 Ruff 干净。

注:仓库里另有若干 `I001` 导入排序告警来自并发开发的其他文件,不在本 PR 范围。
