### PR TITLE
docs(deploy): 记录坑 8、9 并修正常驻小节写错的命令

### DIFF
--- a/docs/getting-started/20260811_实机部署踩坑实录.md
+++ b/docs/getting-started/20260811_实机部署踩坑实录.md
@@ -331,21 +331,89 @@ uv tool install --python 3.12 "/tmp/lobster0_agent-0.7.0-py3-none-any.whl[feishu
 
 ---
 
+## 坑 8：`--home` 的位置
+
+`--home` 是**全局参数**，必须放在子命令**前面**：
+
+```bash
+lobster0 --home ~/.lobster0 service install     # 正确
+lobster0 service install --home ~/.lobster0     # 报 unrecognized arguments
+```
+
+从 `usage` 行可以看出层级：`lobster0 [-h] [--version] [--home HOME] {init,setup,...}`。
+
+---
+
+## 坑 9：包安装的用户用不了 `service install`
+
+### 现象
+
+```console
+$ lobster0 --home ~/.lobster0 service install
+error: service_repository_dirty
+```
+
+### 原因
+
+**这是产品缺陷。** `lobster0 service` 是 Phase 6 时期为「macOS + 源码开发」写的：
+`_resolve_repository_commit` 会执行 `git rev-parse HEAD` 与 `git status --porcelain`，
+要求当前目录是一个**干净的 git 仓库**，以便把服务绑定到精确 commit。
+
+而 wheel 安装的机器上**根本没有仓库**，这个检查因此永远无法通过——
+也就是说，**按 README 推荐方式安装的用户，反而用不了服务安装**。
+
+同一份代码里还并存着另一套实现：`src/lobster0/install/service.py`
+（安装器 Task 10 交付）已经包含完整、经测试的 systemd user + LaunchAgent 生命周期，
+带 `Restart=on-failure` / `RestartSec=5`。CLI 只是接错了那一套。
+
+### 状态
+
+修复进行中：让 `service install` 区分「包安装」与「源码运行」两种形态，
+包安装复用已有的 systemd 实现，源码运行保留 git 溯源校验
+（该保证在开发场景下有意义，应当划清适用范围而非删除）。
+
+### 修复前的临时做法
+
+如果需要在修复落地前就让网关常驻，可以手写一个 systemd 单元：
+
+```bash
+sudo tee /etc/systemd/system/lobster0.service > /dev/null <<'UNIT'
+[Unit]
+Description=Lobster0 Gateway
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=ubuntu
+Environment=HOME=/home/ubuntu
+Environment=PATH=/home/ubuntu/.local/bin:/opt/node/bin:/usr/local/bin:/usr/bin:/bin
+ExecStart=/home/ubuntu/.local/bin/lobster0 --home /home/ubuntu/.lobster0 gateway
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+sudo systemctl daemon-reload && sudo systemctl enable --now lobster0
+```
+
+这是绕过手段而非推荐做法，修复落地后应改用 `service install`。
+
+---
+
 ## 部署完成后：让它常驻
 
 前台运行的 `lobster0 gateway` 会随终端关闭而结束，严格说还不算"部署好"。
-装成系统服务后才具备生产形态：
+装成系统服务后才具备生产形态——崩溃 5 秒后自动重启、开机自启。
 
-```bash
-lobster0 service install --home ~/.lobster0
-lobster0 service status --home ~/.lobster0
-lobster0 service logs --home ~/.lobster0
-```
-
-服务单元已内置 `Restart=on-failure` 与 `RestartSec=5`：**崩溃 5 秒后自动重启，开机自启**。
-
-> 装服务前先停掉前台运行的实例，否则两个网关会同时连上同一个飞书应用，
-> 导致一条消息被回复两次。
+> **装服务前先停掉前台运行的实例**，否则两个网关会同时连上同一个飞书应用，
+> 导致一条消息被回复两次。找不到那个终端时可以直接结束进程：
+>
+> ```bash
+> pkill -f "lobster0.*gateway"
+> ps aux | grep lobster0 | grep -v grep    # 无输出即已停干净
+> ```
 
 ---
 
@@ -388,6 +456,8 @@ channel.turn.completed           agent_duration_ms=10611
 | `setup target already exists` | `setup` 是 fresh-install only | 用 `lobster0 secret set` 改单个密钥，别 `rm -rf` |
 | 配了密钥却报 `is not configured` | 产品缺陷：写 `<home>/secrets.env`、读 `cwd/.env` | 已修复；旧版本设 `LOBSTER0_ENV_FILE` 绕过 |
 | `Must have a version` | wheel 被改名，uv 无法解析版本 | 保持原文件名 |
+| `unrecognized arguments: --home` | `--home` 是全局参数 | 放到子命令**前面** |
+| `service_repository_dirty` | 产品缺陷：`service install` 要求干净 git 仓库，包安装没有 | 修复中；临时可手写 systemd 单元 |
 
 ## 给国内部署者的一句话总结
 


### PR DESCRIPTION
## 记录两个新发现的坑,并修正文档里写错的命令

### 坑 8:`--home` 位置写反了

文档此前给的是 `lobster0 service install --home ...`,会报 `unrecognized arguments`。`--home` 是**全局参数**,必须放在子命令**前面**。已修正。

### 坑 9:包安装的用户用不了 `service install`

```console
$ lobster0 --home ~/.lobster0 service install
error: service_repository_dirty
```

**这是产品缺陷,不是误操作。** `_resolve_repository_commit` 执行 `git rev-parse HEAD` 与 `git status --porcelain`,要求当前目录是**干净的 git 仓库**以绑定精确 commit。而 wheel 安装的机器上**根本没有仓库**,检查永远无法通过。

矛盾点在于:**README 首屏主推的就是 wheel 安装**,按推荐方式装的用户反而用不了服务安装。

文档同时记录了一个关键事实:`src/lobster0/install/service.py` 里**已有完整、经测试的 systemd user + LaunchAgent 生命周期**(安装器 Task 10 交付,含 `Restart=on-failure` / `RestartSec=5`),CLI 只是接错了实现——**两套并存**。

修复方向已写明:区分「包安装」与「源码运行」,前者复用已有实现,后者**保留** git 溯源校验(该保证在开发场景下有意义,应划清适用范围而非删除)。

附了修复落地前的临时 systemd 单元,并**明确标注这是绕过手段、不是推荐做法**。

### 常驻小节补充

用户实际遇到「找不到跑着网关的那个终端」,补上 `pkill -f "lobster0.*gateway"` 与确认命令。

速查表扩充到 11 条。`validate_docs.py` PASS,`tests.test_documentation` 9/9 PASS。
