### PR TITLE
docs(deploy): 补完实机部署踩坑实录,记录全部 7 个坑与最终结果

### DIFF
--- a/docs/getting-started/20260811_实机部署踩坑实录.md
+++ b/docs/getting-started/20260811_实机部署踩坑实录.md
@@ -203,14 +203,172 @@ https://registry.npmmirror.com
 
 ---
 
-## 待补充
+## 坑 4：换了源，`uv sync` 还是慢 —— lock 文件锁死了下载地址
 
-部署仍在进行中，以下环节的实际结果会陆续补入：
+### 现象
 
-- `uv sync --all-extras` 的实际耗时与结果
-- `lobster0 init` 与 `doctor` 在这台机器上的输出
-- 飞书应用配置与长连接实测
+已经把 `UV_DEFAULT_INDEX` 指到清华源，`uv sync --all-extras` 仍然极慢，
+最终耗时 **25 分 11 秒**，卡在 `python-telegram-bot`、`ruff` 等几个包上。
+
+### 原因
+
+`uv.lock` 里为每个包记录了**精确的下载 URL**（本仓库共 679 处 `files.pythonhosted.org`）。
+`uv sync` 走的是 lock 文件里的地址以保证可复现，**不经过 `UV_DEFAULT_INDEX`**。
+也就是说换源对这一步根本没生效。
+
+### 结论
+
+这是可复现构建的正常代价，不是配置错误。可选做法：
+
+- **直接等**（推荐）。中途 Ctrl+C 会前功尽弃，重来更慢。
+- 若确实无法忍受，可用 `--no-sources` 强制重新解析依赖而非照搬 lock——
+  但这会失去 lock 文件的可复现保证，不建议常规使用。
+
+`ruff` 是开发期工具（10.94 MiB 二进制），运行时并不需要。
+只用飞书的话，装 `[feishu]` 而非 `--all-extras` 可以少装两个渠道 SDK。
+
+---
+
+## 坑 5：`setup` 拒绝覆盖已有配置
+
+### 现象
+
+```console
+$ lobster0 setup
+...
+error: setup target already exists: /home/ubuntu/.lobster0/config.toml
+```
+
+### 原因
+
+`setup` 是 **fresh-install only**：它的职责是初始化一个全新状态目录，
+因此发现 `config.toml` 已存在就拒绝，避免误覆盖正在使用的配置。
+
+### 当时的解法与代价
+
+```bash
+rm -rf ~/.lobster0 && lobster0 setup
+```
+
+**这是有代价的**：`~/.lobster0` 里还有数据库、记忆、对话历史、自动化任务与审批记录，
+删掉等于全部清零。部署初期目录里没什么东西，代价可以接受；
+**已经在用一段时间之后绝不能这么做**。
+
+### 现在的正确做法
+
+已新增专用命令，只改一个密钥而不动其他任何数据：
+
+```bash
+lobster0 secret --home ~/.lobster0 list      # 只显示名字与是否已设，不显示值
+lobster0 secret --home ~/.lobster0 set LOBSTER0_MODEL_API_KEY
+```
+
+值只从终端交互读取，连输两次确认；**绝不接受命令行参数或管道输入**——
+避免密钥进入 shell 历史或 `ps` 输出。
+
+> 该命令在 v0.7.0 预发布包中尚未包含，需要更新到之后的版本。
+> 在此之前可直接编辑 `~/.lobster0/secrets.env`，改完确认权限仍是 0600。
+
+---
+
+## 坑 6：`setup` 写入的密钥，运行时读不到
+
+### 现象
+
+`secrets.env` 里三个值俱全、权限 0600，但：
+
+```console
+$ lobster0 gateway
+error: LOBSTER0_MODEL_API_KEY is not configured
+
+$ lobster0 doctor
+[FAIL] feishu_runtime: missing environment variable(s): LOBSTER0_FEISHU_APP_ID, LOBSTER0_FEISHU_APP_SECRET
+```
+
+### 原因
+
+**这是一个真实的产品缺陷**，不是配置错误：`setup` 把凭据写到
+`<home>/secrets.env`，而运行时默认只加载**当前工作目录**的 `.env`，
+除非用户显式设置 `LOBSTER0_ENV_FILE`。两端约定不一致，配了等于没配。
+
+### 状态
+
+已修复：未显式指定 `LOBSTER0_ENV_FILE` 时，运行时会回退到 `<home>/secrets.env`，
+也就是 `setup` 刚写入的那个文件。测试中有专门的回归断言守着这条路径。
+
+修复前的临时绕过方式（v0.7.0 预发布包仍需要）：
+
+```bash
+echo 'export LOBSTER0_ENV_FILE=/home/ubuntu/.lobster0/secrets.env' >> ~/.bashrc
+source ~/.bashrc
+```
+
+---
+
+## 坑 7：wheel 改名导致安装失败
+
+### 现象
+
+```console
+error: Failed to parse: `lobster0.whl`
+  Caused by: Must have a version
+```
+
+### 原因
+
+`uv` 从 wheel **文件名**中解析包名与版本。
+`lobster0_agent-0.7.0-py3-none-any.whl` 改成 `lobster0.whl` 后就无从得知版本号。
+
+### 解法
+
+下载时保持原文件名：
+
+```bash
+curl -fL -o /tmp/lobster0_agent-0.7.0-py3-none-any.whl \
+  https://gh-proxy.com/https://github.com/NEDONION/lobster0/releases/download/v0.7.0/lobster0_agent-0.7.0-py3-none-any.whl
+uv tool install --python 3.12 "/tmp/lobster0_agent-0.7.0-py3-none-any.whl[feishu]"
+```
+
+---
+
+## 部署完成后：让它常驻
+
+前台运行的 `lobster0 gateway` 会随终端关闭而结束，严格说还不算"部署好"。
+装成系统服务后才具备生产形态：
+
+```bash
+lobster0 service install --home ~/.lobster0
+lobster0 service status --home ~/.lobster0
+lobster0 service logs --home ~/.lobster0
+```
+
+服务单元已内置 `Restart=on-failure` 与 `RestartSec=5`：**崩溃 5 秒后自动重启，开机自启**。
+
+> 装服务前先停掉前台运行的实例，否则两个网关会同时连上同一个飞书应用，
+> 导致一条消息被回复两次。
+
+---
+
+## 部署结果
+
+**已跑通。** 云端龙虾在飞书中正常收发消息，网关日志显示完整链路：
+
+```
+channel.transport.connected      WebSocket 长连接建立
+bot identity resolved            name=Lucas云端🦞
+channel.inbound.accepted         收到消息
+channel.turn.started
+channel.turn.completed           agent_duration_ms=10611
+```
+
+从零到端到端可用共踩 7 个坑，其中**两个是产品真缺陷**（坑 6 的 Secret 路径不一致、
+以及此前修复的 `tzdata` 缺失导致 `init` 必然失败）。二者都只在纯净 Linux 服务器上暴露，
+在维护者的 macOS 上永远看不到——这正是实机部署不可替代的原因。
+
+## 尚未验证
+
 - Web 控制台的首次实机启动（其 JS 侧**从未被验证过**，预计会有问题）
+- `install.sh` 一行安装（发布流水线的 `assemble` 阶段尚未跑通）
 
 ---
 
@@ -226,6 +384,10 @@ https://registry.npmmirror.com
 | `pnpm install` 极慢 | 默认走 npm 官方 registry | `npm config set registry https://registry.npmmirror.com` |
 | `heartbeat.timezone must be a valid IANA timezone` | uv 的 Python 不带时区数据库 | 已修复（补 `tzdata` 依赖），拉最新代码即可 |
 | `This project is configured to use 10.14.0 of pnpm` | Node 24 的 corepack 拉起 pnpm 11 | 先 `corepack prepare pnpm@10.14.0 --activate` |
+| `uv sync` 换了源仍然极慢 | `uv.lock` 锁死了 679 个下载地址，不走自定义索引 | 直接等；这是可复现构建的代价 |
+| `setup target already exists` | `setup` 是 fresh-install only | 用 `lobster0 secret set` 改单个密钥，别 `rm -rf` |
+| 配了密钥却报 `is not configured` | 产品缺陷：写 `<home>/secrets.env`、读 `cwd/.env` | 已修复；旧版本设 `LOBSTER0_ENV_FILE` 绕过 |
+| `Must have a version` | wheel 被改名，uv 无法解析版本 | 保持原文件名 |
 
 ## 给国内部署者的一句话总结
 


### PR DESCRIPTION
## 实机部署已跑通,补完全部记录

云端龙虾在飞书中正常收发消息,网关日志显示完整链路打通。文档从「进行中」改为记录最终结果,并补入此前缺失的**坑 4-7**。

## 新增的四个坑

**坑 4:换了源 `uv sync` 仍慢 25 分钟**

根因是 `uv.lock` 里锁死了 **679 个** `files.pythonhosted.org` 下载地址,`uv sync` 走 lock 里的地址以保证可复现,**不经过 `UV_DEFAULT_INDEX`**。明确写出这是可复现构建的正常代价、不是配置错误,并提醒中途 Ctrl+C 反而更慢。

**坑 5:`setup` 拒绝覆盖已有配置**

当时用 `rm -rf ~/.lobster0` 绕过。文档**明确写出这个做法的代价**——会连带删除数据库、记忆、对话历史与审批记录,部署初期尚可接受,用了一段时间之后绝不能这么做。同时给出现在的正确做法 `lobster0 secret set`,并注明该命令**尚未进入 v0.7.0 预发布包**,旧版本仍需手工编辑文件。

**坑 6:`setup` 写入的密钥运行时读不到**

标注为**产品真缺陷**而非配置错误,附已修复状态与旧版本的绕过方式。

**坑 7:wheel 改名导致 `Must have a version`**

## 另补「部署完成后让它常驻」

前台 `gateway` 随终端关闭而结束,严格说不算部署好。给出 `service install` 并提醒:**装服务前必须先停掉前台实例**,否则两个网关同时连上同一飞书应用,一条消息会被回复两次。

## 结论部分如实标注

- 共 7 个坑,其中**两个是产品真缺陷**(Secret 路径不一致、`tzdata` 缺失),二者**都只在纯净 Linux 服务器上暴露,macOS 永远看不到**
- **尚未验证**:Web 控制台首次实机启动(JS 侧从未验证过)、`install.sh` 一行安装(流水线 `assemble` 未跑通)

速查表扩充到 9 条。`validate_docs.py` PASS,`tests.test_documentation` 9/9 PASS。
