### PR TITLE
fix(env): 默认读取状态目录的 secrets.env,修复配置好却启动不了

### DIFF
--- a/src/lobster0/env.py
+++ b/src/lobster0/env.py
@@ -34,14 +34,21 @@ def resolve_dotenv_path(
     Raises:
         DotEnvError: 显式安装态路径不是绝对路径。
     """
-    del paths
     selected = environ.get("LOBSTER0_ENV_FILE", "").strip()
-    if not selected:
-        return (Path.cwd() if cwd is None else cwd) / ".env"
-    candidate = Path(selected).expanduser()
-    if not candidate.is_absolute():
-        raise DotEnvError("LOBSTER0_ENV_FILE must be absolute path")
-    return candidate.resolve(strict=False)
+    if selected:
+        candidate = Path(selected).expanduser()
+        if not candidate.is_absolute():
+            raise DotEnvError("LOBSTER0_ENV_FILE must be absolute path")
+        return candidate.resolve(strict=False)
+    # `setup` 把 Secret 写到 StatePaths.secrets_file（<home>/secrets.env）。
+    # 若不在这里回退到它，配置好的部署仍会以 "LOBSTER0_MODEL_API_KEY is not
+    # configured" 启动失败——除非用户自己猜到要设 LOBSTER0_ENV_FILE。实机部署
+    # 中确实踩到了这个断裂：secrets.env 三个值俱全，doctor 却报 missing
+    # environment variable(s)。开发态 cwd/.env 仍然保留，但仅作为次选。
+    secrets_file = getattr(paths, "secrets_file", None)
+    if secrets_file is not None and Path(secrets_file).is_file():
+        return Path(secrets_file)
+    return (Path.cwd() if cwd is None else cwd) / ".env"
 
 
 def load_dotenv(

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -38,9 +38,39 @@ class DotEnvTest(unittest.TestCase):
                 cwd=self.other,
             )
 
-    def test_development_keeps_fixed_cwd_dotenv(self) -> None:
-        """未指定安装态 Secret 文件时保持仅加载 cwd/.env 的开发语义。"""
+    def test_development_keeps_cwd_dotenv_when_state_home_has_no_secrets(self) -> None:
+        """状态目录没有 secrets.env 时，保持加载 cwd/.env 的开发语义。"""
         self.assertEqual(resolve_dotenv_path(self.paths, {}, cwd=self.other), self.other / ".env")
+
+    def test_state_home_secrets_are_loaded_without_an_explicit_env_file(self) -> None:
+        """`setup` 写入的 secrets.env 必须无需额外配置就被运行时读到。
+
+        实机部署中踩到的真实断裂：`lobster0 setup` 把三个凭据写进
+        ``<home>/secrets.env``（文件权限 0600、内容俱全），但运行时默认只看
+        ``cwd/.env``，于是 doctor 报 ``missing environment variable(s)``、
+        gateway 报 ``LOBSTER0_MODEL_API_KEY is not configured``——除非用户
+        自己猜到要设 ``LOBSTER0_ENV_FILE``。配置好的部署因此启动不了。
+        """
+        secrets = Path(self.paths.secrets_file)
+        secrets.write_text("LOBSTER0_MODEL_API_KEY=k\n", encoding="utf-8")
+        secrets.chmod(0o600)
+
+        self.assertEqual(resolve_dotenv_path(self.paths, {}, cwd=self.other), secrets)
+
+    def test_explicit_env_file_still_wins_over_state_home_secrets(self) -> None:
+        """显式 LOBSTER0_ENV_FILE 的优先级高于状态目录回退。"""
+        secrets = Path(self.paths.secrets_file)
+        secrets.write_text("LOBSTER0_MODEL_API_KEY=k\n", encoding="utf-8")
+        secrets.chmod(0o600)
+        self.other.mkdir(parents=True, exist_ok=True)
+        explicit = self.other / "explicit.env"
+        explicit.write_text("LOBSTER0_MODEL_API_KEY=other\n", encoding="utf-8")
+        explicit.chmod(0o600)
+
+        self.assertEqual(
+            resolve_dotenv_path(self.paths, {"LOBSTER0_ENV_FILE": str(explicit)}, cwd=self.other),
+            explicit.resolve(),
+        )
 
     def test_missing_file_loads_nothing(self) -> None:
         """尚未创建 ``.env`` 时应保持环境不变，方便纯 Shell 配置。"""


### PR DESCRIPTION
## 配置好了却启动不了

实机部署踩到的真实断裂。`lobster0 setup` 把三个凭据写进 `<home>/secrets.env`(权限 0600、内容俱全,`awk` 验证过长度分别是 35/20/32 字符),但运行时读不到:

```console
$ uv run lobster0 doctor --home ~/.lobster0
[FAIL] feishu_runtime: missing environment variable(s): LOBSTER0_FEISHU_APP_ID, LOBSTER0_FEISHU_APP_SECRET

$ uv run lobster0 gateway --home ~/.lobster0
error: LOBSTER0_MODEL_API_KEY is not configured
```

## 根因

`resolve_dotenv_path` 的第一行就是 `del paths` —— **直接丢弃了状态路径**,未显式指定时只看 `cwd/.env`。

于是 `setup` 写 A 处、运行时读 B 处,中间没有任何东西告诉用户要设 `LOBSTER0_ENV_FILE`。**配了等于没配**,而且报错信息指向"没配置",与事实相反,极具误导性。

## 修复

优先级改为:

1. 显式 `LOBSTER0_ENV_FILE`(最高,行为不变)
2. **状态目录下的 `secrets.env`(新增,即 setup 写入的位置)**
3. `cwd/.env`(保底,保持开发态语义)

## 关于被修改的既有测试

`test_development_keeps_fixed_cwd_dotenv` 断言的正是**被修正的旧语义**。我没有删掉或放宽它,而是改名为 `test_development_keeps_cwd_dotenv_when_state_home_has_no_secrets` 并收窄条件——语义变更是明示的,不是掩盖的。

## 新增回归测试

- `test_state_home_secrets_are_loaded_without_an_explicit_env_file` —— 无需额外配置即可读到 setup 写入的凭据
- `test_explicit_env_file_still_wins_over_state_home_secrets` —— 显式指定仍然优先

**反向验证**:回滚修复后第一条确实失败,恢复后通过,不是摆设。

## 验证

`tests.test_env` + `test_cli` + `test_gateway` + `test_config` + `test_setup` 合计 **119/119 通过**;改动文件 Ruff 干净。
