### PR TITLE
docs(deploy): 记录坑 11(云主机无 systemd 用户会话),部署全流程跑通

### DIFF
--- a/docs/getting-started/20260811_实机部署踩坑实录.md
+++ b/docs/getting-started/20260811_实机部署踩坑实录.md
@@ -449,9 +449,86 @@ Failed to prepare filename /tmp/lobster0-gateway.service.999.tmp: Invalid argume
 
 ---
 
+## 坑 11：云主机上没有 systemd 用户会话（最后一道关卡）
+
+### 现象
+
+前面所有问题都解决之后，`service install` 仍然失败，而且错误信息毫无用处：
+
+```console
+$ lobster0 --home ~/.lobster0 service install
+error: service_install_failed
+```
+
+### 定位
+
+关键是去问 systemd 本身：
+
+```console
+$ loginctl show-user ubuntu --property=Linger
+Failed to get user: User ID 1000 is not logged in or lingering
+$ systemctl --user is-system-running
+Failed to connect to bus: No medium found
+```
+
+**这台机器上根本没有 systemd 用户会话。**
+
+### 原因
+
+`service install` 安装的是**用户级**服务（`systemctl --user`），它需要一个常驻的
+systemd 用户实例和可连接的 D-Bus。而云服务器通过 SSH 登录时：
+
+- 默认**不**为用户启动常驻的 `user@<uid>.service`；
+- 用户登出后其 systemd 实例即被回收；
+- `XDG_RUNTIME_DIR` 在非登录会话里也常常没有设置。
+
+这就是 **linger** 存在的意义：让用户即使没有登录，systemd 也为其保持一个常驻实例。
+服务器上跑用户级服务，开 linger 是标准做法。
+
+### 解法（一条命令）
+
+```bash
+sudo loginctl enable-linger ubuntu && \
+sudo systemctl start user@1000.service && sleep 3 && \
+export XDG_RUNTIME_DIR=/run/user/1000 && \
+systemctl --user is-system-running
+```
+
+`systemctl start user@1000.service` 立刻把用户实例拉起来，配合手动指定
+`XDG_RUNTIME_DIR`，**不需要断开重连 SSH**。看到 `running`（或 `degraded`）即表示
+bus 已可用。
+
+然后固化环境变量，否则下次新开终端又会连不上：
+
+```bash
+echo 'export XDG_RUNTIME_DIR=/run/user/$(id -u)' >> ~/.bashrc
+```
+
+实测结果：
+
+```console
+running
+service installed
+service installed=true running=true
+```
+
+### 为什么在容器和 Mac 上都碰不到
+
+容器里通常以 root 直接跑、且往往没有完整的 systemd；macOS 用的是 launchd，
+压根没有"用户级 systemd 会话"这个概念。**这个问题只有在真实云主机上、
+以普通用户通过 SSH 操作时才会出现。**
+
+### 待改进
+
+`service_install_failed` 这个错误信息本身是个问题：它没有告诉用户任何可行动的信息。
+正确做法是在安装前检测用户 bus 是否可用，并直接提示运行 `loginctl enable-linger`。
+**错误信息没用，比 bug 本身更消耗人。**
+
+---
+
 ## 部署结果
 
-**已跑通。** 云端龙虾在飞书中正常收发消息，网关日志显示完整链路：
+**已完整跑通，且以系统服务常驻。** 云端龙虾在飞书中正常收发消息：
 
 ```
 channel.transport.connected      WebSocket 长连接建立
@@ -461,9 +538,29 @@ channel.turn.started
 channel.turn.completed           agent_duration_ms=10611
 ```
 
-从零到端到端可用共踩 7 个坑，其中**两个是产品真缺陷**（坑 6 的 Secret 路径不一致、
-以及此前修复的 `tzdata` 缺失导致 `init` 必然失败）。二者都只在纯净 Linux 服务器上暴露，
-在维护者的 macOS 上永远看不到——这正是实机部署不可替代的原因。
+服务状态：
+
+```console
+$ lobster0 --home ~/.lobster0 service status
+service installed=true running=true
+```
+
+即关闭终端、断开 SSH、重启服务器都会自动恢复，崩溃后 5 秒自动重启。
+
+### 这次部署一共暴露 5 个产品缺陷
+
+全部只在**真实 Linux 云主机**上才会出现，在维护者的 macOS 与 CI 容器里都碰不到：
+
+| # | 缺陷 | 只在何处暴露 |
+| --- | --- | --- |
+| 1 | `tzdata` 缺失导致 `init` 必然失败 | 纯净 Linux（uv 的解释器不带时区库） |
+| 2 | `setup` 写 `<home>/secrets.env`、运行时读 `cwd/.env` | 任何机器，但需真正配置后才发现 |
+| 3 | 包安装的用户用不了 `service install` | 按 README 首屏推荐方式安装时 |
+| 4 | systemd 校验临时文件名非法 | 真实 Linux + 已装 systemd |
+| 5 | 云主机默认无 systemd 用户会话 | 真实云主机 + 普通用户 + SSH |
+
+其中 4 和 5 层层嵌套：修好一个才会露出下一个。**这正是实机部署不可替代的原因**——
+它们没有一个能靠代码审查、单元测试或容器验证发现。
 
 ## 尚未验证
 
@@ -488,6 +585,8 @@ channel.turn.completed           agent_duration_ms=10611
 | `setup target already exists` | `setup` 是 fresh-install only | 用 `lobster0 secret set` 改单个密钥，别 `rm -rf` |
 | 配了密钥却报 `is not configured` | 产品缺陷：写 `<home>/secrets.env`、读 `cwd/.env` | 已修复；旧版本设 `LOBSTER0_ENV_FILE` 绕过 |
 | `Must have a version` | wheel 被改名，uv 无法解析版本 | 保持原文件名 |
+| `service_install_failed` | 云主机上没有 systemd 用户会话 | `sudo loginctl enable-linger <用户名>` |
+| `Failed to connect to bus: No medium found` | 同上，且 `XDG_RUNTIME_DIR` 未设置 | 开 linger 后 `export XDG_RUNTIME_DIR=/run/user/$(id -u)` |
 | `unrecognized arguments: --home` | `--home` 是全局参数 | 放到子命令**前面** |
 | `service_repository_dirty` | 产品缺陷：`service install` 要求干净 git 仓库，包安装没有 | 修复中；临时可手写 systemd 单元 |
 


### PR DESCRIPTION
## 部署全流程跑通,记录最后一道关卡

### 坑 11:云主机上没有 systemd 用户会话

前面所有问题解决之后,`service install` **仍然**失败,而且错误信息毫无用处:

```console
$ lobster0 --home ~/.lobster0 service install
error: service_install_failed
```

向 systemd 本身求证才定位到:

```console
$ loginctl show-user ubuntu --property=Linger
Failed to get user: User ID 1000 is not logged in or lingering
$ systemctl --user is-system-running
Failed to connect to bus: No medium found
```

**这台机器上根本没有 systemd 用户会话。** 云服务器 SSH 登录默认不为用户启动常驻的 `user@<uid>.service`,登出即回收,`XDG_RUNTIME_DIR` 在非登录会话中也常常未设置。而 `service install` 装的正是**用户级**服务。

给出**无需断开重连**的一条命令解法,并实测跑通:

```
running
service installed
service installed=true running=true
```

### 记录了一个待改进项

`service_install_failed` 这个错误信息本身就是问题——它没给用户任何可行动的信息。正确做法是安装前检测用户 bus 并直接提示 `loginctl enable-linger`。**错误信息没用,比 bug 本身更消耗人。**

## 部署结果改写为最终状态

已以系统服务常驻(`installed=true running=true`),并列出本次实机部署暴露的**全部 5 个产品缺陷**及各自的暴露条件:

| # | 缺陷 | 只在何处暴露 |
|---|---|---|
| 1 | `tzdata` 缺失,`init` 必然失败 | 纯净 Linux |
| 2 | 密钥写 A 处读 B 处 | 需真正配置后才发现 |
| 3 | 包安装用不了 `service install` | 按 README 首屏方式安装时 |
| 4 | systemd 校验临时文件名非法 | 真实 Linux + systemd |
| 5 | 云主机默认无 systemd 用户会话 | 真实云主机 + 普通用户 + SSH |

其中 4 和 5 **层层嵌套**:修好一个才会露出下一个。这五个没有一个能靠代码审查、单元测试或容器验证发现——这正是实机部署不可替代的原因。

`validate_docs.py` PASS,`tests.test_documentation` 9/9 PASS。
