### PR TITLE
docs(readme): 理顺安装路径，中英文都给出一条能跑通的命令

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,10 +136,21 @@ GitHub 远端请求走本机 `gh`，本地仓库请求走 `git`；凭据不会�
 
 ## 快速开始
 
-### 现在可用：源码安装
+### 安装
+
+安装命令见文首的[安装](#安装)一节（含中国大陆镜像源版本），这里不重复。
+
+安装后 `lobster0` 是全局命令，接着执行 `lobster0 setup` 配置、`lobster0 gateway` 启动。
+完整的服务器部署流程见 [Linux 服务器部署指南](docs/getting-started/20260811_Linux服务器部署指南.md)，
+国内网络的坑见[实机部署踩坑实录](docs/getting-started/20260811_实机部署踩坑实录.md)。
+
+### 从源码运行（开发与贡献）
+
+只想把它跑起来用的话，直接看上面的[安装](#安装)——一条命令即可，不需要 Node.js 和 pnpm。
+这一节是给要改代码、跑测试的人用的。
 
 需要 Python 3.12+、[uv](https://docs.astral.sh/uv/)、Node.js
-`22.22.3 <= version < 23` 或 `24.15.0 <= version < 25`，以及 pnpm。
+`22.22.3 <= version < 23` 或 `24.15.0 <= version < 25`，以及 pnpm（因为要自己构建 TUI）。
 
 ```bash
 git clone https://github.com/NEDONION/lobster0.git
@@ -203,33 +214,6 @@ uv run lobster0 gateway
 
 Owner、allowlist、平台凭据和真实验收步骤见[本地运行指南](docs/getting-started/20260807_本地运行指南.md)。
 
-### 安装
-
-`v0.7.0` 已作为**预发布**发出，wheel 可以直接匿名下载安装：
-
-```bash
-curl -fL --proto '=https' --tlsv1.2 \
-  -o /tmp/lobster0_agent-0.7.0-py3-none-any.whl \
-  https://github.com/NEDONION/lobster0/releases/download/v0.7.0/lobster0_agent-0.7.0-py3-none-any.whl \
-  && uv tool install --python 3.12 "/tmp/lobster0_agent-0.7.0-py3-none-any.whl[feishu]"
-```
-
-中国大陆的机器建议加镜像与国内源，否则下载会很慢甚至中断：
-
-```bash
-curl -fL --proto '=https' --tlsv1.2 \
-  -o /tmp/lobster0_agent-0.7.0-py3-none-any.whl \
-  https://gh-proxy.com/https://github.com/NEDONION/lobster0/releases/download/v0.7.0/lobster0_agent-0.7.0-py3-none-any.whl \
-  && UV_DEFAULT_INDEX=https://pypi.tuna.tsinghua.edu.cn/simple \
-     uv tool install --python 3.12 "/tmp/lobster0_agent-0.7.0-py3-none-any.whl[feishu]"
-```
-
-> 文件名必须保持原样——`uv` 要从中读取版本号，改名会报 `Must have a version`。
-
-安装后 `lobster0` 是全局命令，接着执行 `lobster0 setup` 配置、`lobster0 gateway` 启动。
-完整的服务器部署流程见 [Linux 服务器部署指南](docs/getting-started/20260811_Linux服务器部署指南.md)，
-国内网络的坑见[实机部署踩坑实录](docs/getting-started/20260811_实机部署踩坑实录.md)。
-
 ### 一行安装（尚不可用）
 
 ```bash
@@ -238,8 +222,11 @@ curl -fsSL --proto '=https' --tlsv1.2 \
 ```
 
 > [!WARNING]
-> **这个 URL 目前仍返回 404。** `install.sh` 由发布流水线的 `assemble` 阶段生成，
-> 而该阶段目前尚未跑通，因此 Release 里还没有这个文件。请先用上面的 wheel 安装方式。
+> **这个 URL 目前仍返回 404，而且有两个独立的原因。** 其一，`install.sh` 由发布流水线的
+> `assemble` 阶段生成，该阶段尚未跑通，Release 里还没有这个文件。其二，`releases/latest/`
+> 只解析到**正式版**，而 `v0.7.0` 被标记为预发布，所以本仓库当前根本没有 latest release——
+> 即使 `install.sh` 生成出来，在发出第一个正式版之前这条 URL 依然会 404。
+> 请先用上面的 wheel 安装方式。
 >
 > `v0.7.0` 是**预发布**：真机安装矩阵（Tier 1）、包发布到 PyPI、镜像摘要 smoke 与
 > attestation 均**未执行**，状态为 **PUBLIC GATES PENDING**。它可以用来自己部署，

--- a/README_EN.md
+++ b/README_EN.md
@@ -8,7 +8,7 @@
 
 [![Python 3.12+](https://img.shields.io/badge/Python-3.12%2B-3776AB?logo=python&logoColor=white)](pyproject.toml)
 [![Node.js 22.22.3–<23 or 24.15.0–<25](https://img.shields.io/badge/Node.js-22.22.3--%3C23%20%7C%2024.15.0--%3C25-339933?logo=nodedotjs&logoColor=white)](tui/package.json)
-[![Version](https://img.shields.io/badge/package-v0.1.0-8B5CF6)](pyproject.toml)
+[![Version](https://img.shields.io/badge/package-v0.7.0-8B5CF6)](pyproject.toml)
 [![Phase 6.5](https://img.shields.io/badge/Phase%206.5-IMPLEMENTATION%20PASS-16A34A)](docs/progress/index.html)
 [![License MIT](https://img.shields.io/badge/License-MIT-0F172A)](LICENSE)
 
@@ -64,20 +64,53 @@ New installations and older configurations without `tools.mode` default to `auto
 
 ## Quick start
 
-### One-line install
+### Install
+
+`v0.7.0` is out as a **prerelease** and its wheel can be installed directly. All you need is
+[uv](https://docs.astral.sh/uv/) — no preinstalled Node.js or pnpm:
+
+```bash
+W=lobster0_agent-0.7.0-py3-none-any.whl
+curl -fL --proto '=https' --tlsv1.2 -o /tmp/${W} \
+  https://github.com/NEDONION/lobster0/releases/download/v0.7.0/${W} \
+  && uv tool install --python 3.12 "/tmp/${W}[feishu]"
+```
+
+> Keep the filename exactly as published — `uv` reads the version out of it and fails with
+> `Must have a version` when it is renamed. The braces in `${W}` matter too: a bare `$W[feishu]`
+> is array subscripting in zsh, the default shell on macOS.
+
+`lobster0` is then a global command:
+
+```bash
+lobster0 --version
+lobster0 setup         # prompts for the model API key, Feishu app credentials, and owner
+lobster0 gateway       # starts the Feishu gateway over WebSocket — no public port needed
+```
+
+`lobster0 setup` is interactive, so run it separately rather than pasting it with the installer.
+Use `lobster0 secret set LOBSTER0_MODEL_API_KEY` to fix or rotate one credential — do **not**
+`rm -rf ~/.lobster0`, which would delete memory, history, scheduled tasks and audit records too.
+
+`v0.7.0` is **RELEASE CANDIDATE / PUBLIC GATES PENDING**: the Tier 1 real-machine matrix, the PyPI
+publish and the image digest smokes have not been executed, so it is usable for self-hosting but is
+not a fully verified stable build.
+
+### One-line install (not available yet)
 
 ```bash
 curl -fsSL --proto '=https' --tlsv1.2 \
   https://github.com/NEDONION/lobster0/releases/latest/download/install.sh | bash
 ```
 
-> [!IMPORTANT]
-> This command describes the behaviour **after** the v0.7.0 Release is published. This repository
-> has no Release and no tag yet, so the URL currently returns 404. The one-line install path is
-> **RELEASE CANDIDATE / PUBLIC GATES PENDING**: the real-machine install matrix, the package
-> publish and the image digest smokes have never been executed. Per-item evidence lives in the
+> [!WARNING]
+> **This URL returns 404 today, for two independent reasons.** First, `install.sh` is produced by the
+> release pipeline's `assemble` stage, which does not pass yet, so no Release carries the file.
+> Second, `releases/latest/` only resolves to a **stable** release, and `v0.7.0` is marked as a
+> prerelease — so this repository has no latest release at all, and the URL would keep returning 404
+> even once `install.sh` exists, until a stable version ships. Use the wheel install above for now.
+> Per-item evidence lives in the
 > [v0.7.0 one-line install candidate record](docs/evals/releases/v0.7.0-install.md).
-> Until then, use the [source development install](#source-development-install) below.
 
 The installer ships its own pinned uv, managed Python 3.12, managed Node.js and platform pi-tui
 bundle, so **no preinstalled Python, Node.js or pnpm is required**. It installs into `~/.lobster0`


### PR DESCRIPTION
## 起因

官网这轮主推「一条命令安装并启动」时对照 README，发现 README 自身的安装路径前后矛盾，英文版更是完全没有可用的安装方式。

## 中文 README

- **同一条命令存了 4 份**：「快速开始」里的 `### 安装` 和文首的 `## 安装` 完全重复（含中国大陆镜像版各两份）。命令里带版本号，多份副本意味着发版时漏改就静默变成坏链接。改成交叉引用，副本 4 → 2。
- **`### 现在可用：源码安装` 与文首矛盾**：文首已经主推 wheel 一条命令，这里却把源码路径说成当前唯一可用的方式。改名为 `### 从源码运行（开发与贡献）`，并说明只想用的话看文首即可，不需要 Node.js 和 pnpm。
- 把精简后的 `### 安装` 提到「快速开始」开头，贡献者路径不再排在头条。

## 英文 README（问题更严重）

- **Quick start 的头条是返回 404 的 `install.sh | bash`**，而全文 `uv tool install` 出现 **0 次** —— 英文读者拿不到任何一条能跑通的安装路径。补上 `### Install` 一节。
- **一句已经过时的断言**：「This repository has no Release and no tag yet」——`v0.7.0` 已经以预发布形式发出了。
- **版本徽章还停在 `v0.1.0`**，中文版和 `src/lobster0/_version.py` 都是 `0.7.0`。

## 两边都补上的一点

`install.sh` 404 其实有**两个独立原因**，原文只写了一个：

1. `install.sh` 由发布流水线的 `assemble` 阶段生成，该阶段尚未跑通；
2. `releases/latest/` 只解析到**正式版**，而 `v0.7.0` 标记为预发布 —— 所以本仓库当前根本没有 latest release。**即使 `install.sh` 生成出来，在发出第一个正式版之前那条 URL 依然会 404。**

## 验证

- 实测英文版新增的那条命令：下载到 752KB 真 wheel，包名 `lobster0-agent`、版本 `0.7.0`、`feishu` extra 存在、`Requires-Python: >=3.12` 与 `--python 3.12` 对得上
- 两个 README 的内部锚点无失效、引用的本地文件均存在
- 版本号与 `src/lobster0/_version.py` 一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)