### PR TITLE
fix(feishu): 图片必须显式调 resolve 才会下载，SDK 不会自动缓存

### DIFF
--- a/src/lobster0/channels/feishu.py
+++ b/src/lobster0/channels/feishu.py
@@ -4,7 +4,7 @@ import importlib
 import re
 import tempfile
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path
 from types import ModuleType
@@ -45,7 +45,7 @@ class FeishuMessageView(Protocol):
     body_text: str
     raw_content_type: str
     parent_message_id: str
-    resources: list
+    image_descriptors: tuple[Any, ...]
     create_time: datetime | str | int | None
 
 
@@ -83,9 +83,11 @@ class FeishuAdapter:
         elif message.chat_type != "p2p":
             return IgnoredInbound("unsupported_message")
 
-        images = _cached_image_paths(message)
+        # 这里只看描述符判断"这条消息带没带图"——判断是免费的，下载不是。真正的
+        # 下载由 Transport 在准入通过之后再做，图片路径随后补上。
+        has_image = bool(message.image_descriptors)
         text = sanitize_inbound_text(message.body_text).strip()
-        if not text and images:
+        if not text and has_image:
             # 只发图不配文字是常见用法；给一句中性提示，让这一轮不至于被当成空消息丢弃。
             text = "请看这张图片。"
         if not text:
@@ -105,7 +107,6 @@ class FeishuAdapter:
             text=text,
             reply_to_message_id=message.message_id,
             replied_to_message_id=_valid_message_id(message.parent_message_id),
-            image_paths=images,
             received_at=_received_at(message.create_time, self._clock),
         )
 
@@ -143,6 +144,9 @@ class _OfficialMessageView:
     body_text: str
     raw_content_type: str
     parent_message_id: str
+    # 只带图片描述符（type + file_key），不含本地路径：判断"带没带图"是免费的，
+    # 真正下载由 Transport 在准入之后再做。
+    image_descriptors: tuple[Any, ...]
     create_time: datetime | str | int | None
 
 
@@ -432,6 +436,15 @@ class FeishuTransport:
         view = _official_message_view(message)
         normalized = self._adapter.normalize(view)
         if isinstance(normalized, InboundMessage):
+            # 下载必须发生在准入**之后**：resources 只是描述符，把它换成本地文件要真的
+            # 走一次网络。放在准入前，任何陌生人发一张图就能让我们下载，等于送出一个
+            # 免费的流量与磁盘放大器。
+            normalized = replace(
+                normalized,
+                image_paths=await self._resolve_images(
+                    view.message_id, view.image_descriptors
+                ),
+            )
             await self._on_inbound(normalized)
         elif self._observer is not None:
             try:
@@ -445,6 +458,33 @@ class FeishuTransport:
                 )
             except Exception:
                 pass
+
+    async def _resolve_images(
+        self, message_id: str, descriptors: tuple[Any, ...]
+    ) -> tuple[tuple[Path, str], ...]:
+        """把入站消息里的图片描述符换成 SDK 缓存好的本地文件。
+
+        ``InboundMessage.resources`` 只是 ``ResourceDescriptor``（``type`` + ``file_key``），
+        **不含本地路径**——SDK 不会自动下载任何东西。必须显式调
+        ``resolve_resources_to_cache`` 才会真正落盘并返回带 ``path`` 的
+        ``CachedResource``。这一点曾经理解错，导致图片能力整条链路静默失效：
+        代码在读一个永远不存在的字段，于是永远拿到空列表，没有任何报错。
+
+        只解析 ``type == "image"`` 的描述符：文件、音频、视频对视觉模型没有意义，
+        为它们付一次下载与磁盘是纯浪费。
+
+        任何一步失败都只让这一轮没有图，不让整条消息处理失败——看不到图是能力降级，
+        丢掉 Owner 的消息是故障。
+        """
+        if not descriptors or not message_id:
+            return ()
+        try:
+            cached = await self._channel.resolve_resources_to_cache(
+                message_id=message_id, resources=list(descriptors)
+            )
+        except Exception:  # noqa: BLE001 - 下载失败不得吞掉 Owner 的消息
+            return ()
+        return _cached_image_paths(cached)
 
     def _handle_reconnecting(self) -> None:
         """同步接收 SDK 自动重连通知并更新安全状态。"""
@@ -529,12 +569,20 @@ def _official_message_view(message: Any) -> _OfficialMessageView:
         body_text=str(getattr(message, "body_text", "") or ""),
         raw_content_type=str(getattr(message, "raw_content_type", "") or ""),
         parent_message_id=_parent_message_id(message),
+        image_descriptors=tuple(
+            item
+            for item in (getattr(message, "resources", None) or ())
+            if getattr(item, "type", None) == "image"
+        ),
         create_time=getattr(message, "create_time", None),
     )
 
 
-def _cached_image_paths(message: Any) -> tuple[tuple[Path, str], ...]:
-    """取出 SDK 已经下载并缓存到本地的图片资源。
+def _cached_image_paths(resources: Any) -> tuple[tuple[Path, str], ...]:
+    """从 ``CachedResource`` 列表里取出真正落盘的图片。
+
+    入参是 ``FeishuChannel.resolve_resources_to_cache`` 的返回值，**不是**
+    ``InboundMessage.resources``——后者只是不含路径的描述符。
 
     只接受 ``decision == "cached"``：``skipped``/``rejected`` 表示 SDK 因为超限或策略
     没有真的把文件落盘，此时 ``path`` 不可读，当成图片带出去只会在读取时炸掉。
@@ -542,7 +590,6 @@ def _cached_image_paths(message: Any) -> tuple[tuple[Path, str], ...]:
     同时按 MIME 二次过滤：``resources`` 里也可能有音频、文件，它们不能被当作图片
     送进视觉模型。
     """
-    resources = getattr(message, "resources", None)
     if not resources:
         return ()
     found: list[tuple[Path, str]] = []

--- a/src/lobster0/evals/channel.py
+++ b/src/lobster0/evals/channel.py
@@ -164,6 +164,8 @@ class _MessageView:
     body_text: str = "hello"
     raw_content_type: str = "text"
     parent_message_id: str = ""
+    # 与 _OfficialMessageView 同名：只带图片描述符，本地路径由 Transport 后补。
+    image_descriptors: tuple = ()
     create_time: datetime = datetime(2026, 8, 8, tzinfo=UTC)
 
 

--- a/tests/fakes/fake_channel.py
+++ b/tests/fakes/fake_channel.py
@@ -1,7 +1,7 @@
 """Channel 契约测试使用的纯内存对象。"""
 
 from collections.abc import Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any
@@ -24,7 +24,8 @@ class FakeFeishuMessage:
     body_text: str = "你好"
     raw_content_type: str = "text"
     parent_message_id: str = ""
-    resources: list = field(default_factory=list)
+    # 与真实 _OfficialMessageView 同名：只带图片描述符，不含本地路径。
+    image_descriptors: tuple = ()
     create_time: datetime = datetime(2026, 8, 8, tzinfo=UTC)
 
 
@@ -110,6 +111,10 @@ class FakeOfficialChannel:
         self.outcomes = list(outcomes)
         self.handlers: dict[str, Any] = {}
         self.constructor_kwargs: dict[str, Any] = {}
+        # 媒体缓存：真实 SDK 只有被显式调用才会下载，这里如实记录每次调用。
+        self.cached_resources: list[Any] = []
+        self.resolve_calls: list[tuple[str, int]] = []
+        self.resolve_error: BaseException | None = None
         self.sent: list[tuple[str, Any, Any]] = []
         self.cards_updated: list[tuple[str, dict[str, Any]]] = []
         self.typing_added: list[str] = []
@@ -165,6 +170,19 @@ class FakeOfficialChannel:
         """记录 Typing 清理。"""
         self.typing_removed.append((message_id, reaction_id))
         return True
+
+    async def resolve_resources_to_cache(
+        self, *, message_id: str, resources: list[Any]
+    ) -> list[Any]:
+        """模拟"必须显式调用才会下载"的真实语义并记录调用。
+
+        真实 SDK 不会自动缓存任何资源；把这次调用记下来，测试才能证明代码真的
+        发起了下载，而不是在读一个永远为空的字段。
+        """
+        self.resolve_calls.append((message_id, len(resources)))
+        if self.resolve_error is not None:
+            raise self.resolve_error
+        return list(self.cached_resources)
 
     async def update_card(self, message_id: str, card: dict[str, Any]):
         """记录卡片更新。"""

--- a/tests/test_feishu_images.py
+++ b/tests/test_feishu_images.py
@@ -1,31 +1,50 @@
-"""飞书图片消息必须能进入管线，并带出已缓存的本地图片路径。"""
+"""飞书图片消息必须进入管线，并在准入之后换成本地可读的图片路径。
+
+## 这个文件为什么分成两段
+
+图片链路有两个各自独立的环节，早前把它们混成一段测，结果两段都没被真正验证：
+
+1. **准入**（``FeishuAdapter.normalize``）：只看描述符判断"带没带图"。判断是免费的。
+2. **取回**（``FeishuTransport._resolve_images``）：真的走一次网络下载。
+
+早前的实现以为 SDK 会自动把图片下载好，直接在 ``message.resources`` 上找
+``decision`` 和 ``path``——这两个字段在 ``ResourceDescriptor`` 上根本不存在，于是
+循环每次都跳过，整条链路静默失效。签名层面的守卫在
+``tests/test_feishu_sdk_contract.py``；这里验证行为。
+"""
 
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 
 from lobster0.channels.base import IgnoredInbound, InboundMessage
-from lobster0.channels.feishu import FeishuAdapter
+from lobster0.channels.feishu import FeishuAdapter, FeishuTransport
 from lobster0.config import FeishuConfig
-from tests.fakes.fake_channel import FakeFeishuMessage
+from tests.fakes.fake_channel import FakeFeishuMessage, FakeOfficialSdk
 
 
-class _Resource:
-    """模拟 SDK 已缓存好的一个资源。"""
+def _descriptor(resource_type: str = "image", file_key: str = "img_v3_x"):
+    """构造一个与真实 ``ResourceDescriptor`` 同形的描述符：没有 path，没有 decision。"""
+    return SimpleNamespace(
+        type=resource_type, file_key=file_key, file_name=None, duration_ms=None
+    )
 
-    def __init__(
-        self,
-        *,
-        decision: str = "cached",
-        mime_type: str = "image/png",
-        path: str = "/tmp/cached.png",
-        resource_type: str = "image",
-    ) -> None:
-        self.decision = decision
-        self.mime_type = mime_type
-        self.path = Path(path)
-        self.resource_type = resource_type
-        self.sha256 = "a" * 64
-        self.size = 4
+
+def _cached(
+    *,
+    decision: str = "cached",
+    mime_type: str = "image/png",
+    path: str = "/tmp/cached.png",
+):
+    """构造一个与真实 ``CachedResource`` 同形的下载结果。"""
+    return SimpleNamespace(
+        decision=decision,
+        mime_type=mime_type,
+        path=Path(path),
+        sha256="a" * 64,
+        size=4,
+        reason=None,
+    )
 
 
 class FeishuImageAdmissionTest(unittest.TestCase):
@@ -45,59 +64,43 @@ class FeishuImageAdmissionTest(unittest.TestCase):
             )
         )
 
-    def test_image_message_is_admitted_with_its_cached_path(self) -> None:
-        """图片消息必须进入管线，并带出本地缓存路径。"""
-        message = FakeFeishuMessage(
-            raw_content_type="image",
-            body_text="",
-            resources=[_Resource()],
+    def test_image_message_is_admitted(self) -> None:
+        """图片消息必须进入管线，不再被当作不支持的类型丢弃。"""
+        result = self.adapter.normalize(
+            FakeFeishuMessage(
+                raw_content_type="image",
+                body_text="看看这张",
+                image_descriptors=(_descriptor(),),
+            )
         )
 
-        result = self.adapter.normalize(message)
-
         self.assertIsInstance(result, InboundMessage)
-        assert isinstance(result, InboundMessage)
-        self.assertEqual(len(result.image_paths), 1)
-        self.assertEqual(result.image_paths[0], (Path("/tmp/cached.png"), "image/png"))
 
     def test_image_without_text_still_carries_a_prompt(self) -> None:
         """只发图不配文字时也要有可用正文，否则整轮会被当成空消息丢弃。"""
-        message = FakeFeishuMessage(
-            raw_content_type="image", body_text="", resources=[_Resource()]
+        result = self.adapter.normalize(
+            FakeFeishuMessage(
+                raw_content_type="image",
+                body_text="",
+                image_descriptors=(_descriptor(),),
+            )
         )
-
-        result = self.adapter.normalize(message)
 
         assert isinstance(result, InboundMessage)
         self.assertTrue(result.text.strip())
 
-    def test_uncached_resource_is_not_exposed(self) -> None:
-        """SDK 没能缓存下来的资源不能被当成可读路径带出去。"""
-        for decision in ("skipped", "rejected"):
-            with self.subTest(decision=decision):
-                message = FakeFeishuMessage(
-                    raw_content_type="image",
-                    body_text="看看这张",
-                    resources=[_Resource(decision=decision)],
-                )
-
-                result = self.adapter.normalize(message)
-
-                assert isinstance(result, InboundMessage)
-                self.assertEqual(result.image_paths, ())
-
-    def test_non_image_resource_is_not_exposed_as_an_image(self) -> None:
-        """音频、文件等不能被当作图片送进视觉模型。"""
-        message = FakeFeishuMessage(
-            raw_content_type="file",
-            body_text="这是文件",
-            resources=[_Resource(mime_type="application/pdf", resource_type="file")],
+    def test_admission_does_not_carry_paths(self) -> None:
+        """准入阶段不得带出任何图片路径——那时还没有下载过任何东西。"""
+        result = self.adapter.normalize(
+            FakeFeishuMessage(
+                raw_content_type="image",
+                body_text="看看这张",
+                image_descriptors=(_descriptor(),),
+            )
         )
 
-        result = self.adapter.normalize(message)
-
-        if isinstance(result, InboundMessage):
-            self.assertEqual(result.image_paths, ())
+        assert isinstance(result, InboundMessage)
+        self.assertEqual(result.image_paths, ())
 
     def test_text_message_still_has_no_images(self) -> None:
         """纯文字消息必须保持原行为，不受本次改动影响。"""
@@ -113,6 +116,79 @@ class FeishuImageAdmissionTest(unittest.TestCase):
         )
 
         self.assertIsInstance(result, IgnoredInbound)
+
+
+class FeishuImageResolutionTest(unittest.IsolatedAsyncioTestCase):
+    """验证取回阶段：必须真的发起下载，且只认真正落盘的结果。"""
+
+    def setUp(self) -> None:
+        """构造一个记录 resolve 调用的假 SDK Transport。"""
+        self.sdk = FakeOfficialSdk()
+        self.transport = FeishuTransport(
+            FeishuConfig(
+                enabled=True,
+                account_id="default",
+                owner_open_id="ou_owner",
+                allowed_open_ids=("ou_owner",),
+            ),
+            app_id="cli_x",
+            app_secret="secret",
+            on_inbound=self._collect,
+            sdk=self.sdk,
+        )
+        self.inbound: list[InboundMessage] = []
+
+    async def _collect(self, message: InboundMessage) -> None:
+        """记录被投递到管线的消息。"""
+        self.inbound.append(message)
+
+    async def test_descriptors_are_resolved_into_local_paths(self) -> None:
+        """描述符必须被显式下载成本地路径——SDK 不会自动做这件事。"""
+        self.sdk.channel.cached_resources = [_cached()]
+
+        paths = await self.transport._resolve_images("om_x", (_descriptor(),))
+
+        self.assertEqual(paths, ((Path("/tmp/cached.png"), "image/png"),))
+        self.assertEqual(
+            self.sdk.channel.resolve_calls,
+            [("om_x", 1)],
+            "必须调用一次 resolve_resources_to_cache，否则永远拿不到图片",
+        )
+
+    async def test_uncached_results_are_not_exposed(self) -> None:
+        """SDK 没能落盘的结果不能被当成可读路径带出去。"""
+        for decision in ("skipped", "rejected"):
+            with self.subTest(decision=decision):
+                self.sdk.channel.cached_resources = [_cached(decision=decision)]
+
+                paths = await self.transport._resolve_images("om_x", (_descriptor(),))
+
+                self.assertEqual(paths, ())
+
+    async def test_non_image_mime_is_not_exposed_as_an_image(self) -> None:
+        """即便 SDK 缓存成功，非图片 MIME 也不能送进视觉模型。"""
+        self.sdk.channel.cached_resources = [_cached(mime_type="application/pdf")]
+
+        paths = await self.transport._resolve_images("om_x", (_descriptor(),))
+
+        self.assertEqual(paths, ())
+
+    async def test_no_descriptors_means_no_network_call(self) -> None:
+        """没有图片描述符时不得发起任何下载——纯文字轮次不该付网络代价。"""
+        paths = await self.transport._resolve_images("om_x", ())
+
+        self.assertEqual(paths, ())
+        self.assertEqual(self.sdk.channel.resolve_calls, [])
+
+    async def test_download_failure_degrades_instead_of_dropping_the_message(
+        self,
+    ) -> None:
+        """下载失败只让这一轮没有图，不能让 Owner 的消息整条丢掉。"""
+        self.sdk.channel.resolve_error = RuntimeError("network down")
+
+        paths = await self.transport._resolve_images("om_x", (_descriptor(),))
+
+        self.assertEqual(paths, ())
 
 
 if __name__ == "__main__":

--- a/tests/test_feishu_sdk_contract.py
+++ b/tests/test_feishu_sdk_contract.py
@@ -79,6 +79,45 @@ class FeishuSdkContractTest(unittest.TestCase):
         fields = {field.name for field in dataclasses.fields(lark_channel.ChannelConfig)}
         self.assertIn("media_cache", fields)
 
+    def test_inbound_resources_are_descriptors_without_local_paths(self) -> None:
+        """``InboundMessage.resources`` 只是描述符，**没有**本地路径。
+
+        真实事故：早前的实现直接在 ``message.resources`` 上找 ``decision`` 和
+        ``path``，以为 SDK 会自动把图片下载好。这两个字段在 ``ResourceDescriptor``
+        上根本不存在，于是循环每次都跳过，图片能力整条链路静默失效——没有报错，
+        没有日志，只有模型说"我看不到图片"。
+        """
+        descriptor_fields = {
+            field.name for field in dataclasses.fields(lark_channel.ResourceDescriptor)
+        }
+        self.assertEqual(
+            descriptor_fields & {"decision", "path"},
+            set(),
+            "描述符上出现了 decision/path，缓存模型可能已变，请重新确认解析路径",
+        )
+        self.assertIn("file_key", descriptor_fields)
+        self.assertIn("type", descriptor_fields)
+
+        cached_fields = {
+            field.name for field in dataclasses.fields(lark_channel.CachedResource)
+        }
+        self.assertTrue(
+            {"decision", "path", "mime_type"}.issubset(cached_fields),
+            f"CachedResource 字段已变化：{sorted(cached_fields)}",
+        )
+
+    def test_downloading_requires_an_explicit_resolve_call(self) -> None:
+        """必须显式调用才会下载：这是"图片看不到"那次事故的根因。"""
+        resolve = getattr(lark_channel.FeishuChannel, "resolve_resources_to_cache", None)
+        self.assertIsNotNone(resolve, "SDK 不再提供 resolve_resources_to_cache")
+        parameters = set(inspect.signature(resolve).parameters)
+        self.assertTrue(
+            {"message_id", "resources"}.issubset(parameters),
+            f"resolve_resources_to_cache 签名已变化：{sorted(parameters)}",
+        )
+        source = inspect.getsource(FeishuTransport._resolve_images)
+        self.assertIn("resolve_resources_to_cache", source)
+
     def test_explicit_keywords_still_override_the_config_base(self) -> None:
         """SDK 必须保持"``config`` 作底座、显式关键字覆盖"的合并顺序。
 


### PR DESCRIPTION
## 症状

Owner 在飞书发图，Agent 回「图片本体没有传进我的上下文」。开了 `media_cache` 之后仍然如此。

## 根因

`InboundMessage.resources` 是 `List[ResourceDescriptor]`——只有 `type` 和 `file_key`，**没有 `decision`，也没有 `path`**。

带本地路径的是 `CachedResource`，而它只由 `FeishuChannel.resolve_resources_to_cache()` 产出，**必须显式调用**；SDK 不会自动下载任何东西。

`_cached_image_paths` 却直接在 `resources` 上找 `decision == "cached"`——这两个字段在描述符上根本不存在，于是循环每次都跳过，永远返回空元组。没有异常，没有日志，只有模型说「我看不到图片」。静默失效，比崩溃难查得多。

`media_cache` 配置本身是必要的（决定缓存落在哪、多大、存多久），但它不触发下载。

## 改法

- `FeishuTransport._resolve_images`：显式调 `resolve_resources_to_cache`，只解析 `type == "image"` 的描述符——文件、音频、视频对视觉模型没有意义。
- **下载发生在准入之后**：把描述符换成本地文件要真走一次网络。放在准入前，任何陌生人发一张图就能让我们下载，等于送出一个免费的流量与磁盘放大器。
- `_OfficialMessageView` 带上 `image_descriptors`，Adapter 只据此判断「带没带图」（判断免费，下载不免费），路径由 Transport 在准入后补上。
- `_cached_image_paths` 改为接收 resolve 的返回值，仍只认 `decision == "cached"`：`skipped`/`rejected` 时 `path` 不可读。

## 测试为什么之前没拦住

`test_feishu_images.py` 里的 `_Resource` 假件**自带 `decision` 和 `path`**，测的是一个真实 SDK 里不存在的结构。假件放行了真 SDK 会拒绝的用法——与上一次 `media_cache` 关键字那次是同一类事故。

现在拆成两段测：

| 环节 | 验证什么 |
| --- | --- |
| Adapter 准入 | 靠描述符判断带没带图，不得带出任何路径 |
| Transport 取回 | 真的发起下载，并记录调用次数 |

假 Channel 的 `resolve_resources_to_cache` 如实模拟「不调就没有」。签名层面在 `test_feishu_sdk_contract.py` 锁死：描述符上不得出现 `decision`/`path`，`CachedResource` 必须有，且 `_resolve_images` 必须调用 resolve。

已反向验证：把下载退回成直接读描述符，`test_descriptors_are_resolved_into_local_paths` 立刻失败。

## 验证

`2108 tests, OK (skipped=4)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)