### PR TITLE
docs(deploy): 记录坑 12 —— 代理方案在当前架构下行不通

### DIFF
--- a/docs/getting-started/20260811_实机部署踩坑实录.md
+++ b/docs/getting-started/20260811_实机部署踩坑实录.md
@@ -526,6 +526,52 @@ service installed=true running=true
 
 ---
 
+## 坑 12：国内机器上，代理方案行不通（架构决定，不是配置问题）
+
+### 现象
+
+部署在国内的 Gateway 无法访问 Google / Bing / DuckDuckGo，`http_get` 全部失败。
+自然的想法是配一个代理，设 `HTTPS_PROXY` 让流量绕出去。
+
+**但这行不通。**
+
+### 原因
+
+`src/lobster0/tools/web.py` 的 `PinnedHTTPSConnection` 是一个**刻意的安全设计**：
+先解析域名并验证得到的公网 IP，然后 `connect()` 里直接
+
+```python
+socket.create_connection((self._target.addresses[0], self._target.port), ...)
+```
+
+即**绕过第二次 DNS，直连已验证的那个 IP**。这防的是 DNS 重绑定攻击——不给攻击者
+在校验通过后把域名重新指向内网地址的机会。
+
+代价是：这条路径**完全不读 `HTTP_PROXY` / `HTTPS_PROXY`**，也不经过任何代理。
+配了也不会生效，而且不会报错——只会像现在这样超时。
+
+### 可行的出路
+
+| 方案 | 可行性 |
+| --- | --- |
+| 配置 `HTTPS_PROXY` 环境变量 | **无效**，工具绕过代理直连 IP |
+| 换用网络不受限的机器（如香港） | **可行，且最干净** |
+| 给工具增加代理支持 | 需要重新权衡上述安全设计，属产品决策 |
+
+实测佐证（Gateway 自己的诊断结论）：
+
+```
+GitHub API 响应正常（http_get）
+GitHub 下载服务器极慢：709 字节花了 12.6 秒
+  —— 换算下来 13MB 的二进制需要约 65 小时
+Google / Bing / DuckDuckGo 均被拦截
+```
+
+**注意区分两类问题**：搜索引擎是被拦截（连不上），GitHub 是能连但极慢。
+前者代理能解决而当前架构不支持，后者换机器才有意义。
+
+---
+
 ## 部署结果
 
 **已完整跑通，且以系统服务常驻。** 云端龙虾在飞书中正常收发消息：
@@ -586,6 +632,7 @@ service installed=true running=true
 | 配了密钥却报 `is not configured` | 产品缺陷：写 `<home>/secrets.env`、读 `cwd/.env` | 已修复；旧版本设 `LOBSTER0_ENV_FILE` 绕过 |
 | `Must have a version` | wheel 被改名，uv 无法解析版本 | 保持原文件名 |
 | `service_install_failed` | 云主机上没有 systemd 用户会话 | `sudo loginctl enable-linger <用户名>` |
+| 搜索/外网全部超时，配了 `HTTPS_PROXY` 也没用 | 网络工具直连已验证 IP，架构上绕过代理 | 换网络不受限的机器；代理在当前架构下无效 |
 | `Failed to connect to bus: No medium found` | 同上，且 `XDG_RUNTIME_DIR` 未设置 | 开 linger 后 `export XDG_RUNTIME_DIR=/run/user/$(id -u)` |
 | `unrecognized arguments: --home` | `--home` 是全局参数 | 放到子命令**前面** |
 | `service_repository_dirty` | 产品缺陷：`service install` 要求干净 git 仓库，包安装没有 | 修复中；临时可手写 systemd 单元 |


### PR DESCRIPTION
用户在国内机器上搜索全部失败,自然想到配代理。**但这条路走不通,而且不是配置问题。**

`tools/web.py` 的 `PinnedHTTPSConnection` 先解析域名验证公网 IP,再在 `connect()` 里直接 `socket.create_connection` 到那个已验证地址,**绕过第二次 DNS**。这是防 DNS 重绑定的刻意设计。

副作用:该路径**完全不读 `HTTP_PROXY`/`HTTPS_PROXY`**,配了不生效**且不报错**,只表现为超时——最容易让人白花时间的那种失败。

文档同时区分了两类网络问题:搜索引擎是**被拦截**(连不上),GitHub 是**能连但极慢**(709 字节 12.6 秒)。前者代理本可解决而当前架构不支持,后者只有换机器才有意义。

`validate_docs.py` PASS。