### PR TITLE
fix(concurrency): 找回被并发提交冲掉的 /stop 与长程预算

### DIFF
--- a/src/lobster0/channels/manager.py
+++ b/src/lobster0/channels/manager.py
@@ -23,7 +23,7 @@ from lobster0.channels.approvals import (
 )
 from lobster0.channels.base import DeliveryKind, InboundMessage
 from lobster0.channels.delivery import split_message
-from lobster0.channels.experience import ChannelExperience
+from lobster0.channels.experience import ChannelExperience, ExperienceActivity
 from lobster0.channels.feedback_commands import FeedbackCommandOutcome
 from lobster0.channels.observability import ChannelObserver
 from lobster0.channels.progress import progress_from_metadata, progress_to_metadata
@@ -54,6 +54,8 @@ from lobster0.storage.conversations import (
 )
 
 _FAILURE_NOTICE = "抱歉，这条消息处理失败了，请稍后重试。"
+# /stop 结果只在那条命令自己被处理前有用，留一个小上界防止异常路径下无限增长。
+_MAX_STOP_OUTCOMES = 128
 
 
 class TurnHandler(Protocol):
@@ -187,6 +189,13 @@ class ChannelManager:
         self._enqueued_guard = asyncio.Lock()
         self._locks: dict[str, _LockEntry] = {}
         self._locks_guard = asyncio.Lock()
+        # 每个 Conversation 至多一个执行中的 Turn Task；/stop 就是取消它。
+        self._active_turns: dict[str, asyncio.Task[TurnResult]] = {}
+        # 由 _request_stop 显式置位，用来把「Owner 主动停止」与「Gateway 关停」
+        # 两种 CancelledError 区分开——后者必须继续上抛，前者必须被吞掉。
+        self._stop_requested: set[str] = set()
+        # /stop 那条入站事件自己的确认文案所需的结果，_control_notice 取用后即弹出。
+        self._stop_outcomes: dict[InboundEventKey, bool] = {}
         self._workers: list[asyncio.Task[None]] = []
         self._feeder: asyncio.Task[None] | None = None
         self._stopping = asyncio.Event()
@@ -235,11 +244,54 @@ class ChannelManager:
         if not result.inserted:
             self._observe_inbound(message, result.event, "duplicate", False)
             return InboundAcceptance(False, False)
+        # /stop 的取消动作必须在这里发生，而不是等 Worker 领取它。
+        # _process 的第一件事是 `async with self._conversation_lock(...)`，
+        # 走正常路径的 /stop 会排在正在执行的那个 Turn 后面等锁——等它拿到锁，
+        # 要停的东西早跑完了。放在 receive() 里则不占 Worker、不等锁，
+        # worker_count=1、队列已满时同样立即生效。
+        if self._is_stop_command(result.event):
+            self._record_stop_outcome(
+                result.event.key,
+                self._request_stop(result.event.external_conversation_id),
+            )
         if message.image_paths:
             self._pending_images[result.event.key] = message.image_paths
         enqueued = await self._enqueue(result.event.key)
         self._observe_inbound(message, result.event, "accepted", enqueued)
         return InboundAcceptance(True, enqueued)
+
+    def _is_stop_command(self, event: StoredInboundEvent) -> bool:
+        """判断这条消息是否为 Owner 发出的停止命令。
+
+        授权与 /reset、/permissions、/restart 完全同源：``_trusted_owner`` 要求
+        外部身份等于配置 Owner **且** 是私聊。群里任何人喊 /stop 都不会取消任何东西。
+
+        必须是**恰好** ``/stop``：``_stop_notice`` 对多余参数只回"用法：/stop"，
+        如果这里放宽成前缀匹配，就会出现"取消了但告诉你用法错了"的自相矛盾。
+        """
+        return event.content.split() == ["/stop"] and self._trusted_owner(event)
+
+    def _request_stop(self, conversation_id: str) -> bool:
+        """取消该 Conversation 正在执行的 Turn；没有在跑的 Turn 时返回 False。
+
+        Args:
+            conversation_id: 平台会话 ID。
+
+        Returns:
+            是否真的取消了一个执行中的 Turn。
+        """
+        task = self._active_turns.get(conversation_id)
+        if task is None or task.done():
+            return False
+        self._stop_requested.add(conversation_id)
+        task.cancel()
+        return True
+
+    def _record_stop_outcome(self, key: InboundEventKey, stopped: bool) -> None:
+        """记下 /stop 的结果供确认文案使用，并保持字典有界。"""
+        if len(self._stop_outcomes) >= _MAX_STOP_OUTCOMES:
+            self._stop_outcomes.pop(next(iter(self._stop_outcomes)), None)
+        self._stop_outcomes[key] = stopped
 
     async def start(self) -> None:
         """恢复遗留状态并启动 feeder 与有限数量 Worker。"""
@@ -519,8 +571,12 @@ class ChannelManager:
                         result=command.result,
                     )
                     return
-            try:
-                result = await self.service.handle_inbound(
+            # Turn 跑在自己的 Task 里，/stop 才能只取消它而不牵连 Worker。
+            # 取消最终落到既有路径上：TurnService 的 except CancelledError 已经
+            # 负责 self._turns.cancel(turn.id) 与 turn_cancelled 事件，
+            # 这里不新建第二套取消机制。
+            turn_task = asyncio.ensure_future(
+                self.service.handle_inbound(
                     user_id=self.owner_id,
                     channel=event.key.channel,
                     account_id=event.key.account_id,
@@ -533,7 +589,21 @@ class ChannelManager:
                     identity_verified=self._verified_owner(event),
                     image_paths=self._pending_images.pop(event.key, ()),
                 )
+            )
+            self._active_turns[event.external_conversation_id] = turn_task
+            try:
+                result = await turn_task
             except asyncio.CancelledError:
+                if self._consume_stop_request(event.external_conversation_id):
+                    await self._settle_owner_stop(
+                        session_id=session.id,
+                        event=event,
+                        activity=activity,
+                        started=started,
+                    )
+                    # 刻意不 raise：被取消的是内层 turn_task，Worker Task 本身
+                    # 从未被 cancel。一次 /stop 不该废掉整个 Channel Worker。
+                    return
                 failure_notice = self._failure_diagnostics(
                     session_id=session.id,
                     event=event,
@@ -565,18 +635,21 @@ class ChannelManager:
                     error=error,
                 )
                 final_delivery_required = True
+                progress_message_id = None
                 if activity is not None:
                     outcome = await activity.finish(
                         content=failure_notice,
                         failed=True,
                     )
                     final_delivery_required = outcome.final_delivery_required
-                if final_delivery_required:
-                    self._create_failure_delivery(
-                        session.id,
-                        event,
-                        content=failure_notice,
-                    )
+                    progress_message_id = outcome.progress_message_id
+                self._create_failure_delivery(
+                    session.id,
+                    event,
+                    content=failure_notice,
+                    delivery_required=final_delivery_required,
+                    progress_message_id=progress_message_id,
+                )
                 self._inbound.mark_failed(event.key, "channel_turn_failed")
                 self._observe_turn(
                     event,
@@ -586,6 +659,10 @@ class ChannelManager:
                     error_code="channel_turn_failed",
                 )
                 return
+            finally:
+                if self._active_turns.get(event.external_conversation_id) is turn_task:
+                    del self._active_turns[event.external_conversation_id]
+                self._stop_requested.discard(event.external_conversation_id)
 
             final_delivery_required = True
             final_delivery_offset = 0
@@ -631,6 +708,72 @@ class ChannelManager:
                 started=started,
                 result=result,
             )
+
+    def _consume_stop_request(self, conversation_id: str) -> bool:
+        """判断这次 CancelledError 是否来自 Owner 的 /stop，并消费该标记。
+
+        两个条件都必须成立：
+
+        1. ``_request_stop`` 显式置过位；
+        2. **当前 Worker Task 自己没有被 cancel**——``cancelling() == 0``。
+           关停走的是 ``worker.cancel()``，那种 CancelledError 必须继续上抛，
+           否则 Worker 不会退出、``stop()`` 会一直等下去。
+        """
+        if conversation_id not in self._stop_requested:
+            return False
+        current = asyncio.current_task()
+        if current is not None and current.cancelling() > 0:
+            return False
+        self._stop_requested.discard(conversation_id)
+        return True
+
+    async def _settle_owner_stop(
+        self,
+        *,
+        session_id: int,
+        event: StoredInboundEvent,
+        activity: ExperienceActivity | None,
+        started: float,
+    ) -> None:
+        """把 Owner 主动停止结算成一条可投递诊断，并让入站事件进入终态。
+
+        持久化一致性由既有取消路径保证：``TurnService`` 已经在同一个
+        ``except asyncio.CancelledError`` 里把 Turn 标成 ``cancelled``，
+        中途完成的 Tool 批次也已经由 ``on_intermediate`` 落库。这里只负责
+        告诉 Owner 发生了什么。
+        """
+        notice = self._failure_diagnostics(
+            session_id=session_id,
+            event=event,
+            fallback_error_code="turn_stopped",
+            stage="Owner 主动停止",
+            reason="你发送了 /stop，本轮任务已在当前位置安全取消。",
+            suggestion=(
+                "已完成的步骤和文件改动都保留着；需要继续就重新发送任务，"
+                "系统不会自动续跑。"
+            ),
+        )
+        final_delivery_required = True
+        progress_message_id: str | None = None
+        if activity is not None:
+            outcome = await activity.finish(content=notice, failed=True)
+            final_delivery_required = outcome.final_delivery_required
+            progress_message_id = outcome.progress_message_id
+        self._create_failure_delivery(
+            session_id,
+            event,
+            content=notice,
+            delivery_required=final_delivery_required,
+            progress_message_id=progress_message_id,
+        )
+        self._fail_running_event(event.key, "turn_stopped")
+        self._observe_turn(
+            event,
+            status="interrupted",
+            session_id=session_id,
+            started=started,
+            error_code="turn_stopped",
+        )
 
     async def _handle_feedback_command(self, event: StoredInboundEvent) -> str | None:
         """处理 /good、/bad；不是反馈命令时返回 ``None`` 让消息继续进入模型。
@@ -682,7 +825,25 @@ class ChannelManager:
             return self._reset_notice(parts, event, session_id)
         if parts[0] == "/restart":
             return self._restart_notice(parts, event)
+        if parts[0] == "/stop":
+            return self._stop_notice(parts, event)
         return None
+
+    def _stop_notice(self, parts: list[str], event: StoredInboundEvent) -> str:
+        """确认 Owner 的 /stop；真正的取消已经在 ``receive()`` 里发生过了。
+
+        这条确认走正常队列，因此天然排在"Turn 真的停下来"之后：
+        Owner 看到的顺序是 Turn 停止诊断 → 本条确认。
+
+        权限判断复用与 /reset、/permissions、/restart 完全相同的 ``_trusted_owner``。
+        """
+        if not self._trusted_owner(event):
+            return "只有 Owner 私聊可以停止当前任务。"
+        if len(parts) != 1:
+            return "用法：/stop"
+        if self._stop_outcomes.pop(event.key, False):
+            return "已停止本轮任务。已完成的步骤和文件改动都保留着，系统不会自动续跑。"
+        return "当前没有正在执行的任务，无需停止。"
 
     def _restart_notice(
         self,
@@ -903,9 +1064,27 @@ class ChannelManager:
         event: StoredInboundEvent,
         *,
         content: str = _FAILURE_NOTICE,
+        delivery_required: bool = True,
+        progress_message_id: str | None = None,
     ) -> None:
-        """把任意内部失败压缩为固定、可投递且不含异常正文的提示。"""
+        """把任意内部失败压缩为固定、可投递且不含异常正文的提示。
+
+        Args:
+            session_id: 归属会话。
+            event: 触发本次失败的入站事件。
+            content: 已脱敏的诊断正文。
+            delivery_required: 平台是否仍需要一条普通文本投递；卡片已经完整
+                展示时为 False，但内部通知消息**仍然要建**——它是失败卡片能被
+                /good、/bad 反查到的唯一锚点。
+            progress_message_id: Owner 在 IM 里真正看到并可以「回复」的那张卡片的
+                平台 ID。以前只有成功路径登记这层映射，失败卡片因此永远反查不到，
+                Owner 对失败卡回复 /bad 只会得到"没有找到这条回答"。
+        """
         notice = self._messages.create_channel_notice(session_id, content)
+        if progress_message_id:
+            self._record_card_delivery(notice.id, event, progress_message_id)
+        if not delivery_required:
+            return
         self._deliveries.create_parts(
             message_id=notice.id,
             channel=event.key.channel,
@@ -1192,12 +1371,14 @@ def _failure_profile(error: Exception) -> tuple[str, str, str]:
         return (
             "Agent Tool Loop",
             (
-                f"本轮已用 {error.elapsed_seconds:.1f} 秒，超过单轮 "
-                f"{error.deadline_seconds} 秒的墙钟预算，已在工具边界安全停止。"
+                f"本轮已用 {error.elapsed_seconds:.1f} 秒，超过你配置的单轮 "
+                f"{error.deadline_seconds} 秒墙钟预算。这个预算**只在工具边界检查**，"
+                "不会打断已经在执行的工具，所以实际耗时可以显著超过配置值"
+                "（一次 run_command 最长可达 120 秒）。"
             ),
             (
-                "请把任务拆小后重试；确实需要更长时间，就调高 agent.max_turn_seconds"
-                "（或 LOBSTER0_MAX_TURN_SECONDS）。"
+                "墙钟预算默认是关闭的（agent.max_turn_seconds = 0）；不想被按时间打断"
+                "就把它调回 0，改用私聊发送 /stop 随时停止——/stop 在工具执行途中也生效。"
             ),
         )
     if isinstance(error, AgentNoProgressError):

--- a/src/lobster0/config.py
+++ b/src/lobster0/config.py
@@ -1,9 +1,9 @@
 """Lobster0 的 TOML 配置、环境变量覆盖与边界校验。"""
 
 import contextlib
+import ipaddress
 import json
 import os
-import ipaddress
 import re
 import tomllib
 from collections.abc import Mapping
@@ -232,11 +232,13 @@ class AgentConfig:
     model: str = "provider/model"
     # 当前生效 Provider 的 id。旧配置没有这个字段，加载时补成实际生效的那条。
     provider: str = "default"
-    max_tool_iterations: int = 32
-    max_tool_iterations_hard: int = 64
-    max_no_progress_iterations: int = 3
-    # 单次 Turn 的墙钟预算：计数预算拦不住“每次换个命令重试”的死循环。
-    max_turn_seconds: int = 90
+    max_tool_iterations: int = 200
+    max_tool_iterations_hard: int = 400
+    max_no_progress_iterations: int = 12
+    # 单次 Turn 的墙钟预算，``0`` 表示不限时（默认）。墙钟时间不是"人想停"的代理
+    # 变量，按秒表杀掉正常长任务是错的；想停止由 Owner 发 /stop。机制保留，
+    # 运维设正整数即可重新封顶。
+    max_turn_seconds: int = 0
     context_budget_tokens: int = 32_000
     tool_result_max_chars: int = 20_000
 
@@ -585,18 +587,18 @@ def load_config(
 
     model = _non_empty_string(agent_raw.get("model", "provider/model"), "agent.model")
     max_tool_iterations = _positive_integer(
-        agent_raw.get("max_tool_iterations", 32), "agent.max_tool_iterations"
+        agent_raw.get("max_tool_iterations", 200), "agent.max_tool_iterations"
     )
     max_tool_iterations_hard = _positive_integer(
-        agent_raw.get("max_tool_iterations_hard", 64),
+        agent_raw.get("max_tool_iterations_hard", 400),
         "agent.max_tool_iterations_hard",
     )
     max_no_progress_iterations = _positive_integer(
-        agent_raw.get("max_no_progress_iterations", 3),
+        agent_raw.get("max_no_progress_iterations", 12),
         "agent.max_no_progress_iterations",
     )
-    max_turn_seconds = _positive_integer(
-        agent_raw.get("max_turn_seconds", 90),
+    max_turn_seconds = _non_negative_integer(
+        agent_raw.get("max_turn_seconds", 0),
         "agent.max_turn_seconds",
     )
     context_budget_tokens = _positive_integer(
@@ -1116,7 +1118,7 @@ def load_config(
         "LOBSTER0_MAX_NO_PROGRESS_ITERATIONS",
         max_no_progress_iterations,
     )
-    max_turn_seconds = _environment_integer(
+    max_turn_seconds = _environment_non_negative_integer(
         source,
         "LOBSTER0_MAX_TURN_SECONDS",
         max_turn_seconds,
@@ -1340,6 +1342,16 @@ def _positive_integer(value: object, name: str) -> int:
     """校验严格正整数，并显式排除布尔值。"""
     if type(value) is not int or value <= 0:
         raise ConfigError(f"{name} must be a positive integer")
+    return value
+
+
+def _non_negative_integer(value: object, name: str) -> int:
+    """校验非负整数，并显式排除布尔值。
+
+    用于"``0`` 表示关闭"的开关型预算，例如 ``agent.max_turn_seconds``。
+    """
+    if type(value) is not int or value < 0:
+        raise ConfigError(f"{name} must be a non-negative integer")
     return value
 
 
@@ -2121,6 +2133,21 @@ def _environment_integer(source: Mapping[str, str], key: str, default: int) -> i
     except ValueError as error:
         raise ConfigError(f"{key} must be a positive integer") from error
     return _positive_integer(value, key)
+
+
+def _environment_non_negative_integer(
+    source: Mapping[str, str],
+    key: str,
+    default: int,
+) -> int:
+    """读取可选的非负整数环境变量；``0`` 是合法的"关闭"值。"""
+    if key not in source:
+        return default
+    try:
+        value = int(source[key])
+    except ValueError as error:
+        raise ConfigError(f"{key} must be a non-negative integer") from error
+    return _non_negative_integer(value, key)
 
 
 def _environment_url(source: Mapping[str, str], key: str, default: str) -> str:

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -26,10 +26,10 @@ class BootstrapTest(unittest.TestCase):
         self.assertEqual(result.applied_migrations, (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13))
         self.assertEqual(result.owner.display_name, "Owner")
         self.assertEqual(config.agent.model, "deepseek-v4-pro")
-        self.assertEqual(config.agent.max_tool_iterations, 32)
-        self.assertEqual(config.agent.max_tool_iterations_hard, 64)
-        self.assertEqual(config.agent.max_no_progress_iterations, 3)
-        self.assertEqual(config.agent.max_turn_seconds, 90)
+        self.assertEqual(config.agent.max_tool_iterations, 200)
+        self.assertEqual(config.agent.max_tool_iterations_hard, 400)
+        self.assertEqual(config.agent.max_no_progress_iterations, 12)
+        self.assertEqual(config.agent.max_turn_seconds, 0)
         self.assertEqual(config.provider.base_url, "https://api.deepseek.com")
         self.assertEqual(config.provider.api_key_env, "LOBSTER0_MODEL_API_KEY")
         self.assertEqual(config.ui.language, "zh-CN")
@@ -38,7 +38,7 @@ class BootstrapTest(unittest.TestCase):
         self.assertTrue(config.permissions.discover_user_executables)
         self.assertEqual(getattr(config.tools, "mode", None), "autopilot")
         self.assertIn(
-            "max_turn_seconds = 90",
+            "max_turn_seconds = 0",
             self.paths.config.read_text(encoding="utf-8"),
         )
         self.assertIn(
@@ -46,9 +46,9 @@ class BootstrapTest(unittest.TestCase):
             self.paths.config.read_text(encoding="utf-8"),
         )
         template = self.paths.config.read_text(encoding="utf-8")
-        self.assertIn("max_tool_iterations = 32", template)
-        self.assertIn("max_tool_iterations_hard = 64", template)
-        self.assertIn("max_no_progress_iterations = 3", template)
+        self.assertIn("max_tool_iterations = 200", template)
+        self.assertIn("max_tool_iterations_hard = 400", template)
+        self.assertIn("max_no_progress_iterations = 12", template)
         self.assertIn('[tools]\nmode = "autopilot"', template)
         self.assertIn("# [channels.feishu]", template)
         self.assertIn('# app_id_env = "LOBSTER0_FEISHU_APP_ID"', template)

--- a/tests/test_channel_manager.py
+++ b/tests/test_channel_manager.py
@@ -112,7 +112,13 @@ class TrackingTurnService:
             self.reached_concurrency.set()
         try:
             if self.gate is not None:
-                await self.gate.wait()
+                try:
+                    await self.gate.wait()
+                except asyncio.CancelledError:
+                    # 与真实 TurnService.handle_inbound 的 except CancelledError
+                    # 分支保持一致：取消时把 Turn 落成 cancelled 再上抛。
+                    self.turns.cancel(turn.id)
+                    raise
             if on_event is not None and self.emit_event:
                 await on_event(
                     RunEvent(
@@ -628,7 +634,8 @@ class ChannelManagerTest(unittest.IsolatedAsyncioTestCase):
 
         with self.database.connect_read_only() as connection:
             success_delivery = connection.execute(
-                "SELECT * FROM deliveries ORDER BY id LIMIT 1"
+                "SELECT * FROM deliveries WHERE delivery_kind = 'message' "
+                "ORDER BY id LIMIT 1"
             ).fetchone()
         self.assertEqual(success_delivery["content"], "reply:hello")
         self.assertEqual(success_delivery["reply_to_message_id"], "om_ok")
@@ -652,7 +659,8 @@ class ChannelManagerTest(unittest.IsolatedAsyncioTestCase):
         )
         with self.database.connect_read_only() as connection:
             failure_delivery = connection.execute(
-                "SELECT * FROM deliveries WHERE reply_to_message_id = 'om_fail'"
+                "SELECT * FROM deliveries WHERE reply_to_message_id = 'om_fail' "
+                "AND delivery_kind = 'message'"
             ).fetchone()
             dump = "\n".join(
                 str(row[0])
@@ -1335,6 +1343,278 @@ class ChannelManagerTest(unittest.IsolatedAsyncioTestCase):
                 "WHERE reply_to_message_id = 'om_wait_restart'"
             ).fetchone()
         self.assertEqual(delivery["delivery_kind"], "approval")
+
+    async def test_stop_interrupts_a_turn_that_is_actually_running(self) -> None:
+        """真正的验收点：``/stop`` 必须打断**正在执行中**的 Turn。
+
+        Owner 的原话是"我能不能在它执行的时候让它停止"。事后登记等于没有，
+        所以这里让 Service 卡在一个测试持有的 Event 上，Turn 真的停在半途，
+        再从另一侧投递 ``/stop``。
+        """
+        gate = asyncio.Event()
+        service = TrackingTurnService(
+            self.sessions,
+            self.messages,
+            self.turns,
+            gate=gate,
+            expected_concurrency=1,
+        )
+        manager = self._manager(service, queue_size=8, worker_count=2)
+        await manager.start()
+        try:
+            await manager.receive(self._message("om_long", "跑一个长任务"))
+            # Turn 已经进入 Service 且卡在 gate 上——此刻它确实在执行中。
+            await asyncio.wait_for(service.reached_concurrency.wait(), timeout=2)
+            self.assertEqual(service.active, 1)
+
+            await manager.receive(self._message("om_stop", "/stop"))
+            await manager.wait_idle(timeout=2)
+        finally:
+            gate.set()
+            await manager.stop()
+
+        # gate 从未在停止前被 set：Turn 是被取消的，不是自己跑完的。
+        turn = self.turns.get_by_inbound(
+            self.sessions.get_or_create(
+                self.owner.id, "feishu", "default", "oc_chat"
+            ).id,
+            "om_long",
+        )
+        self.assertEqual(turn.status, "cancelled")
+
+    async def test_stop_keeps_partial_work_persisted_and_consistent(self) -> None:
+        """被停止的 Turn 必须留下一致的持久状态：读数据库验证，不靠断言口号。"""
+        gate = asyncio.Event()
+        service = TrackingTurnService(
+            self.sessions,
+            self.messages,
+            self.turns,
+            gate=gate,
+            expected_concurrency=1,
+        )
+        manager = self._manager(service, queue_size=8, worker_count=2)
+        await manager.start()
+        try:
+            await manager.receive(self._message("om_long", "跑一个长任务"))
+            await asyncio.wait_for(service.reached_concurrency.wait(), timeout=2)
+            await manager.receive(self._message("om_stop", "/stop"))
+            await manager.wait_idle(timeout=2)
+        finally:
+            gate.set()
+            await manager.stop()
+
+        session = self.sessions.get_or_create(
+            self.owner.id, "feishu", "default", "oc_chat"
+        )
+        turn = self.turns.get_by_inbound(session.id, "om_long")
+        self.assertEqual(turn.status, "cancelled")
+        # 用户那条消息仍然在，没有因为取消被回滚掉。
+        history = self.messages.list_recent(session.id, limit=50)
+        self.assertIn("跑一个长任务", [message.content for message in history])
+        # 入站事件到达终态，不会在重启后被重放。
+        self.assertEqual(
+            tuple(self.inbound.list_by_status("feishu", "default", "running")),
+            (),
+        )
+        self.assertEqual(
+            tuple(self.inbound.list_by_status("feishu", "default", "queued")),
+            (),
+        )
+        # Owner 收到了确认，而且诊断里带着稳定错误码。
+        notices = [
+            message.content
+            for message in history
+            if message.role == "assistant"
+        ]
+        self.assertTrue(
+            any("turn_stopped" in notice for notice in notices),
+            notices,
+        )
+
+    async def test_worker_survives_an_owner_stop_and_keeps_serving(self) -> None:
+        """Owner 的 ``/stop`` 不得杀死 Worker——否则一次停止就废掉整个 Channel。"""
+        gate = asyncio.Event()
+        service = TrackingTurnService(
+            self.sessions,
+            self.messages,
+            self.turns,
+            gate=gate,
+            expected_concurrency=1,
+        )
+        manager = self._manager(service, queue_size=8, worker_count=2)
+        await manager.start()
+        try:
+            await manager.receive(self._message("om_long", "长任务"))
+            await asyncio.wait_for(service.reached_concurrency.wait(), timeout=2)
+            await manager.receive(self._message("om_stop", "/stop"))
+            await manager.wait_idle(timeout=2)
+
+            gate.set()
+            await manager.receive(self._message("om_next", "停完之后还能用吗"))
+            await manager.wait_idle(timeout=2)
+        finally:
+            gate.set()
+            await manager.stop()
+
+        self.assertIn(("oc_chat", "om_next"), service.calls)
+        session = self.sessions.get_or_create(
+            self.owner.id, "feishu", "default", "oc_chat"
+        )
+        self.assertEqual(
+            self.turns.get_by_inbound(session.id, "om_next").status,
+            "completed",
+        )
+
+    async def test_stop_without_a_running_turn_says_so(self) -> None:
+        """空闲时 ``/stop`` 必须明确说"没有正在执行的任务"，而不是假装停了什么。"""
+        service = TrackingTurnService(self.sessions, self.messages, self.turns)
+        manager = self._manager(service, queue_size=4, worker_count=1)
+        await manager.start()
+        try:
+            await manager.receive(self._message("om_stop", "/stop"))
+            await manager.wait_idle(timeout=2)
+        finally:
+            await manager.stop()
+
+        self.assertEqual(service.calls, [])
+        session = self.sessions.get_or_create(
+            self.owner.id, "feishu", "default", "oc_chat"
+        )
+        notices = [
+            message.content
+            for message in self.messages.list_recent(session.id, limit=50)
+            if message.role == "assistant"
+        ]
+        self.assertEqual(len(notices), 1)
+        self.assertIn("没有正在执行", notices[0])
+
+    async def test_stop_with_extra_arguments_cancels_nothing(self) -> None:
+        """``/stop now`` 只回用法提示，绝不能"取消了却说你用法错了"。"""
+        gate = asyncio.Event()
+        service = TrackingTurnService(
+            self.sessions,
+            self.messages,
+            self.turns,
+            gate=gate,
+            expected_concurrency=1,
+        )
+        manager = self._manager(service, queue_size=8, worker_count=2)
+        await manager.start()
+        try:
+            await manager.receive(self._message("om_long", "长任务"))
+            await asyncio.wait_for(service.reached_concurrency.wait(), timeout=2)
+            await manager.receive(self._message("om_stop", "/stop now"))
+            await asyncio.sleep(0)
+            self.assertEqual(service.active, 1)
+            gate.set()
+            await manager.wait_idle(timeout=2)
+        finally:
+            gate.set()
+            await manager.stop()
+
+        session = self.sessions.get_or_create(
+            self.owner.id, "feishu", "default", "oc_chat"
+        )
+        self.assertEqual(
+            self.turns.get_by_inbound(session.id, "om_long").status,
+            "completed",
+        )
+        notices = [
+            message.content
+            for message in self.messages.list_recent(session.id, limit=50)
+            if message.role == "assistant"
+        ]
+        self.assertIn("用法：/stop", notices)
+
+    async def test_non_owner_stop_cannot_cancel_anything(self) -> None:
+        """群聊与非 Owner 私聊的 ``/stop`` 都不得取消任何 Turn。
+
+        授权判断必须与 /reset、/permissions、/restart 完全同源
+        （``_trusted_owner``：身份等于配置 Owner **且** 私聊）。
+        """
+        for label, kwargs in (
+            ("group", {"chat_type": "group", "chat_id": "oc_group"}),
+            ("stranger", {"external_user_id": "ou_stranger"}),
+        ):
+            with self.subTest(actor=label):
+                gate = asyncio.Event()
+                service = TrackingTurnService(
+                    self.sessions,
+                    self.messages,
+                    self.turns,
+                    gate=gate,
+                    expected_concurrency=1,
+                )
+                manager = self._manager(service, queue_size=8, worker_count=2)
+                await manager.start()
+                try:
+                    await manager.receive(
+                        self._message(f"om_long_{label}", "长任务")
+                    )
+                    await asyncio.wait_for(
+                        service.reached_concurrency.wait(), timeout=2
+                    )
+                    await manager.receive(
+                        self._message(f"om_stop_{label}", "/stop", **kwargs)
+                    )
+                    await asyncio.sleep(0)
+                    # 关键断言：Turn 仍然在跑，没有被外人掐掉。
+                    self.assertEqual(service.active, 1)
+                    gate.set()
+                    await manager.wait_idle(timeout=2)
+                finally:
+                    gate.set()
+                    await manager.stop()
+
+                session = self.sessions.get_or_create(
+                    self.owner.id, "feishu", "default", "oc_chat"
+                )
+                self.assertEqual(
+                    self.turns.get_by_inbound(session.id, f"om_long_{label}").status,
+                    "completed",
+                )
+
+    async def test_failure_card_can_receive_feedback(self) -> None:
+        """失败卡片必须能被 ``/good``、``/bad`` 反查到。
+
+        真实事故：Owner 对一张 turn_deadline 失败卡回复 /bad，得到
+        "没有找到这条回答，无法记录反馈。"。根因是失败路径从不登记
+        ``delivery_kind='card'`` 映射——只有成功路径调用 _record_card_delivery。
+        """
+        service = TrackingTurnService(
+            self.sessions,
+            self.messages,
+            self.turns,
+            fail=True,
+        )
+        transport = ManagerCapabilityTransport()
+        manager = self._manager(service, queue_size=4, worker_count=1)
+        manager.attach_experience(
+            ChannelCapabilities(
+                transport=transport,
+                streaming_card=True,
+                update_interval=0.0001,
+            )
+        )
+        await manager.start()
+        try:
+            await manager.receive(self._message("om_fail", "会失败的任务"))
+            await manager.wait_idle(timeout=2)
+        finally:
+            await manager.stop()
+
+        delivery = self.deliveries.find_sent_by_platform_message_id(
+            channel="feishu",
+            account_id="default",
+            platform_message_id="om_manager_card",
+            kind="card",
+        )
+        self.assertIsNotNone(delivery)
+        assert delivery is not None
+        target = self.messages.get(delivery.message_id)
+        self.assertIsNotNone(target)
+        assert target is not None
+        self.assertEqual(target.role, "assistant")
 
     def _manager(
         self,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,10 +35,11 @@ class ConfigTest(unittest.TestCase):
         )
 
         self.assertEqual(config.agent.model, "provider/model")
-        self.assertEqual(config.agent.max_tool_iterations, 32)
-        self.assertEqual(config.agent.max_tool_iterations_hard, 64)
-        self.assertEqual(config.agent.max_no_progress_iterations, 3)
-        self.assertEqual(config.agent.max_turn_seconds, 90)
+        self.assertEqual(config.agent.max_tool_iterations, 200)
+        self.assertEqual(config.agent.max_tool_iterations_hard, 400)
+        self.assertEqual(config.agent.max_no_progress_iterations, 12)
+        # 0 = 不限时。Owner 明确要求长程任务不被墙钟预算打断。
+        self.assertEqual(config.agent.max_turn_seconds, 0)
         self.assertEqual(config.ui.language, "zh-CN")
         self.assertEqual(config.provider.base_url, "https://api.openai.com/v1")
         self.assertEqual(config.provider.api_key_env, "LOBSTER0_MODEL_API_KEY")
@@ -167,27 +168,27 @@ class ConfigTest(unittest.TestCase):
             )
 
     def test_legacy_toml_soft_budget_expands_implicit_hard_budget(self) -> None:
-        """旧 TOML 只配置较大 soft 时应自动把隐式 hard 提升到同值。"""
+        """旧 TOML 只配置 soft 时，隐式 hard 必须始终不低于 soft。"""
         self.paths.config.write_text(
-            "[agent]\nmax_tool_iterations = 100\n",
+            "[agent]\nmax_tool_iterations = 600\n",
             encoding="utf-8",
         )
 
         config = load_config(self.paths, {}, {})
 
-        self.assertEqual(config.agent.max_tool_iterations, 100)
-        self.assertEqual(config.agent.max_tool_iterations_hard, 100)
+        self.assertEqual(config.agent.max_tool_iterations, 600)
+        self.assertEqual(config.agent.max_tool_iterations_hard, 600)
 
     def test_legacy_environment_soft_budget_expands_implicit_hard_budget(self) -> None:
-        """旧环境变量只配置较大 soft 时应自动把隐式 hard 提升到同值。"""
+        """旧环境变量只配置 soft 时，隐式 hard 必须始终不低于 soft。"""
         config = load_config(
             self.paths,
-            {"LOBSTER0_MAX_TOOL_ITERATIONS": "100"},
+            {"LOBSTER0_MAX_TOOL_ITERATIONS": "600"},
             {},
         )
 
-        self.assertEqual(config.agent.max_tool_iterations, 100)
-        self.assertEqual(config.agent.max_tool_iterations_hard, 100)
+        self.assertEqual(config.agent.max_tool_iterations, 600)
+        self.assertEqual(config.agent.max_tool_iterations_hard, 600)
 
     def test_toml_hard_remains_explicit_when_environment_overrides_soft(self) -> None:
         """TOML 显式 hard 不得被环境 soft 静默提升。"""
@@ -451,13 +452,25 @@ class ConfigTest(unittest.TestCase):
                 "[agent]\nmax_no_progress_iterations = true\n",
                 "max_no_progress_iterations",
             ),
-            ("[agent]\nmax_turn_seconds = 0\n", "max_turn_seconds"),
+            ("[agent]\nmax_turn_seconds = -1\n", "max_turn_seconds"),
             ("[agent]\nmax_turn_seconds = true\n", "max_turn_seconds"),
         ):
             with self.subTest(content=content):
                 self.paths.config.write_text(content, encoding="utf-8")
                 with self.assertRaisesRegex(ConfigError, expected):
                     load_config(self.paths, {}, {})
+
+    def test_wall_clock_budget_can_be_switched_on_and_off(self) -> None:
+        """``0`` 是"不限时"开关；运维想封顶时设正整数仍然生效，机制没有被删掉。"""
+        self.paths.config.write_text(
+            "[agent]\nmax_turn_seconds = 300\n", encoding="utf-8"
+        )
+        self.assertEqual(load_config(self.paths, {}, {}).agent.max_turn_seconds, 300)
+
+        self.assertEqual(
+            load_config(self.paths, {"LOBSTER0_MAX_TURN_SECONDS": "0"}, {}).agent.max_turn_seconds,
+            0,
+        )
 
     def test_unknown_key_is_rejected(self) -> None:
         """拼错的配置项必须立即失败，而不是静默使用默认值。"""


### PR DESCRIPTION
## 问题

两个并发会话各自基于旧快照提交，后一个把前一个的改动整体盖掉。测试一直是绿的，因为被删的功能连同它的测试一起消失了。

### 1. `/stop` 控制被删

`3c2dbb8`（飞书图片）删掉了 `373d48f` 的 Owner 停止控制：`manager.py` 里 `_consume_stop_request`、`_is_stop_command`、`_record_stop_outcome`、`_request_stop`、`_settle_owner_stop`、`_stop_notice` 六个方法，以及 `test_channel_manager.py` 里 6 个验收测试。

### 2. main 上的全新 init 是坏的

`f2488cc`（depth-1 子 Agent）基于 `373d48f` 之前的 `config.py` 提交，把 `max_turn_seconds` 的语义改了回去——`bootstrap.py` 仍渲染 `max_turn_seconds = 0`，`config.py` 却重新只收正整数：

```
ConfigError: agent.max_turn_seconds must be a positive integer
```

在干净 worktree 检出 HEAD 复现确认，不是本地工作区的问题。

## 修法

- `/stop`：按 `373d48f` 恢复六个方法与测试，再把飞书图片改动（`image_paths` 透传、`_pending_images`）重新叠加。
- 预算：三方合并把 `373d48f` 的语义补回 HEAD（`0` = 不限时、`_non_negative_integer`、200/400/12 默认值），`f2488cc` 的子 Agent 代码与测试原样保留。

墙钟预算与 `/stop` 是同一个设计的两半：不按秒表杀正常长任务，想停由 Owner 发 `/stop`。只恢复一半两边都不成立。

## 验证

- `2080 tests, OK (skipped=4)`
- 恢复前干净检出 HEAD：53 failures / 27 errors

未触碰并发会话正在写的 `media/router.py`、`media/__init__.py`、`tests/test_media_router.py`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)