### PR TITLE
feat(observability): 入站图片每一种结果都留痕，并修好 handle 漏传图片

### DIFF
--- a/src/lobster0/agent/turn.py
+++ b/src/lobster0/agent/turn.py
@@ -232,6 +232,10 @@ class TurnService:
             conversation_kind="local",
             identity_verified=True,
             attachments=attachments,
+            # 曾经漏传：``handle`` 收下了 image_paths 却没往下交，于是 CLI/桌面端
+            # 直接传本地图片这条路静默失效，症状与飞书那次一模一样——没有报错，
+            # 只是模型看不见图。
+            image_paths=image_paths,
         )
 
     def _attachment_summaries(

--- a/src/lobster0/channels/feishu.py
+++ b/src/lobster0/channels/feishu.py
@@ -474,17 +474,62 @@ class FeishuTransport:
         为它们付一次下载与磁盘是纯浪费。
 
         任何一步失败都只让这一轮没有图，不让整条消息处理失败——看不到图是能力降级，
-        丢掉 Owner 的消息是故障。
+        丢掉 Owner 的消息是故障。但**每一种结果都要留痕**：这里所有失败模式的表现
+        完全相同（这一轮没有图），不记数就没法事后区分是哪一环断的。
         """
-        if not descriptors or not message_id:
+        if not message_id:
+            self._observe_media(message_id, 0, 0, "failed", "media_message_id_missing")
+            return ()
+        if not descriptors:
+            # 不是错误：纯文字轮次本来就没有描述符。但它与"SDK 该给却没给"表现一致，
+            # 记下来才能分辨。
+            self._observe_media(message_id, 0, 0, "empty", "media_no_descriptors")
             return ()
         try:
             cached = await self._channel.resolve_resources_to_cache(
                 message_id=message_id, resources=list(descriptors)
             )
         except Exception:  # noqa: BLE001 - 下载失败不得吞掉 Owner 的消息
+            self._observe_media(
+                message_id, len(descriptors), 0, "failed", "media_download_failed"
+            )
             return ()
-        return _cached_image_paths(cached)
+        paths = _cached_image_paths(cached)
+        if not paths:
+            # 报出第一个被丢弃图片的具体原因，而不是笼统的"没拿到"——
+            # "SDK 没落盘"和"MIME 不支持"是两种完全不同的修法。
+            reason = next(
+                (code for item in cached if (code := _image_drop_reason(item))),
+                "media_not_cached",
+            )
+            self._observe_media(message_id, len(descriptors), 0, "empty", reason)
+        else:
+            self._observe_media(message_id, len(descriptors), len(paths), "resolved")
+        return paths
+
+    def _observe_media(
+        self,
+        message_id: str,
+        descriptor_count: int,
+        resolved_count: int,
+        outcome: str,
+        error_code: str | None = None,
+    ) -> None:
+        """上报一次图片解析结果；埋点自身失败绝不影响消息处理。"""
+        if self._observer is None:
+            return
+        try:
+            self._observer.media(
+                channel="feishu",
+                account_id=self._config.account_id,
+                external_message_id=message_id or "invalid",
+                descriptor_count=descriptor_count,
+                resolved_count=resolved_count,
+                outcome=outcome,
+                error_code=error_code,
+            )
+        except Exception:  # noqa: BLE001 - 观测不得成为新的故障源
+            pass
 
     def _handle_reconnecting(self) -> None:
         """同步接收 SDK 自动重连通知并更新安全状态。"""
@@ -594,16 +639,31 @@ def _cached_image_paths(resources: Any) -> tuple[tuple[Path, str], ...]:
         return ()
     found: list[tuple[Path, str]] = []
     for item in resources:
-        if getattr(item, "decision", None) != "cached":
+        if _image_drop_reason(item):
             continue
-        mime = str(getattr(item, "mime_type", "") or "")
-        if mime not in {"image/png", "image/jpeg"}:
-            continue
-        path = getattr(item, "path", None)
-        if path is None:
-            continue
-        found.append((Path(path), mime))
+        found.append((Path(item.path), str(item.mime_type)))
     return tuple(found)
+
+
+def _image_drop_reason(item: Any) -> str:
+    """判定一个缓存结果为何不可用；可用时返回空串。
+
+    三种丢弃原因在最终表现上完全一样——这一轮没有图——不分开记就没法排查。
+    与 ``_cached_image_paths`` 共用同一份判断，避免"过滤逻辑"和"上报原因"漂移成
+    两套各说各话的规则。
+    """
+    decision = getattr(item, "decision", None)
+    if decision != "cached":
+        # skipped/rejected 表示 SDK 因超限或策略没有真的落盘，path 不可读。
+        return "media_not_cached"
+    mime = str(getattr(item, "mime_type", "") or "")
+    if mime not in {"image/png", "image/jpeg"}:
+        # 音频、文件等不能当作图片送进视觉模型。
+        return "media_unsupported_mime"
+    if getattr(item, "path", None) is None:
+        # 判定为已缓存却没有路径，属于 SDK 契约异常，值得单独一个码。
+        return "media_path_missing"
+    return ""
 
 
 def _parent_message_id(message: Any) -> str:

--- a/src/lobster0/channels/observability.py
+++ b/src/lobster0/channels/observability.py
@@ -62,6 +62,10 @@ _CAPABILITIES = frozenset(
         "typing_stop",
         "progress_create",
         "progress_update",
+        # 入站图片的下载与缓存。它和 Typing/进度卡同类：失败只让这一轮少一项能力，
+        # 不改变权威回复。但它此前完全没有痕迹——图片没进模型时，日志里一片空白，
+        # 只有 Owner 在 IM 里看到"我看不到图片"，无从判断断在哪一环。
+        "media_resolve",
     }
 )
 
@@ -268,6 +272,52 @@ class ChannelObserver:
             session_id=session_id,
             turn_id=turn_id,
         )
+
+    def media(
+        self,
+        *,
+        channel: str,
+        account_id: str,
+        external_message_id: str,
+        descriptor_count: int,
+        resolved_count: int,
+        outcome: str,
+        error_code: str | None = None,
+        user_id: int | None = None,
+    ) -> None:
+        """记录入站图片从"描述符"到"本地文件"的每一次转换，成功也记。
+
+        ## 为什么成功也要记
+
+        这条链路的失败模式全都是**静默**的：描述符为空、下载被拒、MIME 不符、
+        文件超限——每一种的结果都一样，就是"这一轮没有图"，日志里什么都不留。
+        2026-08-13 排查"飞书看不到图"时，正是因为只有失败分支没有埋点，无法区分
+        "SDK 没给描述符"和"下载失败了"，只能靠反复重启和手工复现去猜。
+
+        记下 ``descriptor_count`` 与 ``resolved_count`` 两个数，就能一眼分辨：
+
+        - ``0 → 0``：SDK 根本没给图片描述符，问题在通道或消息类型；
+        - ``N → 0``：拿到了描述符但一张都没落地，问题在下载或过滤；
+        - ``N → M``（M < N）：部分被过滤，``error_code`` 说明原因；
+        - ``N → N``：正常。
+
+        Args:
+            descriptor_count: SDK 给出的图片描述符数量。
+            resolved_count: 最终可用的本地图片数量。
+            outcome: ``resolved`` / ``empty`` / ``failed``。
+            error_code: 稳定错误码；``outcome`` 为 ``resolved`` 时可省略。
+        """
+        metadata = self._chain_metadata(channel, account_id, external_message_id)
+        metadata["descriptor_count"] = _non_negative_int(
+            descriptor_count, "descriptor_count"
+        )
+        metadata["resolved_count"] = _non_negative_int(resolved_count, "resolved_count")
+        metadata["outcome"] = _choice(
+            outcome, frozenset({"resolved", "empty", "failed"}), "outcome"
+        )
+        if error_code is not None:
+            metadata["error_code"] = _error_code(error_code)
+        self._record("channel.media.resolved", metadata, user_id=user_id)
 
     def tool_count(self, turn_id: int | None) -> int:
         """返回某个内部 Turn 的 ToolRun 数量；未知 Turn 按零处理。"""

--- a/tests/test_feishu_images.py
+++ b/tests/test_feishu_images.py
@@ -34,13 +34,17 @@ def _cached(
     *,
     decision: str = "cached",
     mime_type: str = "image/png",
-    path: str = "/tmp/cached.png",
+    path: str | None = "/tmp/cached.png",
 ):
-    """构造一个与真实 ``CachedResource`` 同形的下载结果。"""
+    """构造一个与真实 ``CachedResource`` 同形的下载结果。
+
+    ``path`` 允许为 ``None``：真实 ``CachedResource.path`` 是 ``Optional``，
+    "判定已缓存却没有路径"是必须能表达的一种 SDK 契约异常。
+    """
     return SimpleNamespace(
         decision=decision,
         mime_type=mime_type,
-        path=Path(path),
+        path=None if path is None else Path(path),
         sha256="a" * 64,
         size=4,
         reason=None,
@@ -189,6 +193,110 @@ class FeishuImageResolutionTest(unittest.IsolatedAsyncioTestCase):
         paths = await self.transport._resolve_images("om_x", (_descriptor(),))
 
         self.assertEqual(paths, ())
+
+
+class FeishuImageObservabilityTest(unittest.IsolatedAsyncioTestCase):
+    """每一种结果都必须留痕——所有失败模式的表现完全一样，不记数就查不出来。"""
+
+    def setUp(self) -> None:
+        """构造带观测器的 Transport。"""
+        self.sdk = FakeOfficialSdk()
+        self.observer = _RecordingObserver()
+        self.transport = FeishuTransport(
+            FeishuConfig(
+                enabled=True,
+                account_id="default",
+                owner_open_id="ou_owner",
+                allowed_open_ids=("ou_owner",),
+            ),
+            app_id="cli_x",
+            app_secret="secret",
+            on_inbound=self._collect,
+            sdk=self.sdk,
+            observer=self.observer,
+        )
+
+    async def _collect(self, message: InboundMessage) -> None:
+        """本用例不关心投递结果。"""
+
+    async def test_success_records_both_counts(self) -> None:
+        """成功也要记：只记失败的话，"什么都没发生"依然无从判断。"""
+        self.sdk.channel.cached_resources = [_cached()]
+
+        await self.transport._resolve_images("om_x", (_descriptor(),))
+
+        self.assertEqual(
+            self.observer.media_events,
+            [("om_x", 1, 1, "resolved", None)],
+        )
+
+    async def test_each_failure_mode_has_its_own_code(self) -> None:
+        """三种丢弃原因必须可区分——修法完全不同。"""
+        cases = (
+            (_cached(decision="rejected"), "media_not_cached"),
+            (_cached(mime_type="application/pdf"), "media_unsupported_mime"),
+            (_cached(path=None), "media_path_missing"),
+        )
+        for resource, expected in cases:
+            with self.subTest(expected=expected):
+                self.observer.media_events.clear()
+                self.sdk.channel.cached_resources = [resource]
+
+                await self.transport._resolve_images("om_x", (_descriptor(),))
+
+                self.assertEqual(
+                    self.observer.media_events,
+                    [("om_x", 1, 0, "empty", expected)],
+                )
+
+    async def test_download_failure_is_distinguishable_from_no_descriptors(self) -> None:
+        """"下载失败"与"SDK 没给描述符"必须分开——正是这次查不出来的根因。"""
+        self.sdk.channel.resolve_error = RuntimeError("network down")
+        await self.transport._resolve_images("om_x", (_descriptor(),))
+
+        self.observer.media_events.clear()
+        await self.transport._resolve_images("om_y", ())
+
+        self.assertEqual(
+            self.observer.media_events,
+            [("om_y", 0, 0, "empty", "media_no_descriptors")],
+        )
+
+    async def test_observer_failure_never_breaks_message_handling(self) -> None:
+        """埋点自身失败绝不能成为新的故障源。"""
+        self.observer.explode = True
+        self.sdk.channel.cached_resources = [_cached()]
+
+        paths = await self.transport._resolve_images("om_x", (_descriptor(),))
+
+        self.assertEqual(paths, ((Path("/tmp/cached.png"), "image/png"),))
+
+
+class _RecordingObserver:
+    """只记录 media 观测调用的最小观测器。"""
+
+    def __init__(self) -> None:
+        self.media_events: list[tuple[str, int, int, str, str | None]] = []
+        self.explode = False
+
+    def media(
+        self,
+        *,
+        channel: str,
+        account_id: str,
+        external_message_id: str,
+        descriptor_count: int,
+        resolved_count: int,
+        outcome: str,
+        error_code: str | None = None,
+        user_id: int | None = None,
+    ) -> None:
+        """记录一次图片解析观测。"""
+        if self.explode:
+            raise RuntimeError("observer is broken")
+        self.media_events.append(
+            (external_message_id, descriptor_count, resolved_count, outcome, error_code)
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_vision_attachments.py
+++ b/tests/test_vision_attachments.py
@@ -171,3 +171,33 @@ class AttachImagesToRequestTest(unittest.TestCase):
         self.assertEqual(updated.messages[-1].content, "user-text")
         self.assertEqual(updated.messages[-1].role, "user")
         self.assertEqual(updated.model, "deepseek-v4-pro")
+
+
+class HandleForwardsImagePathsTest(unittest.IsolatedAsyncioTestCase):
+    """``TurnService.handle`` 必须把本地图片路径交给 ``handle_inbound``。
+
+    真实缺陷：``handle`` 声明了 ``image_paths`` 参数却没有往下传，于是 CLI 与桌面端
+    直接给本地图片这条路静默失效——没有报错，只是模型看不见图。症状与飞书那次
+    完全一样，而且同样不会有任何日志。
+    """
+
+    async def test_image_paths_reach_handle_inbound(self) -> None:
+        """转发必须真的发生；只声明参数不算实现。"""
+        from unittest.mock import AsyncMock, patch
+
+        from lobster0.agent.turn import TurnService
+
+        paths = ((Path("/tmp/a.png"), "image/png"),)
+        service = TurnService.__new__(TurnService)
+        with patch.object(
+            TurnService, "handle_inbound", new=AsyncMock(return_value=None)
+        ) as inbound:
+            await TurnService.handle(
+                service,
+                user_id=1,
+                text="看看这张图",
+                conversation_id="c1",
+                image_paths=paths,
+            )
+
+        self.assertEqual(inbound.await_args.kwargs["image_paths"], paths)


### PR DESCRIPTION
## 为什么

排查「飞书看不到图」时最大的障碍不是 bug 本身，而是**这条链路一点痕迹都没有**。所有失败模式的表现完全相同——这一轮没有图——日志里一片空白，只能靠反复重启、手工复现和翻 SDK 源码去猜断在哪一环。

## 加了什么

`ChannelObserver.media`：记录一次入站图片从「描述符」到「本地文件」的转换，**成功也记**。只记失败的话，「什么都没发生」依然无从判断。

两个计数一起看就能定位：

| descriptor → resolved | 说明 |
| --- | --- |
| `0 → 0` | SDK 根本没给描述符，问题在通道或消息类型 |
| `N → 0` | 拿到描述符但一张没落地，看 `error_code` |
| `N → M` | 部分被过滤 |
| `N → N` | 正常 |

失败原因拆成可区分的稳定码，因为修法完全不同：

`media_no_descriptors` / `media_download_failed` / `media_not_cached` / `media_unsupported_mime` / `media_path_missing` / `media_message_id_missing`

过滤逻辑与上报原因共用 `_image_drop_reason` 一份判断，避免漂移成两套各说各话的规则。埋点自身失败一律吞掉——观测不得成为新的故障源，有测试盯着。

## 顺带修好的真 bug

`TurnService.handle` 声明了 `image_paths` 却**没有传给** `handle_inbound`，于是 CLI 与桌面端直接给本地图片这条路静默失效。症状与飞书那次一模一样，而且同样没有任何日志。

已补转发与测试，并反向验证：去掉转发，测试立刻失败。

## 关于飞书那张图（尚未定位）

本次排查已确认：

- Transport 层用**真实凭据**实测可以把图片下载成本地文件并挂上 `InboundMessage`（`decision=cached`，`image/jpeg`，176 KB）
- 视觉后端配置完整（`providers` 里有 `vision`，`LOBSTER0_VISION_MODEL=qwen3-vl-flash`，key 存在）

早先「缓存目录里没有文件」的判断是**错的**——`media_cache` 的 ttl 是 1 小时，当时下的文件早已被清理，不能作为「没下载过」的证据。

真实链路为何仍然没把图交给模型，尚未定位。这次加的埋点正是为了下一次发图时能直接从日志读出断点，而不是继续猜。

## 验证

`2113 tests, OK (skipped=4)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)