### PR TITLE
docs(website): 官网文档与 README 对齐，并把「反引号里的 JSX」变成机械检查

### DIFF
--- a/docs/superpowers/plans/2026-08-10-lobster0-website-polish-round2.md
+++ b/docs/superpowers/plans/2026-08-10-lobster0-website-polish-round2.md
@@ -550,3 +550,37 @@ Round 13 把安装命令铺开到官网和中英文档之后，`0.7.0` 在 3 个
 ### 验证
 
 `tsc` / `eslint` / `vitest` 33（+2）/ `build` / `playwright` 11 passed 全绿；截图确认两种代码块高亮一致。
+
+---
+
+## Round 15 — 官网文档与 README 对齐，并把「反引号里的 JSX」变成机械检查（2026-08-12）
+
+### 起因
+
+刚在 README 里查清 `install.sh` 404 有**两个**独立原因，而官网文档只写了一个（`assemble` 阶段未跑通），
+漏了更关键的那个：`releases/latest/` 只解析到**正式版**，`v0.7.0` 标记为预发布，所以仓库当前根本没有
+latest release——即使 `install.sh` 生成出来，在发出第一个正式版之前那条 URL 依然会 404。中英文档都补齐。
+
+### 又踩了同一个坑（第二次）
+
+改中文文档时又写成了 `` `v<ReleaseVersion />` ``。**MDX 的行内代码是字面量**，反引号里的 JSX 不会求值，
+页面上原样渲染出 `v<ReleaseVersion />`。Round 14 刚记过这个坑，靠肉眼又漏了一次。
+
+所以这次不只是改回 `<code>`，而是加了机械守卫：扫描所有 MDX 的行内代码片段，一旦里面出现
+`<大写开头的标签` 就失败。已验证会失败——临时把 `<code>` 改回反引号，测试立刻红并打印出
+`getting-started.mdx: \`v<ReleaseVersion />\``，然后还原。
+
+**教训**：同一个坑踩第二次，说明它不该靠记忆防守。判断标准是「这个错误能不能被机械检查出来」，
+能的话就该写成测试，而不是写进文档提醒自己。
+
+### 顺带排查（无问题）
+
+Playwright 日志里出现 `Encountered a script tag while rendering React component`。查了：自己的组件里
+没有 `<script>`，两处 `dangerouslySetInnerHTML` 注入的 SVG 里也没有；生产构建和 dev 模式下、
+含 reduced-motion 与逐个点 tab 的交互路径都复现不出来。结论是 Next 开发工具覆盖层自身的产物，
+不是本项目代码的问题，未做改动。
+
+### 验证
+
+`tsc` / `eslint` / `vitest` 34（+1）/ `build` / `playwright` 11 passed 1 skipped 全绿；
+浏览器实测两个语言的文档页均无组件泄漏成字面量。

--- a/website/content/docs/getting-started.en.mdx
+++ b/website/content/docs/getting-started.en.mdx
@@ -37,8 +37,11 @@ To fix or rotate a single credential, use `lobster0 secret set LOBSTER0_MODEL_AP
 green `doctor`, so it is usable for self-hosting — but the Tier 1 hardware matrix, the PyPI release,
 and image attestation have not run, so treat it as unverified for production.
 
-A one-line `install.sh` is not published yet: the release pipeline's `assemble` stage does not pass,
-so use the wheel above for now.
+A one-line `install.sh` is not available yet, for two independent reasons. First, `install.sh` is
+produced by the release pipeline's `assemble` stage, which does not pass. Second, `releases/latest/`
+only resolves to a **stable** release, and <code>v<ReleaseVersion /></code> is marked as a prerelease,
+so this repository has no latest release at all — the URL would keep returning 404 even once
+`install.sh` exists, until a stable version ships. Use the wheel install above for now.
 
 ## Run from source
 

--- a/website/content/docs/getting-started.mdx
+++ b/website/content/docs/getting-started.mdx
@@ -37,8 +37,10 @@ lobster0 gateway       # 启动飞书网关（WebSocket 长连接，不需要公
 <code>v<ReleaseVersion /></code> 是**预发布**。它已经在纯净的 Ubuntu 24.04 实机上验证到 `doctor` 全绿，可以用来自己部署，
 但 Tier 1 真机矩阵、PyPI 发布与镜像 attestation 都还没跑，不应当作完整验证过的稳定版。
 
-`install.sh` 形式的一行安装尚未产出（发布流水线的 `assemble` 阶段还没跑通），所以目前请用上面的
-wheel 安装方式。
+`install.sh` 形式的一行安装尚未可用，有两个独立的原因：一是 `install.sh` 由发布流水线的 `assemble`
+阶段生成，该阶段还没跑通；二是 `releases/latest/` 只解析到**正式版**，而 <code>v<ReleaseVersion /></code> 标记为
+预发布，所以仓库当前根本没有 latest release —— 即使 `install.sh` 生成出来，在发出第一个正式版之前
+那条 URL 依然会 404。目前请用上面的 wheel 安装方式。
 
 ## 从源码运行
 

--- a/website/src/content/docs-version.test.ts
+++ b/website/src/content/docs-version.test.ts
@@ -27,6 +27,19 @@ describe('docs never hardcode the release artifacts', () => {
     expect(offenders).toEqual([]);
   });
 
+  // MDX inline code spans are literal, so a component written inside backticks
+  // ships the tag text to readers instead of rendering. Caught twice by eye now;
+  // this makes it mechanical.
+  it('never puts a component inside an inline code span', () => {
+    const offenders: string[] = [];
+    for (const { name, text } of mdxFiles()) {
+      for (const [span] of text.matchAll(/`[^`\n]*`/g)) {
+        if (/<[A-Z][A-Za-z]*\b/.test(span)) offenders.push(`${name}: ${span}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
   it('builds the install command from the single release version', () => {
     expect(siteFacts.install).toContain(`lobster0_agent-${siteFacts.version}-py3-none-any.whl`);
     expect(siteFacts.install).toContain(`releases/download/v${siteFacts.version}/`);


### PR DESCRIPTION
## 对齐 README

[#43](https://github.com/NEDONION/lobster0/pull/43) 里查清 `install.sh` 404 有**两个**独立原因，而官网文档只写了一个（`assemble` 阶段未跑通），漏掉了更关键的那个：

> `releases/latest/` 只解析到**正式版**，而 `v0.7.0` 标记为预发布，所以仓库当前根本没有 latest release —— **即使 `install.sh` 生成出来，在发出第一个正式版之前那条 URL 依然会 404。**

中英文档都补齐。

## 同一个坑踩了第二次，所以写成了测试

改的过程中又把组件写进了反引号：`` `v<ReleaseVersion />` ``。**MDX 的行内代码是字面量**，里面的 JSX 不会求值，页面上原样渲染出标签文本。上一轮刚记录过这个坑，靠肉眼又漏了一次。

判断标准是「这个错误能不能被机械检查出来」——能，所以不该再靠记忆防守。新增守卫：扫描所有 MDX 的行内代码片段，一旦出现 `<大写开头的标签` 即失败。

已验证会失败：临时把 `<code>` 改回反引号，测试立刻红并打印

```
getting-started.mdx: `v<ReleaseVersion />`
```

## 顺带排查（结论是无需改动）

Playwright 日志里的 `Encountered a script tag while rendering React component`：自己的组件里没有 `<script>`，两处 `dangerouslySetInnerHTML` 注入的 SVG 里也没有；生产构建和 dev 模式下、含 reduced-motion 与逐个点 tab 的交互路径都复现不出来。判定为 Next 开发工具覆盖层自身的产物。

## 验证

`tsc` / `eslint` / `vitest` 34 / `build` / `playwright` 11 passed 1 skipped 全绿；浏览器实测中英文档页均无组件泄漏成字面量。

🤖 Generated with [Claude Code](https://claude.com/claude-code)