### PR TITLE
docs(phase8): 多模态输入统一设计——图片、语音与其他附件

### DIFF
--- a/docs/engineering/phase-8/20260814_多模态输入统一设计.md
+++ b/docs/engineering/phase-8/20260814_多模态输入统一设计.md
@@ -1,0 +1,410 @@
+# 多模态输入统一设计：图片、语音与其他附件
+
+> 文档日期：2026-08-14
+> 状态：**DESIGN**
+> 触发事件：飞书图片能力连续两次**静默失效**。第一次是给 SDK 传了不存在的构造关键字
+> （Gateway 起不来，日志只有一句 `gateway startup or runtime failed`）；第二次是读了
+> `ResourceDescriptor` 上不存在的字段（永远拿到空列表，没有任何报错，只有 Owner 在 IM 里
+> 看到"我看不到图片"）。两次都通过了全部单元测试。
+
+---
+
+## 1. 为什么要重新设计，而不是继续打补丁
+
+两次事故的直接原因不同，但失败形态完全一样：
+
+| | 第一次 | 第二次 |
+| --- | --- | --- |
+| 直接原因 | `media_cache=` 不是 SDK 的构造关键字 | `resources` 只是描述符，没有 `path` |
+| 表现 | Gateway 起不来 | 这一轮没有图 |
+| 日志 | 一句笼统的失败 | **完全空白** |
+| 单测 | 全绿（假件来者不拒） | 全绿（假件自带虚构字段） |
+
+**共同的结构性问题有三个**，它们不解决，第三次事故只是时间问题：
+
+1. **"没有媒体"和"媒体丢了"在系统里长得一模一样。** 图片没进模型时，代码路径上每一个
+   环节都合法地返回空，没有任何一处认为出了错。
+2. **媒体状态不持久。** `ChannelManager._pending_images` 是一个内存字典。Gateway 重启后
+   `_recover_stale()` 会从数据库重放 queued 事件，此时图片路径**已经随进程消失**，
+   重放出来的那一轮必然没有图，而且不会有任何提示。
+3. **模型路由有两套实现，其中一套是死代码。** `media/switching.py` 的
+   `VisionSwitchingProvider` 被 `runtime.py` 真正使用；`media/router.py` 的
+   `resolve_model_route` 没有任何 `media/` 之外的调用方。两套规则并存，改一套不会影响
+   另一套，任何人都可能改错地方。
+
+再叠加一个业务事实：**Owner 已经在用语音**。当前 Adapter 对 `audio` 直接返回
+`unsupported_message`，连"我暂时听不了语音"这句话都不会说——消息被安静地丢掉。
+
+---
+
+## 2. 现状盘点（2026-08-14 实测）
+
+### 2.1 已经能用的
+
+| 能力 | 状态 | 位置 |
+| --- | --- | --- |
+| 图片进模型（数据结构） | ✅ | `ModelMessage.images: tuple[ImagePart, ...]` |
+| 图片序列化为兼容协议 | ✅ | `openai_compatible._message_payload`，仅带图时切 content parts |
+| 视觉模型自动切换 | ✅ | `VisionSwitchingProvider`，带图必须命中视觉后端，否则 fail closed |
+| 飞书图片下载 | ✅ | `FeishuTransport._resolve_images` → `resolve_resources_to_cache` |
+| 附件 Artifact | ✅ | `ArtifactStore`，`read_artifact` 工具按需读 |
+| 图片解析可观测 | ✅ | `ChannelObserver.media`（2026-08-14 新增） |
+
+已用真实凭据实测：飞书图片可下载为本地文件（`decision=cached`，`image/jpeg`，176 KB），
+视觉后端配置完整（`providers` 有 `vision`，`LOBSTER0_VISION_MODEL=qwen3-vl-flash`）。
+
+### 2.2 缺口
+
+| 缺口 | 影响 | 严重度 |
+| --- | --- | --- |
+| `_pending_images` 只在内存 | 重启/重放后图片静默丢失 | **高** |
+| 语音直接被拒 | Owner 发语音等于消息被吞 | **高** |
+| Telegram / Discord 零媒体处理 | 两个渠道完全没有多模态 | 中 |
+| `resolve_model_route` 死代码 | 两套规则，改错地方无感知 | 中 |
+| 图片仅支持 png/jpeg | webp/heic（iPhone 默认）被丢弃 | 中 |
+| 媒体缓存在系统临时目录 | TTL 1 小时，事后无法复查 | 低 |
+| 文件/视频/表情包无处理 | 静默忽略 | 低 |
+
+### 2.3 各类型当前行为
+
+飞书 Adapter 的准入白名单是 `{"text", "post", "image"}`，其余一律
+`IgnoredInbound("unsupported_message")`：
+
+| 飞书消息类型 | 当前 | 期望 |
+| --- | --- | --- |
+| text / post | 进入管线 | 不变 |
+| image | 进入管线，图片解析后挂到请求 | 不变 |
+| audio | **静默丢弃** | 转写后进入管线 |
+| file | **静默丢弃** | 落成 Artifact，模型按需读 |
+| video | **静默丢弃** | 明确告知不支持 |
+| sticker | **静默丢弃** | 明确告知不支持 |
+
+---
+
+## 3. 目标与非目标
+
+### 目标
+
+1. **一条统一管线**：所有渠道、所有模态走同一套"描述 → 取回 → 校验 → 转换 → 路由"。
+2. **媒体状态可持久**：重启后重放的消息仍然带着它的媒体，或者明确告知已失效。
+3. **失败必须可见**：任何一步丢弃媒体都要留下可区分的稳定原因码。
+4. **语音可用**：Owner 发语音能得到正确响应。
+5. **不支持的类型明确告知**，而不是静默丢弃。
+
+### 非目标（本设计明确不做）
+
+- 不做模型侧的语音**输出**（TTS）——那是另一条链路，与输入无关；
+- 不做视频理解——成本与收益不匹配，且没有真实需求；
+- 不做"自动把所有附件塞进上下文"——文件继续走 Artifact + `read_artifact` 按需读；
+- 不引入本地 ASR 模型（whisper 等）——增加部署重量，且已有云端可用。
+
+---
+
+## 4. 核心设计：三层，一个方向
+
+```
+渠道层                    Core 媒体层                   模型层
+─────────                ─────────────                ─────────
+飞书 / TG / Discord       InboundMedia（持久）          ModelPart
+桌面上传                  ↓ 取回                        ├ ImagePart（已有）
+   │                     CachedMedia（本地文件）        └ TextPart（转写产物）
+   └─ MediaRef ────────→ ↓ 校验                            ↓
+      (kind, key, 渠道)   ↓ 转换                        模型路由
+                         ↓                              ├ 文本模型
+                         ModelPart / Artifact           └ 视觉模型
+```
+
+三个概念各有唯一职责，不允许跨层直接读对方的字段——两次事故都源于"跨层猜字段"。
+
+### 4.1 `MediaRef`：渠道给出的引用，不含内容
+
+```python
+@dataclass(frozen=True, slots=True)
+class MediaRef:
+    kind: Literal["image", "audio", "file", "video", "sticker"]
+    external_key: str      # 渠道内部标识（飞书 file_key、TG file_id）
+    file_name: str = ""
+    duration_ms: int | None = None
+```
+
+每个渠道 Adapter 只负责把自己的原生结构翻译成 `MediaRef`。**它不下载任何东西**——判断
+"这条消息带没带媒体"必须是免费的，否则准入检查会变成一个流量放大器。
+
+### 4.2 `InboundMedia`：与入站事件一起持久化
+
+这是修复 `_pending_images` 的关键。新表：
+
+```sql
+CREATE TABLE inbound_media (
+    id INTEGER PRIMARY KEY,
+    channel TEXT NOT NULL,
+    account_id TEXT NOT NULL,
+    external_message_id TEXT NOT NULL,
+    ordinal INTEGER NOT NULL,           -- 同一条消息内的顺序，决定送进模型的顺序
+    kind TEXT NOT NULL CHECK(kind IN ('image','audio','file','video','sticker')),
+    external_key TEXT NOT NULL,
+    file_name TEXT NOT NULL DEFAULT '',
+    duration_ms INTEGER,
+    status TEXT NOT NULL CHECK(status IN (
+        'pending','cached','rejected','expired','unsupported'
+    )),
+    local_path TEXT,                     -- cached 时才有
+    media_type TEXT,
+    size_bytes INTEGER,
+    content_hash TEXT,
+    reason_code TEXT,                    -- 非 cached 时必须有
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (channel, account_id, external_message_id)
+        REFERENCES processed_events(channel, account_id, external_message_id),
+    UNIQUE(channel, account_id, external_message_id, ordinal)
+);
+```
+
+**为什么必须持久**：`processed_events` 已经是可重放的权威入站账本。媒体是那条消息的一部分，
+把它留在内存里等于让消息的一半可重放、另一半不可重放。重启后 `_recover_stale()` 重放时，
+从这张表就能拿回图片路径；文件已被缓存 TTL 清掉时状态转 `expired`，Owner 会收到明确提示，
+而不是得到一个看不见图的回答。
+
+**为什么存 `local_path` 而不是字节**：媒体字节不进数据库。SQLite 存二进制会让备份、
+WAL 和查询全部变重，而本地文件已经由 SDK 的媒体缓存管理。路径失效时状态转 `expired`，
+这是可检测的；把字节塞进库换来的"永不失效"不值这个代价。
+
+### 4.3 `ModelPart`：只有模型真正能吃的东西
+
+现有 `ImagePart` 保持不变。语音**不新增** `AudioPart`——理由见第 6 节。
+
+---
+
+## 5. 图片：补齐，不重做
+
+图片链路的形状已经正确，缺的是持久化与格式覆盖。
+
+### 5.1 准入与取回分离（已实现，写入设计以固化）
+
+```
+normalize()  ← 只看 MediaRef 判断"带没带图"，不下载
+    ↓ 准入通过
+resolve()    ← 真的走一次网络，把 MediaRef 换成本地文件
+```
+
+下载**必须**在准入之后。放在准入前，任何陌生人发一张图就能让 Owner 的机器去下载，
+等于免费的流量与磁盘放大器。
+
+### 5.2 格式覆盖
+
+当前只接受 `image/png` 与 `image/jpeg`（`ImagePart.__post_init__` 硬性拒绝其余）。
+真实痛点是 **iPhone 默认 HEIC** 和**微信/飞书转发常见的 webp**。
+
+处理策略：
+
+| 格式 | 处理 |
+| --- | --- |
+| png / jpeg | 直接送 |
+| webp / heic | **本地转码成 jpeg** 后再送；转码失败降级为 `unsupported` 并明确告知 |
+| gif | 取首帧转 jpeg（动图对视觉模型没有额外信息） |
+| 其余 | `unsupported`，明确告知 |
+
+转码引入一个图像库依赖。这是本设计里唯一新增的运行期依赖，取舍是：不转码就等于对
+iPhone 用户完全不可用，而 Owner 正是 iPhone 用户。
+
+### 5.3 尺寸与数量上限
+
+- 单图 ≤ 8 MB（沿用现值）；
+- 单轮 ≤ 4 张：超出部分标记 `rejected`，并在回答里说明"只看了前 4 张"；
+- 像素上限沿用 Artifact 的 `_MAX_IMAGE_PIXELS`（6400 万），防解压炸弹。
+
+---
+
+## 6. 语音：转写，而不是直接喂给模型
+
+### 6.1 两条路的取舍
+
+| | A. 原生音频模型 | B. 先转写成文字（**选这个**） |
+| --- | --- | --- |
+| 主模型 | 必须换成支持音频的模型 | 不动，仍是 DeepSeek |
+| 上下文 | 音频字节占大量 token | 文字，几乎不增加成本 |
+| 可复查 | Owner 看不到模型"听到"了什么 | 转写文本可见、可纠正 |
+| 记忆/评测 | 音频无法进 failure case | 文字可以原样重放 |
+| 失败模式 | 听错了无从发现 | 转写错误 Owner 一眼能看出来 |
+
+**选 B**。决定性理由是**可复查**：Phase 7 的受控进化要求失败可以被整理成可重放的
+测试用例，音频字节做不到这一点，转写文本可以。而且转写结果直接展示给 Owner，
+听错了他当场就能纠正——原生音频模型听错了没人知道。
+
+### 6.2 语音进入管线的形态
+
+转写产物**不是**一个新的 ModelPart，而是直接成为这一轮的**用户文本**：
+
+```
+Owner 发语音（12 秒）
+  → 下载为本地音频文件
+  → ASR 转写 → "帮我看看昨天那个部署脚本还有没有问题"
+  → InboundMessage.text = 转写结果
+  → 正常走文本主流程（DeepSeek），不触发视觉路由
+```
+
+回答里必须**显式回显转写结果**，例如开头一句
+`（听到：帮我看看昨天那个部署脚本还有没有问题）`。理由与视觉那条一致：模型不能让 Owner
+误以为它听到的和他说的是一回事。转写有歧义时回显尤其重要。
+
+### 6.3 ASR 后端
+
+复用现有的多 Provider 机制，新增一条 `id = "audio"` 的 Provider 配置，与 `vision` 完全
+同构：
+
+```toml
+[[providers]]
+id = "audio"
+base_url = "..."
+api_key_env = "LOBSTER0_AUDIO_API_KEY"
+```
+
+模型名取自 `LOBSTER0_AUDIO_MODEL`。**未配置时不静默降级**：语音消息回一句
+"语音转写没有配置，暂时听不了语音"，而不是安静丢弃。这与视觉那条的 fail-closed 一致。
+
+### 6.4 边界
+
+- 单条语音 ≤ 60 秒 / ≤ 10 MB，超出明确拒绝并说明；
+- 转写文本按现有 `message_max_chars` 截断规则处理；
+- **音频文件用完即删**，不进 Artifact：语音是最私密的输入形态，没有留存的正当理由。
+  转写文本按普通消息持久化，Owner 可以通过既有的 `/forget` 路径处理。
+
+---
+
+## 7. 文件、视频与表情包
+
+| 类型 | 处理 | 理由 |
+| --- | --- | --- |
+| 文件（pdf/txt/csv/zip/json） | 落成 Artifact，回一句"已收到 X，需要我读吗？" | 已有 `read_artifact`，按需读比全塞进上下文省 token 且更可控 |
+| 视频 | 明确告知不支持 | 理解成本高，无真实需求 |
+| 表情包 | 明确告知不支持 | 无信息量 |
+
+关键改动：**从"静默丢弃"改成"明确告知"**。Owner 发了东西却什么反应都没有，是最糟糕的
+交互——他无法区分"系统没收到"和"系统不支持"。
+
+---
+
+## 8. 模型路由：删掉一套
+
+现状是两套并存且其中一套是死代码。**保留 `VisionSwitchingProvider`，删除
+`resolve_model_route`**。
+
+理由不是"先来后到"，而是**放置位置**：`VisionSwitchingProvider` 在 Provider 边界工作，
+`AgentRunner`、`TurnService`、`Context` 全都不需要知道视觉模型的存在——它们照常构造请求，
+包装在最后一刻看一眼请求里有没有图，再决定发给谁。`resolve_model_route` 要求调用方
+自己判断 `has_images` 并解析配置，把同一个判断散到每个调用点。
+
+路由规则（保持 fail-closed）：
+
+| 这一轮 | 路由 |
+| --- | --- |
+| 无图 | 主模型 |
+| 有图 + 视觉已配置 | 视觉模型 |
+| 有图 + 视觉未配置 | **报错**，不静默降级 |
+
+最后一条是硬约束：文本模型收到图片不会报错——它只是看不见，然后**照着上下文编一个像样的
+回答**。Owner 会以为模型真的看过那张图。
+
+---
+
+## 9. 观测：每一种结果都留痕
+
+这是本设计里优先级最高的一条，因为**排查两次事故的最大障碍不是 bug 本身，而是零痕迹**。
+
+`ChannelObserver.media`（已实现）记录每一次转换，**成功也记**：
+
+| `descriptor → resolved` | 结论 |
+| --- | --- |
+| `0 → 0` | 渠道没给媒体引用，问题在渠道层或消息类型 |
+| `N → 0` | 拿到引用但一个都没落地，看 `reason_code` |
+| `N → M` | 部分被过滤 |
+| `N → N` | 正常 |
+
+原因码必须**可区分**，因为修法完全不同：
+
+```
+media_no_descriptors     渠道没给引用
+media_download_failed    下载失败
+media_not_cached         SDK 因超限或策略没落盘
+media_unsupported_mime   类型不支持
+media_path_missing       声称已缓存却没有路径（SDK 契约异常）
+media_expired            重放时本地文件已被缓存清理
+media_too_large          超过大小上限
+media_transcode_failed   转码失败
+asr_not_configured       语音转写未配置
+asr_failed               转写失败
+```
+
+**只记失败是不够的**——"什么都没发生"正是最难查的一种。第二次事故里，如果当时有
+`0 → 0` 的记录，五分钟就能定位到"SDK 没给描述符"这一层，而不是花几小时反复重启复现。
+
+---
+
+## 10. 安全边界
+
+| 边界 | 规则 |
+| --- | --- |
+| 下载时机 | **必须在准入之后**，否则是流量与磁盘放大器 |
+| 下载来源 | 只下载消息自带的引用；绝不下载消息正文里出现的 URL |
+| 大小 | 图片 ≤ 8 MB，音频 ≤ 10 MB，单轮图片 ≤ 4 张 |
+| 解压炸弹 | 沿用 Artifact 的像素上限校验 |
+| 字节留存 | 音频用完即删；图片留在缓存内由 TTL 管理；**均不进数据库、不进日志** |
+| 日志 | 只记 kind / mime / size / hash 前缀 / 原因码，**绝不记内容与路径全文** |
+| 群聊 | 群聊媒体沿用既有的 mention + 白名单准入，不放宽 |
+
+---
+
+## 11. 各渠道适配矩阵
+
+| | 飞书 | Telegram | Discord | 桌面/CLI |
+| --- | --- | --- | --- | --- |
+| 图片 | 已实现 | 待做 | 待做 | 已实现（Artifact） |
+| 语音 | 待做 | 待做 | 待做 | 不适用 |
+| 文件 | 待做 | 待做 | 待做 | 已实现 |
+| 引用形态 | `ResourceDescriptor` + 显式 resolve | `file_id` + getFile | attachment URL | 本地路径 |
+
+三个渠道的原生结构完全不同，但**都能翻译成 `MediaRef`**。这正是要有中间层的原因：
+Core 只认 `MediaRef`，加一个渠道只需要写一个翻译函数，不需要碰媒体管线本身。
+
+---
+
+## 12. 落地顺序
+
+| 步骤 | 内容 | 依赖 | 价值 |
+| --- | --- | --- | --- |
+| 1 | 迁移 v15：`inbound_media` 表；`_pending_images` 改为读写该表 | — | 修掉重启丢图 |
+| 2 | `MediaRef` 抽象 + 飞书 Adapter 改为产出 `MediaRef` | 1 | 为多渠道与多模态铺路 |
+| 3 | 不支持的类型改为**明确告知** | 2 | 立刻消除"发了没反应" |
+| 4 | 语音：`audio` Provider + 转写 + 回显 | 2、3 | Owner 能发语音 |
+| 5 | 图片格式扩展（webp/heic/gif → jpeg） | 2 | iPhone 可用 |
+| 6 | 删除 `resolve_model_route` 死代码 | — | 消除双规则 |
+| 7 | Telegram / Discord 媒体适配 | 2 | 补齐渠道 |
+
+步骤 1 和 3 优先级最高：一个修掉正在发生的数据丢失，一个用极小的改动消除最差的交互。
+
+---
+
+## 13. 测试策略（针对两次事故的直接教训）
+
+两次事故都**通过了全部单元测试**，因为假件比真实 SDK 宽松：第一次假件接受了真 SDK 不接受的
+构造关键字，第二次假件自带了真 SDK 里不存在的字段。
+
+因此本设计要求：
+
+1. **契约测试对着真实 SDK**：`tests/test_feishu_sdk_contract.py` 已经在做——静态签名比对，
+   不建连接、不需凭据，可以和其余单测无条件一起跑。每加一个渠道都要有对应的契约测试。
+2. **假件必须比真实实现更严格，而不是更宽松**：假件的作用是让测试快，不是让测试过。
+3. **反向验证**：每个防回归测试都要确认"把修复退回去，它真的会红"。本次两个修复都做过
+   这一步；没做过这一步的测试等于没测。
+4. **观测本身要有测试**：埋点失败不得成为新的故障源，且每种失败模式的原因码都要断言。
+
+---
+
+## 14. 明确不做
+
+- 不引入本地 ASR / 本地视觉模型：部署重量与收益不匹配；
+- 不做 TTS（语音输出）；
+- 不把文件内容自动塞进上下文——继续 Artifact + 按需读；
+- 不为多模态放宽群聊准入或 Owner 白名单；
+- 不把媒体字节写进数据库或日志。


### PR DESCRIPTION
飞书图片连续两次**静默失效**，且两次都通过了全部单测。本文档盘点实测现状，给出统一设计。

## 三个结构性问题

| 问题 | 后果 |
| --- | --- |
| `_pending_images` 只在内存 | Gateway 重启后重放消息**静默丢图** |
| "没有媒体"与"媒体丢了"长得一样 | 零痕迹，只能靠反复重启复现 |
| 模型路由两套实现，一套是死代码 | `resolve_model_route` 无调用方，改错地方无感知 |

外加一个业务事实：Owner 已经在用语音，而当前 Adapter 对 `audio` 直接返回 `unsupported_message`——**消息被安静丢掉**。

## 统一管线

```
MediaRef（渠道引用，不含内容）
   → InboundMedia（随入站事件持久化）
   → ModelPart（模型真正能吃的东西）
```

三层各有唯一职责，不允许跨层猜字段——两次事故都源于此。

## 关键取舍

**语音选择先转写成文字**，而不是换用原生音频模型。决定性理由是**可复查**：转写文本能进 failure case 可重放，音频字节不能；转写错了 Owner 当场能看出来，原生模型听错了没人知道。回答里必须回显转写结果。

**媒体存路径不存字节**：字节进数据库会让备份和 WAL 全部变重；路径失效是可检测的，状态转 `expired` 并明确告知。

**音频用完即删**：语音是最私密的输入形态，没有留存的正当理由。

**下载必须在准入之后**：放前面等于任何陌生人发张图就能让 Owner 的机器去下载。

## 落地顺序

优先级最高的是步骤 1（`inbound_media` 表，修掉正在发生的数据丢失）和步骤 3（不支持的类型改为明确告知，极小改动消除最差交互）。

## 测试教训写成硬要求

两次事故都是**假件比真实 SDK 宽松**放过去的。文档要求：契约测试对着真实 SDK；假件必须比真实实现更严格；每个防回归测试都要反向验证过"退回修复它真的会红"。

🤖 Generated with [Claude Code](https://claude.com/claude-code)