### PR TITLE
feat(cli): 新增 lobster0 secret set/list,改密钥不再需要删光数据

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ lobster0 setup         # 交互式配置：模型 API Key、飞书 App ID/Secret
 lobster0 gateway       # 启动飞书网关（WebSocket 长连接，无需公网端口）
 ```
 
+> 密钥填错或需要轮换？用 `lobster0 secret set LOBSTER0_MODEL_API_KEY` 就地改掉一个值，
+> **不要** `rm -rf ~/.lobster0`——那会连记忆、会话历史、定时任务和审计记录一起删掉。
+> `lobster0 secret list` 可以查看哪些变量已配置（只显示名称）。
+
 > **文件名必须保持原样**——`uv` 要从中读取版本号，改名会报 `Must have a version`。
 >
 > `v0.7.0` 是**预发布**，整体状态为 **RELEASE CANDIDATE / PUBLIC GATES PENDING**：
@@ -260,6 +264,8 @@ curl -fsSL --proto '=https' --tlsv1.2 \
 | `uv run lobster0` | 启动主 TUI。 |
 | `uv run lobster0 init` | 初始化配置、Memory、Skills 和 SQLite。 |
 | `uv run lobster0 doctor` | 检查配置、目录、Provider、TUI 和数据库。 |
+| `uv run lobster0 secret list` | 查看哪些密钥变量已配置（只显示名称，不显示值）。 |
+| `uv run lobster0 secret set NAME` | 改掉一个填错或轮换的密钥；值从终端隐藏读取，其余状态不动。 |
 | `uv run lobster0 gateway` | 启动已配置的消息 Channel。 |
 | `uv run lobster0 web` | 启动本地 Web 控制台。 |
 | `uv run lobster0 task list` | 查看定时任务；另有 show/runs/pause/resume/run/cancel。 |

--- a/docs/engineering/20260812_已配置实例的Secret更新命令.md
+++ b/docs/engineering/20260812_已配置实例的Secret更新命令.md
@@ -1,0 +1,151 @@
+# 已配置实例的 Secret 更新命令
+
+> 日期：2026-08-12
+> 文档类型：数据破坏级可用性缺口修复实现记录
+> 状态：`IMPLEMENTED`（2026-08-12）
+
+## 1. 触发来源
+
+真实服务器部署中用户填错了模型 API Key。想改掉这一个字符串，当时能走的路只有一条：
+
+```bash
+rm -rf ~/.lobster0 && lobster0 setup
+```
+
+因为 `lobster0 setup` 是 fresh-install only——[src/lobster0/setup.py](../../src/lobster0/setup.py) 的
+`write_fresh_setup` 在 `config.toml` 或 `secrets.env` 已存在时直接抛
+`setup target already exists`，而 CLI 里**没有任何命令能更新一个已经配置好的实例**。
+
+`rm -rf ~/.lobster0` 抹掉的不只是那一个 Key，而是整个状态根：记忆（`MEMORY.md`、`memory/`）、
+会话历史与审批/审计记录（`lobster0.db`）、自动化任务、Prompt/Skill 版本、Workspace。为改一个字符串
+销毁全部状态，不可接受。
+
+## 2. 根因
+
+能力其实已经存在，只是没有出口：
+
+- `update_secret(paths, name, value)` 早就实现了正确语义——就地替换目标变量那一行，保留注释、空行、
+  其他变量的值与顺序，缺失时追加，变量名限定 `LOBSTER0_[A-Z0-9_]+`，值走 `validate_secret_value`，
+  最后经 `_write_private_text` 以 0600 原子落盘；
+- 但它的唯一调用方是 Bridge 的 `providers.set_secret`（[src/lobster0/bridge/server.py](../../src/lobster0/bridge/server.py)），
+  也就是**只有桌面端 UI 能用**。纯 CLI/服务器部署的用户碰不到它。
+
+所以这次的工作量主要在"安全地把它接出来"，不是重新实现。
+
+## 3. 命令形状
+
+新增 `secret` 子命令族：
+
+```bash
+lobster0 secret list [--home DIR]
+lobster0 secret set NAME [--home DIR]
+```
+
+选它而不是 `config` 族的理由：
+
+- 现有 CLI 惯例是**名词族 + 动词子命令**（`task list` / `feedback show` / `service install` /
+  `evolve propose`），`secret set` / `secret list` 与之完全一致；`config set-secret` 这种
+  连字符动宾在本仓库没有先例。
+- 命令的作用域名副其实：它只写 `secrets.env`，**不碰 `config.toml`**。叫 `config` 会让用户以为
+  能改 Channel 开关、Owner ID、模型名，而这些它一个都做不到。等真的要做配置项编辑时，再单独开
+  `config` 族，两者不冲突。
+
+`--home` 挂在族级 parser 上（与 `task` / `feedback` / `service` 一致）。
+
+## 4. 安全约束与实现
+
+### 4.1 值绝不经过 argv
+
+`secret set` 只接受**变量名**这一个位置参数，没有任何承载值的 flag。值通过
+`getpass.getpass(prompt, stream=tty)` 从 `/dev/tty` 隐藏读取，复用 `run_interactive_setup` 已有的
+`_open_tty()` / `_DuplexTty` 机制，不新写终端处理代码。
+
+因此值不会出现在 `ps`、shell 历史、进程环境或任何 argv 里。
+
+### 4.2 非 TTY 时 fail closed
+
+两道闸门，任一不满足都直接报错退出，绝不从管道静默读值：
+
+1. `sys.stdin.isatty()` 为假 → `SetupError("secret input requires an interactive terminal")`；
+2. `_open_tty()` 打不开 controlling TTY → `SetupError("interactive terminal is unavailable")`。
+
+第 1 道是必需的：`getpass` 在 `/dev/tty` 不可用时会退化到 `fallback_getpass`——**回显着**从 stdin 读。
+先卡住非 TTY stdin，就不存在这条退化路径。
+
+### 4.3 只允许已知变量名
+
+`known_secret_names(paths)` 返回允许写入的集合：
+
+| 来源 | 名称 |
+| --- | --- |
+| 固定基线 | `LOBSTER0_MODEL_API_KEY`、`LOBSTER0_FEISHU_APP_ID`、`LOBSTER0_FEISHU_APP_SECRET`、`LOBSTER0_TELEGRAM_BOT_TOKEN`、`LOBSTER0_DISCORD_BOT_TOKEN` |
+| 当前 `config.toml` 实际引用 | 每个 Provider 的 `api_key_env`、各 Channel 的 `app_id_env` / `app_secret_env` / `bot_token_env` |
+
+判据是"这个变量名有没有人读"：固定基线来自 `_required_secret_names` 覆盖的全部平台；配置派生项让
+多 Provider 用户（`LOBSTER0_PROVIDER_<ID>_KEY`）也能改自己的 Key。配置读不出来时退回固定基线——
+`secret` 不承担诊断配置的职责，那是 `doctor`。派生名同样过 `_SECRET_NAME` 正则，配置里写
+`api_key_env = "PATH"` 也进不了允许集合；即便进了，`update_secret` 自身的正则也会再挡一次。
+
+未知名称一律拒绝并回显合法名单，避免打错字后静默写进一个没人读的变量。
+
+### 4.4 输出永不含值
+
+- `secret set` 成功只打印变量名与文件路径；
+- `secret list` 输出 `[SET] NAME` / `[UNSET] NAME`（对齐 `doctor` 的 `[PASS]` 风格），只报告
+  "是否存在且非空"；
+- 异常文本不携带值（`validate_secret_value` 抛的是固定字符串 `unsafe secret value`）。
+
+`describe_secrets(paths)` 用 `load_dotenv` 解析（顺带复用它的 0600 私密性与语法校验），值只在内存里
+用于判空，从不进入任何输出。列表同时展示文件里存在但不属于已知集合的 `LOBSTER0_*` 残留项，便于用户
+发现自己手工编辑时留下的错别字。
+
+## 5. 与既有保证的关系
+
+- **不放松 `setup` 的 fresh-only 保证**：`write_fresh_setup` 的 `setup target already exists` 守卫
+  一行未改。它挡的是"误跑 setup 覆盖可用实例"，这次加的是另一条独立的安全通路。
+- **不破坏 `secrets.env` 回退**：`resolve_dotenv_path` 在 `LOBSTER0_ENV_FILE` 未设置时回退到
+  `<home>/secrets.env`（见 [src/lobster0/env.py](../../src/lobster0/env.py)），`secret set` 写的正是
+  这个文件，所以 `doctor` 与 Gateway 无需任何额外环境变量就能读到新值。
+
+## 6. 验证
+
+- 新增 `tests/test_setup.py::SecretMaintenanceTest` 9 个用例：更新一个变量后其余行逐字节不变、
+  文件保持 0600、未知名称被拒且不落盘、stdin 非 TTY 时**连 `_open_tty` 和 `getpass` 都不调用**、
+  值只经 `getpass(stream=tty)` 读取且不出现在 TTY 回显里、两次输入不一致时不落盘、
+  `describe_secrets` 只报名称与 set/unset；
+- 新增 `tests/test_cli.py::SecretCommandTest` 6 个用例：**已有 `config.toml` 的实例可直接更新**
+  （正是当前必须 `rm -rf` 的那个场景，同时断言 `config.toml` 与 `lobster0.db` 字节不变）、
+  未知名称退出码 2、非 TTY stdin 退出码 2、`secret list` 不输出任何值、`secret` 族的全部
+  option 恰好是 `{-h, --help, --home}`、以及 `doctor` 在 `secret set` 前后由 FAIL 变 PASS 的实测；
+- `tests.test_setup` + `tests.test_cli` + `tests.test_bridge_server` + `tests.test_doctor` +
+  `tests.test_env` 合计 125/125 通过（含真实 PTY 的 setup 用例）；
+- **真实终端实测**（非 mock）：`forkpty` 起一个子进程跑 `secret set`，终端 transcript 里只有两行
+  提示，输入的值一个字符都没回显，落盘后 `secrets.env` 内容正确；
+- **`doctor` 实测反映更新**（在 `LOBSTER0_ENV_FILE` 未设置、纯靠 `secrets.env` 回退的条件下）：
+  更新前 `[FAIL] feishu_runtime: missing environment variable(s): LOBSTER0_FEISHU_APP_SECRET`，
+  真实 PTY 更新后 `[PASS] feishu_runtime`；
+- 全量 `unittest discover`：1835 tests，3 failures + 1 error，与基线的既有失败**一一对应**
+  （`test_release_bundles.TuiBundleTest` 因本机 Node/pnpm 低于门槛；`test_browser_evals` ×1 与
+  `test_cli_eval` ×2 因本 worktree 没有 `browser-worker/dist` 构建产物）。基线另有两个
+  loader error（`test_desktop_packaging`、`test_install_matrix_contract`）源于本 worktree 未装
+  `pyyaml`，`uv sync --extra dev` 后消失，与本次改动无关；
+- `ruff check .` 与 `python scripts/validate_docs.py` 通过。
+
+## 7. 影响范围
+
+`src/lobster0/setup.py`（新增 `KNOWN_SECRET_NAMES`、`SecretStatus`、`known_secret_names`、
+`describe_secrets`、`set_secret_interactively`，不改任何既有函数体）、`src/lobster0/cli.py`
+（parser 注册 + 一个 `_run_secret` 分发函数）、两个测试文件与本文档。不涉及配置格式、Owner 校验、
+Channel 启用逻辑、数据库或任何既有持久化行为。
+
+## 8. 遗留
+
+- 本次只覆盖 Secret。Channel 开关、Owner ID、模型名的编辑仍然只能手改 `config.toml`；真要做时按第 3
+  节的理由单开 `config` 族；
+- `secret set` 不校验值在对应平台上是否真的有效（那需要联网），改完请自行 `lobster0 doctor`
+  确认变量已就位，再重启 Gateway；
+- **既有陷阱（本次未改变）**：`load_dotenv` 只写入进程环境里尚不存在的变量。如果用户在 shell 里
+  `export LOBSTER0_MODEL_API_KEY=...`，或 systemd/launchd unit 里硬写了同名变量，那么改完
+  `secrets.env` 后 `doctor` 和 Gateway 读到的仍是那个更高优先级的旧值，表现为"我改了但没生效"。
+  同理，显式设置 `LOBSTER0_ENV_FILE` 时 `doctor` 读的是那个文件，而 `secret set` 写的始终是
+  `<home>/secrets.env`。这是 `env.py` 的既有语义，本次没有触碰，但值得后续补一条 Doctor 检查。

--- a/src/lobster0/cli.py
+++ b/src/lobster0/cli.py
@@ -72,7 +72,12 @@ from lobster0.gateway_service import (
 )
 from lobster0.install.orchestrator import resolve_install_facts, run_install_action
 from lobster0.paths import PathConfigurationError, StatePaths, build_state_paths, resolve_home
-from lobster0.setup import SetupError, run_interactive_setup
+from lobster0.setup import (
+    SetupError,
+    describe_secrets,
+    run_interactive_setup,
+    set_secret_interactively,
+)
 from lobster0.storage.database import Database, DatabaseError
 from lobster0.storage.migrations import (
     LATEST_SCHEMA_VERSION,
@@ -126,6 +131,25 @@ def build_parser() -> argparse.ArgumentParser:
         dest="command_home",
         help="absolute Lobster0 state directory",
     )
+    secret_parser = subparsers.add_parser(
+        "secret",
+        help="update or inspect the Secret file of an already-configured install",
+    )
+    secret_parser.add_argument(
+        "--home",
+        dest="command_home",
+        help="absolute Lobster0 state directory",
+    )
+    secret_subparsers = secret_parser.add_subparsers(dest="secret_command", required=True)
+    secret_subparsers.add_parser(
+        "list",
+        help="list Secret names and whether each one is set; values are never printed",
+    )
+    secret_set = secret_subparsers.add_parser(
+        "set",
+        help="replace one Secret in place; the value is read from the terminal only",
+    )
+    secret_set.add_argument("name", help="exact Secret environment variable name")
     gateway_parser = subparsers.add_parser(
         "gateway",
         help="run all enabled IM channels with one long-lived Agent runtime",
@@ -406,6 +430,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if arguments.command == "setup":
         return _run_setup(paths, arguments.sandbox_image)
 
+    if arguments.command == "secret":
+        return _run_secret(paths, arguments)
+
     if arguments.command == "task":
         return _run_task(paths, arguments)
 
@@ -532,6 +559,47 @@ def _run_setup(paths: StatePaths, sandbox_image: str | None) -> int:
         return 130
     print(f"Configured Lobster0 at {paths.home} (owner {result.owner.id}).")
     return 0
+
+
+def _run_secret(paths: StatePaths, arguments: argparse.Namespace) -> int:
+    """更新或查看已配置实例的 Secret，不销毁任何既有状态。
+
+    `setup` 是 fresh-only 的，这条路径专门服务"已经在用、只想换一个 Key"的实例：
+    只改 ``secrets.env`` 里目标变量那一行，记忆、会话历史、自动化任务和数据库全部不动。
+    值只从 ``/dev/tty`` 隐藏读取，因此不会进入 argv、``ps`` 或 shell 历史；任何输出都
+    只含变量名。
+
+    Args:
+        paths: 已解析的 Lobster0 状态路径。
+        arguments: argparse 生成且只含子命令与变量名的参数。
+
+    Returns:
+        成功为 0、输入或配置错误为 2、持久化错误为 5、取消为 130。
+    """
+    if paths.home.is_symlink() or not paths.home.is_dir():
+        print("error: Lobster0 state is not initialized", file=sys.stderr)
+        return 2
+    try:
+        if arguments.secret_command == "list":
+            for item in describe_secrets(paths):
+                print(f"[{'SET' if item.configured else 'UNSET'}] {item.name}")
+            return 0
+        if arguments.secret_command == "set":
+            set_secret_interactively(paths, arguments.name)
+            print(f"Updated {arguments.name} in {paths.secrets_file}.")
+            print("Run `lobster0 doctor` to confirm, then restart the Gateway.")
+            return 0
+        raise ValueError("unsupported secret command")
+    except (ConfigError, DotEnvError, SetupError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+    except OSError as error:
+        # OSError 的消息只含 errno 与文件路径，不含被写入的值。
+        print(f"error: {error}", file=sys.stderr)
+        return 5
+    except KeyboardInterrupt:
+        print("Cancelled.", file=sys.stderr)
+        return 130
 
 
 def _run_task(paths: StatePaths, arguments: argparse.Namespace) -> int:

--- a/src/lobster0/setup.py
+++ b/src/lobster0/setup.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import stat
+import sys
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -14,6 +15,8 @@ from types import TracebackType
 from typing import TextIO
 
 from lobster0.bootstrap import InitResult, initialize_state, render_default_config
+from lobster0.config import ConfigError, load_config
+from lobster0.env import load_dotenv
 from lobster0.paths import StatePaths
 
 _FEISHU_OWNER = re.compile(r"ou_[A-Za-z0-9_-]{1,128}\Z")
@@ -267,6 +270,146 @@ def update_secret(paths: StatePaths, name: str, value: str) -> None:
     if not replaced:
         lines.append(f"{name}={value}")
     _write_private_text(path, "".join(f"{line}\n" for line in lines))
+
+
+# 可写入 secrets.env 的固定基线：模型 Secret 加三个平台 Channel 的凭据变量。
+# 这是 _required_secret_names 在"三个 Channel 全部启用"时的并集，也就是 fresh setup
+# 有可能写进 secrets.env 的全部变量名。
+KNOWN_SECRET_NAMES: tuple[str, ...] = (
+    _MODEL_SECRET,
+    *_FEISHU_SECRETS,
+    _TELEGRAM_SECRET,
+    _DISCORD_SECRET,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SecretStatus:
+    """描述一个 Secret 变量是否已配置，**不携带它的值**。"""
+
+    name: str
+    configured: bool
+
+
+def known_secret_names(paths: StatePaths) -> tuple[str, ...]:
+    """返回允许写入本地 secrets.env 的全部变量名。
+
+    判据是"这个变量名有没有人读"：固定基线覆盖模型与三个平台，配置派生项让多
+    Provider 用户也能更新自己的 Key。名单之外的名称一律拒绝，避免打错字之后静默
+    写进一个谁也不会读的变量。
+
+    Args:
+        paths: 已解析的 Lobster0 状态路径。
+
+    Returns:
+        固定基线在前、配置派生名按字典序在后的去重变量名。
+    """
+    names = list(KNOWN_SECRET_NAMES)
+    for name in sorted(_configured_secret_names(paths)):
+        if name not in names:
+            names.append(name)
+    return tuple(names)
+
+
+def _configured_secret_names(paths: StatePaths) -> frozenset[str]:
+    """收集本地配置真正引用的 Secret 变量名。
+
+    配置读不出来时返回空集合而不是抛错：``secret`` 命令不承担诊断配置的职责，那是
+    ``doctor``；固定基线足以覆盖 fresh setup 写过的一切。派生名同样过 ``_SECRET_NAME``
+    正则，配置里写 ``api_key_env = "PATH"`` 也进不了允许集合。
+
+    Args:
+        paths: 已解析的 Lobster0 状态路径。
+
+    Returns:
+        通过变量名形状校验的配置派生名集合。
+    """
+    try:
+        config = load_config(paths, {})
+    except (ConfigError, OSError, ValueError):
+        return frozenset()
+    channels = config.channels
+    candidates = {
+        channels.feishu.app_id_env,
+        channels.feishu.app_secret_env,
+        channels.telegram.bot_token_env,
+        channels.discord.bot_token_env,
+        config.provider.api_key_env,
+        *(provider.api_key_env for provider in config.providers),
+    }
+    return frozenset(
+        name
+        for name in candidates
+        if isinstance(name, str) and _SECRET_NAME.fullmatch(name)
+    )
+
+
+def describe_secrets(paths: StatePaths) -> tuple[SecretStatus, ...]:
+    """报告每个 Secret 变量是否已设置且非空，**绝不返回任何值**。
+
+    解析复用 :func:`load_dotenv`，顺带继承它的 0600 私密性与语法校验。除了已知名单，
+    还会列出文件里实际存在的其他变量，好让用户发现自己手工编辑时留下的错别字。
+
+    Args:
+        paths: 已解析的 Lobster0 状态路径。
+
+    Returns:
+        已知名单在前、文件残留名按字典序在后的只含名称与布尔量的状态。
+
+    Raises:
+        DotEnvError: Secret 文件不私密、无法读取或含非法行。
+    """
+    values: dict[str, str] = {}
+    load_dotenv(paths.secrets_file, values)
+    names = list(known_secret_names(paths))
+    for name in sorted(values):
+        if name not in names:
+            names.append(name)
+    return tuple(
+        SecretStatus(name, bool(values.get(name, "").strip())) for name in names
+    )
+
+
+def set_secret_interactively(paths: StatePaths, name: str) -> None:
+    """从控制终端隐藏读取一个已知 Secret，并就地更新 secrets.env。
+
+    与 fresh-only 的 :func:`run_interactive_setup` 不同，这条路径面对的是用户正在使用
+    的实例：只替换目标变量那一行，其余状态一律不动，因此改一个 Key 不再需要
+    ``rm -rf`` 整个状态根。
+
+    值只经 ``/dev/tty`` 的 getpass 读取，永远不来自 argv、环境或管道；连问两遍并要求
+    一致，避免把打错的值落盘。
+
+    Args:
+        paths: 已解析的 Lobster0 状态路径。
+        name: 目标变量名，必须属于 :func:`known_secret_names`。
+
+    Raises:
+        SetupError: 变量名不在已知名单、stdin 不是终端、控制终端不可用、
+            两次输入不一致，或值无法被受限 dotenv 无损表达。
+        OSError: Secret 文件的原子写入失败。
+    """
+    allowed = known_secret_names(paths)
+    if name not in allowed:
+        raise SetupError(
+            "unknown secret name; expected one of: " + ", ".join(allowed)
+        )
+    # getpass 在 /dev/tty 不可用时会退化成"回显着从 stdin 读"。先卡住非 TTY stdin，
+    # 就不存在那条把 Secret 明文打进终端或从管道静默吃进来的退化路径。
+    if not sys.stdin.isatty():
+        raise SetupError(
+            "setting a secret requires an interactive terminal; "
+            "Lobster0 never reads a secret from a pipe or from the command line"
+        )
+    try:
+        with _open_tty() as tty:
+            value = getpass.getpass(f"New value for {name}: ", stream=tty)
+            confirmation = getpass.getpass(f"Confirm {name}: ", stream=tty)
+    except (EOFError, StopIteration) as error:
+        raise SetupError("secret input ended unexpectedly") from error
+    if value != confirmation:
+        raise SetupError("the two entries did not match; nothing was written")
+    update_secret(paths, name, value)
 
 
 def _write_private_text(path: Path, text: str) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,8 @@ import argparse
 import contextlib
 import io
 import json
+import os
+import stat
 import sys
 import tempfile
 import unittest
@@ -678,6 +680,175 @@ class CliTest(unittest.TestCase):
             exit_code, _, _ = run_cli(["web", "--home", directory])
 
         self.assertEqual(exit_code, 0)
+
+
+class _TerminalStdin(io.StringIO):
+    """isatty 恒为真的 stdin 替身；本身不提供任何 Secret 输入。"""
+
+    def isatty(self) -> bool:
+        """声明当前进程连着交互终端。"""
+        return True
+
+
+class _RecordingTty:
+    """记录全部终端回显的最小双工 TTY fake。"""
+
+    def __init__(self) -> None:
+        """准备一个空的回显缓冲。"""
+        self.output = io.StringIO()
+
+    def __enter__(self) -> "_RecordingTty":
+        """把 fake 作为 context manager 返回。"""
+        return self
+
+    def __exit__(self, *arguments: object) -> None:
+        """保持缓冲可读，不吞掉异常。"""
+
+    def write(self, value: str) -> int:
+        """记录不含 Secret 的提示文本。"""
+        return self.output.write(value)
+
+    def flush(self) -> None:
+        """匹配真实 TTY 的 flush 接口。"""
+
+
+class SecretCommandTest(unittest.TestCase):
+    """`lobster0 secret` 必须能在不销毁状态的前提下更新存量实例的密钥。"""
+
+    def setUp(self) -> None:
+        """准备一个已经配置好、带真实状态的存量实例。"""
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.home = Path(self.temporary_directory.name) / "state"
+        self.paths = build_state_paths(self.home)
+        write_fresh_setup(
+            self.paths,
+            SetupAnswers(True, "ou_owner", False, None, False, None),
+            {
+                "LOBSTER0_MODEL_API_KEY": "old-model-key",
+                "LOBSTER0_FEISHU_APP_ID": "cli_app",
+                "LOBSTER0_FEISHU_APP_SECRET": "old-app-secret",
+            },
+            sandbox_image="ghcr.io/nedonion/lobster0-sandbox@sha256:" + "a" * 64,
+        )
+
+    def _run_secret_set(self, name: str, values: list[str]) -> tuple[int, str, str]:
+        """在受控终端上执行一次 `secret set`。"""
+        with (
+            mock.patch("sys.stdin", new=_TerminalStdin()),
+            mock.patch("lobster0.setup._open_tty", return_value=_RecordingTty()),
+            mock.patch("lobster0.setup.getpass.getpass", side_effect=values),
+        ):
+            return run_cli(["secret", "--home", str(self.home), "set", name])
+
+    def test_updates_a_configured_install_without_destroying_state(self) -> None:
+        """存量实例改一个密钥，不需要 rm -rf，其余状态与其他密钥全部保留。"""
+        config_before = self.paths.config.read_bytes()
+        database_before = self.paths.database.read_bytes()
+
+        exit_code, output, error = self._run_secret_set(
+            "LOBSTER0_FEISHU_APP_SECRET", ["rotated-app-secret", "rotated-app-secret"]
+        )
+
+        self.assertEqual((exit_code, error), (0, ""))
+        self.assertIn("LOBSTER0_FEISHU_APP_SECRET", output)
+        self.assertNotIn("rotated-app-secret", output)
+        self.assertEqual(
+            self.paths.secrets_file.read_text(encoding="utf-8"),
+            "LOBSTER0_MODEL_API_KEY=old-model-key\n"
+            "LOBSTER0_FEISHU_APP_ID=cli_app\n"
+            "LOBSTER0_FEISHU_APP_SECRET=rotated-app-secret\n",
+        )
+        self.assertEqual(stat.S_IMODE(self.paths.secrets_file.stat().st_mode), 0o600)
+        self.assertEqual(self.paths.config.read_bytes(), config_before)
+        self.assertEqual(self.paths.database.read_bytes(), database_before)
+
+    def test_rejects_an_unknown_name_with_a_configuration_exit_code(self) -> None:
+        """打错的变量名必须以退出码 2 拒绝，并提示合法名单。"""
+        original = self.paths.secrets_file.read_text(encoding="utf-8")
+
+        exit_code, output, error = self._run_secret_set(
+            "LOBSTER0_FEISHU_APP_SECRETT", ["never-read", "never-read"]
+        )
+
+        self.assertEqual(exit_code, 2)
+        self.assertIn("LOBSTER0_FEISHU_APP_SECRET", error)
+        self.assertEqual(output, "")
+        self.assertEqual(self.paths.secrets_file.read_text(encoding="utf-8"), original)
+
+    def test_fails_closed_when_stdin_is_not_a_terminal(self) -> None:
+        """stdin 是管道时以退出码 2 失败，绝不从管道读取 Secret。"""
+        original = self.paths.secrets_file.read_text(encoding="utf-8")
+
+        with (
+            mock.patch("sys.stdin", new=io.StringIO("piped-secret\npiped-secret\n")),
+            mock.patch("lobster0.setup.getpass.getpass") as hidden,
+        ):
+            exit_code, output, error = run_cli(
+                ["secret", "--home", str(self.home), "set", "LOBSTER0_MODEL_API_KEY"]
+            )
+
+        self.assertEqual(exit_code, 2)
+        self.assertIn("interactive terminal", error)
+        self.assertEqual((output, hidden.call_count), ("", 0))
+        self.assertEqual(self.paths.secrets_file.read_text(encoding="utf-8"), original)
+
+    def test_list_reports_names_and_state_without_any_value(self) -> None:
+        """列表只回答哪些变量已设置，不得输出任何值。"""
+        exit_code, output, error = run_cli(["secret", "--home", str(self.home), "list"])
+
+        self.assertEqual((exit_code, error), (0, ""))
+        self.assertIn("[SET] LOBSTER0_MODEL_API_KEY", output)
+        self.assertIn("[SET] LOBSTER0_FEISHU_APP_SECRET", output)
+        self.assertIn("[UNSET] LOBSTER0_TELEGRAM_BOT_TOKEN", output)
+        self.assertNotIn("old-model-key", output)
+        self.assertNotIn("old-app-secret", output)
+        self.assertNotIn("cli_app", output)
+
+    def test_secret_command_exposes_no_value_bearing_option(self) -> None:
+        """`secret` 族只接受变量名，任何承载值的 flag 都不得存在。"""
+        parser = build_parser()
+        commands = next(
+            action.choices
+            for action in parser._actions
+            if hasattr(action, "choices") and isinstance(action.choices, dict)
+        )
+        self.assertIn("secret", commands)
+        secret_actions = next(
+            action.choices
+            for action in commands["secret"]._actions
+            if hasattr(action, "choices") and isinstance(action.choices, dict)
+        )
+        options = {
+            option
+            for parsers in (commands["secret"], *secret_actions.values())
+            for action in parsers._actions
+            for option in action.option_strings
+        }
+        self.assertEqual(options, {"-h", "--help", "--home"})
+
+    def test_doctor_reflects_a_secret_updated_through_the_command(self) -> None:
+        """更新后的密钥必须被 doctor 读到：由 FAIL 变 PASS，且不回显值。"""
+        self.paths.secrets_file.write_text(
+            "LOBSTER0_MODEL_API_KEY=old-model-key\nLOBSTER0_FEISHU_APP_ID=cli_app\n",
+            encoding="utf-8",
+        )
+        self.paths.secrets_file.chmod(0o600)
+        secret = "doctor-visible-rotated-secret"
+        environment = {"PATH": os.environ.get("PATH", "")}
+
+        with (
+            mock.patch.dict("lobster0.cli.os.environ", environment, clear=True),
+            mock.patch("lobster0.doctor.importlib.util.find_spec", return_value=object()),
+        ):
+            _, before, _ = run_cli(["doctor", "--home", str(self.home)])
+            self._run_secret_set("LOBSTER0_FEISHU_APP_SECRET", [secret, secret])
+            _, after, _ = run_cli(["doctor", "--home", str(self.home)])
+
+        self.assertIn("[FAIL] feishu_runtime", before)
+        self.assertIn("LOBSTER0_FEISHU_APP_SECRET", before)
+        self.assertIn("[PASS] feishu_runtime", after)
+        self.assertNotIn(secret, before + after)
 
 
 if __name__ == "__main__":

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -17,13 +17,16 @@ from types import TracebackType
 from unittest import mock
 
 from lobster0 import setup as setup_module
-from lobster0.config import load_config
+from lobster0.config import ProviderConfig, load_config, update_providers
 from lobster0.env import load_dotenv
 from lobster0.paths import StatePaths, build_state_paths
 from lobster0.setup import (
     SetupAnswers,
     SetupError,
+    describe_secrets,
+    known_secret_names,
     run_interactive_setup,
+    set_secret_interactively,
     update_secret,
     validate_secret_value,
     write_fresh_setup,
@@ -88,6 +91,14 @@ class _FakeTty:
 
     def flush(self) -> None:
         """匹配真实 TTY 的 flush 接口。"""
+
+
+class _TerminalStdin(io.StringIO):
+    """isatty 恒为真的 stdin 替身；本身不提供任何 Secret 输入。"""
+
+    def isatty(self) -> bool:
+        """声明当前进程连着交互终端。"""
+        return True
 
 
 class SetupTest(unittest.TestCase):
@@ -850,3 +861,185 @@ class UpdateSecretTest(unittest.TestCase):
         ]
         for item in leftovers:
             self.assertNotIn(sentinel, item.read_text(encoding="utf-8", errors="replace"))
+
+
+class SecretMaintenanceTest(unittest.TestCase):
+    """已配置实例更新单个 Secret：只改一行、绝不回显、非 TTY 时 fail closed。"""
+
+    def setUp(self) -> None:
+        """准备一个已经写好 config 与 secrets 的存量实例。"""
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.paths = build_state_paths(Path(self.temporary_directory.name) / "state")
+        self.paths.home.mkdir(mode=0o700, parents=True)
+
+    def _write_secrets(self, text: str) -> None:
+        """预置一个 owner-only 的 secrets 文件。"""
+        self.paths.secrets_file.write_text(text, encoding="utf-8")
+        self.paths.secrets_file.chmod(0o600)
+
+    def _write_config(self, text: str) -> None:
+        """预置一个 owner-only 的配置文件。"""
+        self.paths.config.write_text(text, encoding="utf-8")
+        self.paths.config.chmod(0o600)
+
+    def _set_secret(self, name: str, values: list[str]) -> _FakeTty:
+        """在受控终端上执行一次 secret 写入，返回记录了回显的 TTY。"""
+        tty = _FakeTty([])
+        with (
+            mock.patch("sys.stdin", new=_TerminalStdin()),
+            mock.patch("lobster0.setup._open_tty", return_value=tty),
+            mock.patch("lobster0.setup.getpass.getpass", side_effect=values),
+        ):
+            set_secret_interactively(self.paths, name)
+        return tty
+
+    def test_known_names_cover_the_model_and_every_channel_baseline(self) -> None:
+        """允许写入的名单必须覆盖模型与三个平台的固定变量名。"""
+        names = known_secret_names(self.paths)
+
+        self.assertEqual(
+            names[:5],
+            (
+                "LOBSTER0_MODEL_API_KEY",
+                "LOBSTER0_FEISHU_APP_ID",
+                "LOBSTER0_FEISHU_APP_SECRET",
+                "LOBSTER0_TELEGRAM_BOT_TOKEN",
+                "LOBSTER0_DISCORD_BOT_TOKEN",
+            ),
+        )
+
+    def test_known_names_include_env_vars_the_local_config_actually_reads(self) -> None:
+        """配置里声明的 Provider Key 变量名也必须可写，否则多 Provider 用户改不了。"""
+        write_fresh_setup(
+            self.paths,
+            SetupAnswers.defaults(),
+            {"LOBSTER0_MODEL_API_KEY": "model"},
+            sandbox_image=PINNED_IMAGE,
+        )
+        update_providers(
+            self.paths,
+            providers=(
+                ProviderConfig(id="default"),
+                ProviderConfig(
+                    id="openrouter",
+                    base_url="https://openrouter.ai/api/v1",
+                    api_key_env="LOBSTER0_PROVIDER_OPENROUTER_KEY",
+                ),
+            ),
+            selected="default",
+            model=load_config(self.paths, {}).agent.model,
+        )
+
+        self.assertIn("LOBSTER0_PROVIDER_OPENROUTER_KEY", known_secret_names(self.paths))
+
+    def test_rejects_unknown_names_without_touching_the_file(self) -> None:
+        """打错的变量名必须被拒绝，不能静默写进一个没人读的变量。"""
+        original = "LOBSTER0_MODEL_API_KEY=keep-me\n"
+        self._write_secrets(original)
+
+        for name in ("LOBSTER0_MODEL_API_KEYY", "LOBSTER0_UNKNOWN", "PATH", ""):
+            with self.subTest(name=name), self.assertRaises(SetupError):
+                self._set_secret(name, ["never-read", "never-read"])
+
+        self.assertEqual(self.paths.secrets_file.read_text(encoding="utf-8"), original)
+
+    def test_fails_closed_when_stdin_is_not_a_terminal(self) -> None:
+        """stdin 是管道时必须报错退出，绝不从管道静默读取 Secret。"""
+        original = "LOBSTER0_MODEL_API_KEY=keep-me\n"
+        self._write_secrets(original)
+
+        with (
+            mock.patch("sys.stdin", new=io.StringIO("piped-secret\npiped-secret\n")),
+            mock.patch("lobster0.setup._open_tty") as open_tty,
+            mock.patch("lobster0.setup.getpass.getpass") as hidden,
+            self.assertRaisesRegex(SetupError, "interactive terminal"),
+        ):
+            set_secret_interactively(self.paths, "LOBSTER0_MODEL_API_KEY")
+
+        self.assertEqual(open_tty.call_count, 0)
+        self.assertEqual(hidden.call_count, 0)
+        self.assertEqual(self.paths.secrets_file.read_text(encoding="utf-8"), original)
+
+    def test_updates_one_variable_and_keeps_every_other_byte(self) -> None:
+        """只有目标那一行变化，注释、空行与其他变量逐字节保持原样。"""
+        self._write_secrets(
+            "# model provider\n"
+            "LOBSTER0_MODEL_API_KEY=old-model\n"
+            "\n"
+            "LOBSTER0_FEISHU_APP_ID=cli_app\n"
+            "LOBSTER0_FEISHU_APP_SECRET=feishu-secret\n"
+        )
+
+        self._set_secret("LOBSTER0_MODEL_API_KEY", ["new-model", "new-model"])
+
+        self.assertEqual(
+            self.paths.secrets_file.read_text(encoding="utf-8"),
+            "# model provider\n"
+            "LOBSTER0_MODEL_API_KEY=new-model\n"
+            "\n"
+            "LOBSTER0_FEISHU_APP_ID=cli_app\n"
+            "LOBSTER0_FEISHU_APP_SECRET=feishu-secret\n",
+        )
+        self.assertEqual(stat.S_IMODE(self.paths.secrets_file.stat().st_mode), 0o600)
+
+    def test_reads_the_value_through_getpass_and_never_echoes_it(self) -> None:
+        """值只能经 getpass 隐藏读取，终端回显里不得出现它。"""
+        self._write_secrets("LOBSTER0_MODEL_API_KEY=old\n")
+        sentinel = "sentinel-rotated-key"
+        tty = _FakeTty([])
+
+        with (
+            mock.patch("sys.stdin", new=_TerminalStdin()),
+            mock.patch("lobster0.setup._open_tty", return_value=tty),
+            mock.patch(
+                "lobster0.setup.getpass.getpass", side_effect=[sentinel, sentinel]
+            ) as hidden,
+        ):
+            set_secret_interactively(self.paths, "LOBSTER0_MODEL_API_KEY")
+
+        self.assertEqual(hidden.call_count, 2)
+        for call in hidden.call_args_list:
+            self.assertIs(call.kwargs["stream"], tty)
+            self.assertNotIn(sentinel, call.args[0])
+        self.assertNotIn(sentinel, tty.output.getvalue())
+        self.assertIn(sentinel, self.paths.secrets_file.read_text(encoding="utf-8"))
+
+    def test_rejects_a_mistyped_confirmation_without_touching_the_file(self) -> None:
+        """两次输入不一致时必须放弃写入，避免把打错的值落盘。"""
+        original = "LOBSTER0_MODEL_API_KEY=keep-me\n"
+        self._write_secrets(original)
+
+        with self.assertRaises(SetupError):
+            self._set_secret("LOBSTER0_MODEL_API_KEY", ["typed-one", "typed-two"])
+
+        self.assertEqual(self.paths.secrets_file.read_text(encoding="utf-8"), original)
+
+    def test_describe_reports_names_and_state_but_never_values(self) -> None:
+        """列表只回答"哪些变量已设置且非空"，不携带任何值。"""
+        self._write_secrets(
+            "LOBSTER0_MODEL_API_KEY=sentinel-listed-value\n"
+            "LOBSTER0_FEISHU_APP_ID=\n"
+            "LOBSTER0_MODEL_API_KEYY=sentinel-typo-value\n"
+        )
+
+        described = describe_secrets(self.paths)
+
+        state = {item.name: item.configured for item in described}
+        self.assertTrue(state["LOBSTER0_MODEL_API_KEY"])
+        self.assertFalse(state["LOBSTER0_FEISHU_APP_ID"])
+        self.assertFalse(state["LOBSTER0_TELEGRAM_BOT_TOKEN"])
+        # 手工编辑留下的错别字也要列出来，否则用户永远发现不了它。
+        self.assertTrue(state["LOBSTER0_MODEL_API_KEYY"])
+        rendered = repr(described)
+        self.assertNotIn("sentinel-listed-value", rendered)
+        self.assertNotIn("sentinel-typo-value", rendered)
+
+    def test_describe_reports_every_known_name_when_no_file_exists(self) -> None:
+        """尚未写过 Secret 的实例也要能看清哪些变量还没配。"""
+        described = describe_secrets(self.paths)
+
+        self.assertEqual(
+            tuple(item.name for item in described), known_secret_names(self.paths)
+        )
+        self.assertFalse(any(item.configured for item in described))


### PR DESCRIPTION
## 改一个密钥不再需要删掉全部数据

实机部署时撞到的真实缺陷:`setup` 是 **fresh-install only**(已有 `config.toml` 就报 `setup target already exists`),而**没有任何更新已配置实例的命令**。

所以想改一个打错的 API Key,唯一的路是:

```bash
rm -rf ~/.lobster0 && lobster0 setup
```

这会连带删掉**记忆、对话历史、自动化任务、审批记录、审计轨迹、整个 SQLite 数据库**——为改一个字符串把全部数据清零。用户在部署中确实被迫这么做了。

## 解法

```bash
lobster0 secret --home DIR list      # 只显示名字与是否已设,绝不显示值
lobster0 secret --home DIR set NAME  # 交互式输入,写入前二次确认
```

底层复用**已存在**的 `update_secret()`——它本来就能原地更新单个变量、保留其他内容、原子写入、0600 权限,只是没有 CLI 入口。没有重复实现。

## 密钥绝不经过 argv / 管道 / 环境

`secret set` **没有任何接收值的参数**(测试断言该命令族的完整选项集恰为 `{-h, --help, --home}`)。值只从 TTY 读,回显关闭,连输两次确认。

`sys.stdin.isatty()` 这道闸是**承重的**,不是保险丝:CPython 的 `getpass` 在无法驱动 tty 时会回退到 `fallback_getpass`,而后者**开着回显读 stdin**。先做 isatty 判断才能让那条路不可达。

## 复核实测(逐条验证,非阅读报告)

| 场景 | 结果 |
|---|---|
| `echo "值" \| lobster0 secret set` | **拒绝**,提示"绝不从管道或命令行读取密钥" |
| 拒绝后是否留下文件 | **未创建任何文件** |
| `secret list` 是否泄露值 | **零泄露**,只输出 `[SET]` / `[UNSET]` + 名字 |
| 未知密钥名 | **拒绝**,并回显合法名单 |

## Doctor 联动(实测)

`LOBSTER0_ENV_FILE` 未设(走 `<home>/secrets.env` 回退):

- 改之前:`[FAIL] feishu_runtime: missing environment variable(s): LOBSTER0_FEISHU_APP_SECRET`
- 真 PTY 改之后:`[PASS] feishu_runtime: Feishu credentials are locally ready`

## 未改动的部分

`setup` 的 fresh-only 保护**原样保留**——那道保护正是防止误跑 `setup` 覆盖可用配置的东西。这里是新增一条安全路径,不是放宽旧的。

## 测试

- `SecretMaintenanceTest` 9 例 + `SecretCommandTest` 6 例,含**完整复现 `rm -rf` 场景**:已有 `config.toml` 与数据库的实例更新密钥后,断言两者字节级不变。
- 焦点 125/125;全量对比基线**零新增失败**。

## 已记录但未修的相邻问题

`load_dotenv` 只设置环境中尚不存在的变量。若用户在 shell 或 systemd 单元里 `export` 了同名变量,`secret set` 会更新文件、而 Gateway 仍读旧值,表现为"我改了但没生效"。已写入文档,建议后续由 doctor 增加一条遮蔽检查。
