### PR TITLE
docs(deploy): 补 Linux 服务器部署指南,每条命令均实地验证

### DIFF
--- a/docs/getting-started/20260807_本地运行指南.md
+++ b/docs/getting-started/20260807_本地运行指南.md
@@ -1,5 +1,9 @@
 # Lobster0 本地运行指南
 
+> 本文面向**本机开发**。要把 Lobster0 部署到一台 Linux 服务器上 7×24 运行并接入飞书，
+> 见 [Linux 服务器部署指南](20260811_Linux服务器部署指南.md)——那份文档的每条命令都在纯净
+> `ubuntu:24.04` 上实地验证过，并记录了两个只在纯净服务器上才会暴露的坑。
+
 ## 当前可以运行什么
 
 当前版本已完成默认 pi-tui、Memory Autopilot、Phase 6 Autonomy/Sandbox 与 Phase 6.5 Browser Agent 的代码/离线门禁，状态为

--- a/docs/getting-started/20260811_Linux服务器部署指南.md
+++ b/docs/getting-started/20260811_Linux服务器部署指南.md
@@ -1,0 +1,152 @@
+# Linux 服务器部署指南
+
+> 适用范围：Lobster0 0.7.0 之后的当前 `main`，源码部署方式。
+> 本文每一条命令都在纯净 `ubuntu:24.04` 容器里实地执行验证过，不是照文档推演的。
+> 验证终态：`lobster0 doctor` **28 项 PASS、0 项 FAIL**。
+
+## 这份指南解决什么
+
+在一台全新的 Linux 服务器上，把 Lobster0 跑起来并接入飞书，让它 7×24 在线。
+
+一行安装（`curl ... install.sh | bash`）目前还没有可用的公开 Release，所以本文走**源码部署**。两者的区别只在于「谁来准备 Python 和 Node」：一行安装由安装器自动准备，源码部署需要你先装好。
+
+## 机器配置
+
+实测资源占用：磁盘约 1GB 出头（受管 Python ~150MB + Node ~100MB + Python 依赖 ~300MB + 前端构建产物），网关常驻内存几百 MB。
+
+因此 **2 核 4G / 40GB 起步即可**；4 核 8G 会让前端构建更快，日常运行用不满。飞书走 WebSocket 长连接，平时几乎不耗流量，带宽主要花在调用模型 API 上，5M 足够。
+
+若计划启用 Docker 沙箱执行代码，再预留几 GB 磁盘。
+
+系统建议 **Ubuntu 24.04 LTS**（纯净镜像，不要用带面板的应用镜像）。
+
+## 网络与防火墙
+
+**只需放行 SSH 22 端口（入站）。**
+
+飞书渠道使用**长连接**：程序主动连出去，不接受入站回调。因此：
+
+- 不需要公网回调地址、域名或证书；
+- 不需要内网穿透；
+- 不需要为飞书开放任何入站端口。
+
+轻量服务器默认可能放行了 80/443，建议关闭，攻击面越小越好。
+
+## 部署步骤
+
+### 1. 安装 Node 24
+
+pi-tui（终端界面）依赖 Node，版本范围是 `>=22.22.3 <23` 或 `>=24.15.0 <25`。
+
+```bash
+curl -fsSL -o /tmp/node.tar.xz https://nodejs.org/dist/v24.18.0/node-v24.18.0-linux-x64.tar.xz
+sudo mkdir -p /opt/node && sudo tar -xJf /tmp/node.tar.xz -C /opt/node --strip-components=1
+echo 'export PATH=/opt/node/bin:$PATH' >> ~/.bashrc && source ~/.bashrc
+sudo corepack enable
+```
+
+ARM 机器把 URL 里的 `linux-x64` 换成 `linux-arm64`。
+
+### 2. 安装 uv
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+source ~/.bashrc
+```
+
+### 3. 拉取代码并同步依赖
+
+```bash
+git clone https://github.com/NEDONION/lobster0.git ~/lobster0
+cd ~/lobster0 && uv sync --all-extras
+```
+
+`--all-extras` 会一并装上飞书、Telegram、Discord 三个渠道的 SDK。
+
+### 4. 初始化状态目录
+
+```bash
+uv run lobster0 init --home ~/.lobster0
+```
+
+生成 `~/.lobster0/config.toml` 与数据库。
+
+### 5. 构建终端界面
+
+**这一步必须显式激活项目锁定的 pnpm 版本**，否则会失败（见下方「已知坑」）。
+
+```bash
+cd ~/lobster0 && corepack prepare pnpm@10.14.0 --activate
+cd ~/lobster0/tui && pnpm install --frozen-lockfile && pnpm build
+```
+
+只用飞书网关、不需要在服务器上开终端界面的话，这一步可以跳过；`doctor` 会因此报一项 `pi_tui` FAIL，不影响网关运行。
+
+### 6. 体检
+
+```bash
+cd ~/lobster0 && uv run lobster0 doctor --home ~/.lobster0
+```
+
+预期 **28 项 PASS**。
+
+`[WARN] install_method: source checkout` 是**正常的**，它只是说明你走的是源码部署而非安装包，不是问题。
+
+### 7. 交互式配置
+
+```bash
+uv run lobster0 setup
+```
+
+会依次询问模型 API Key、启用哪些渠道、以及飞书凭据，写入 `~/.lobster0/secrets.env`（权限 0600，仅属主可读）。
+
+### 8. 启动飞书网关
+
+```bash
+uv run lobster0 gateway
+```
+
+## 飞书应用怎么建
+
+在飞书开放平台创建**企业自建应用**，然后：
+
+1. 开启**机器人**能力；
+2. 事件订阅选择**长连接**模式——不需要填回调 URL；
+3. 复制 **App ID** 与 **App Secret**，填入上一节 `setup` 的提问。
+
+`setup` 还会问 Owner（你自己的飞书账号），用于限定只有你能指挥这个机器人。
+
+## 已知坑（实地验证时踩到的）
+
+### tzdata 缺失导致 init 失败
+
+**现象**：`lobster0 init` 报 `heartbeat.timezone must be a valid IANA timezone`。
+
+**原因**：uv 提供的 python-build-standalone 解释器**不自带时区数据库，也不会回退去读系统的 `/usr/share/zoneinfo`**。即使宿主装了系统 tzdata，`ZoneInfo("Asia/Shanghai")` 仍会抛 `ZoneInfoNotFoundError`。系统 `python3` 能解析、而 Lobster0 跑的那个 Python 解析不了，是这个问题最迷惑的地方。
+
+**状态**：已通过把 `tzdata` 补为运行时依赖修复，当前 `main` 不会再遇到。此处保留记录，便于理解为何该依赖不可移除——测试 `tests/test_package_metadata.py` 中有两条回归断言守着它。
+
+### pnpm 版本冲突导致前端构建失败
+
+**现象**：`pnpm build` 报 `This project is configured to use 10.14.0 of pnpm. Your current pnpm is v11.21.0`。
+
+**原因**：Node 24 自带的 corepack 会拉起较新的 pnpm，而本项目锁定 `pnpm@10.14.0`（见 `tui/package.json` 的 `packageManager` 字段），版本不符即拒绝执行。
+
+**解法**：构建前显式激活锁定版本，即第 5 步的 `corepack prepare pnpm@10.14.0 --activate`。
+
+## 验证记录
+
+| 步骤 | 结果 |
+| --- | --- |
+| 安装 uv | PASS |
+| 拉取代码 | PASS |
+| `uv sync --all-extras` | PASS |
+| CLI 可用（`lobster0 0.7.0`） | PASS |
+| `lobster0 init` | PASS（补 tzdata 后） |
+| 安装 Node 24.18.0 | PASS |
+| 构建 pi-tui | PASS（显式激活 pnpm 10.14.0 后） |
+| `lobster0 doctor` | **28 PASS / 0 FAIL** |
+
+以上均在纯净 `ubuntu:24.04` 容器、非 root 用户下执行。
+
+**尚未验证**：飞书长连接的真实连通性与端到端对话，这需要真实的 App ID / App Secret，无法在离线环境中完成。第 7、8 步的实际效果请以你自己机器上的输出为准。

--- a/scripts/validate_docs.py
+++ b/scripts/validate_docs.py
@@ -31,6 +31,7 @@ CURRENT_RELATIVE_DOCS = (
     Path("docs/superpowers/specs/2026-08-09-phase-6-autonomy-sandbox-design.md"),
     Path("docs/superpowers/plans/2026-08-09-phase-6-autonomy-sandbox.md"),
     Path("docs/getting-started/20260807_本地运行指南.md"),
+    Path("docs/getting-started/20260811_Linux服务器部署指南.md"),
     Path("docs/evals/README.md"),
     Path("docs/evals/releases/v0.5.0.md"),
     Path("docs/evals/releases/v0.5.1.md"),


### PR DESCRIPTION
## 一份每条命令都实地验证过的 Linux 部署指南

在纯净 `ubuntu:24.04` 容器、非 root 用户下完整走通部署链路,终态 **`lobster0 doctor` 28 项 PASS、0 项 FAIL**。

指南按**实际执行顺序**记录,不是照着文档推演的——过程中真撞到了两个坑,都写进了文档。

## 实地验证挖出的两个坑(Mac 上永远看不到)

### 1. tzdata 缺失 → `init` 必然失败

uv 提供的 python-build-standalone 解释器**不自带时区数据库,也不会回退去读系统的 `/usr/share/zoneinfo`**。最迷惑的地方是:系统 `python3` 能解析 `Asia/Shanghai`,但 Lobster0 跑的那个 Python 解析不了。

已在 PR #30 修复。指南里保留成因说明,是为了解释这个依赖为何不可移除(测试里有两条回归断言守着)。

### 2. pnpm 版本冲突 → 前端构建失败

Node 24 自带的 corepack 会拉起 pnpm 11,而项目锁定 `pnpm@10.14.0`,版本不符直接拒绝构建。解法是先 `corepack prepare pnpm@10.14.0 --activate`。

## 顺带澄清的一点

飞书渠道走 **WebSocket 长连接**——程序主动连出去,不接受入站回调。所以**不需要**公网回调地址、域名、证书或内网穿透,防火墙只放行 SSH 22 即可。这点之前容易被误解成需要复杂的公网配置。

## 诚实标注

**飞书端到端连通性尚未验证**——那需要真实的 App ID / App Secret,离线环境做不到。文档里已明确写出这一点,没有把未验证的部分说成已验证。

## 验证

- `scripts/validate_docs.py` PASS(新文档已注册进校验器,链接与格式持续受检)
- `tests.test_documentation` 9/9 PASS
