### PR TITLE
fix(feishu): 图片占位符不得当成 Owner 的提问发给模型

### DIFF
--- a/src/lobster0/channels/feishu.py
+++ b/src/lobster0/channels/feishu.py
@@ -29,6 +29,8 @@ from lobster0.storage.channels import StoredInboundEvent
 _MESSAGE_ID = re.compile(r"om_[A-Za-z0-9_-]{1,128}\Z")
 _OPEN_ID = re.compile(r"ou_[A-Za-z0-9_-]{1,128}\Z")
 _CHAT_ID = re.compile(r"oc_[A-Za-z0-9_-]{1,128}\Z")
+# SDK 的 image/post 转换器统一渲染成 ``![image](<file_key>)``；file_key 不含右括号。
+_IMAGE_PLACEHOLDER = re.compile(r"!\[image\]\([^)\s]*\)")
 
 
 class FeishuMessageView(Protocol):
@@ -86,10 +88,15 @@ class FeishuAdapter:
         # 这里只看描述符判断"这条消息带没带图"——判断是免费的，下载不是。真正的
         # 下载由 Transport 在准入通过之后再做，图片路径随后补上。
         has_image = bool(message.image_descriptors)
-        text = sanitize_inbound_text(message.body_text).strip()
+        # SDK 把图片消息渲染成 ``![image](file_key)`` 放进 body_text。这是**渲染产物**，
+        # 不是 Owner 打的字：真正的图片会作为 ImagePart 挂到请求上。把它留在正文里，
+        # 模型会以为 Owner 发来了一段坏掉的 Markdown 链接，然后去分析这段链接
+        # ——真实事故：模型收到了图，却回"你发的是没有 artifact_id 的 Markdown 链接"，
+        # 全程没有描述图里的任何内容。
+        text = sanitize_inbound_text(_strip_image_placeholders(message.body_text)).strip()
         if not text and has_image:
             # 只发图不配文字是常见用法；给一句中性提示，让这一轮不至于被当成空消息丢弃。
-            text = "请看这张图片。"
+            text = "请看这张图片。" if len(message.image_descriptors) == 1 else "请看这些图片。"
         if not text:
             return IgnoredInbound("empty_message")
         if len(text) > self._config.message_max_chars:
@@ -439,12 +446,19 @@ class FeishuTransport:
             # 下载必须发生在准入**之后**：resources 只是描述符，把它换成本地文件要真的
             # 走一次网络。放在准入前，任何陌生人发一张图就能让我们下载，等于送出一个
             # 免费的流量与磁盘放大器。
-            normalized = replace(
-                normalized,
-                image_paths=await self._resolve_images(
-                    view.message_id, view.image_descriptors
-                ),
+            paths = await self._resolve_images(
+                view.message_id, view.image_descriptors
             )
+            text = normalized.text
+            if view.image_descriptors and not paths:
+                # Owner 明明发了图，我们却一张都没取回。此时正文里那句"请看这张图片"
+                # 会让模型对着不存在的图编内容。把真实情况写进这一轮，让它照实说。
+                text = (
+                    f"{text}\n\n"
+                    "（系统提示：这条消息里的图片没能取回，你看不到它。"
+                    "请如实告诉我图片读取失败，不要猜测图片内容。）"
+                )
+            normalized = replace(normalized, image_paths=paths, text=text)
             await self._on_inbound(normalized)
         elif self._observer is not None:
             try:
@@ -643,6 +657,17 @@ def _cached_image_paths(resources: Any) -> tuple[tuple[Path, str], ...]:
             continue
         found.append((Path(item.path), str(item.mime_type)))
     return tuple(found)
+
+
+def _strip_image_placeholders(text: str) -> str:
+    """去掉 SDK 为图片渲染出的 ``![image](file_key)`` 占位符。
+
+    图文混排（post）里 Owner 的说明文字要原样保留，只摘掉占位符；纯图片消息摘完
+    就是空串，由调用方补一句中性提示。
+    """
+    if not isinstance(text, str) or "![image]" not in text:
+        return text if isinstance(text, str) else ""
+    return _IMAGE_PLACEHOLDER.sub(" ", text)
 
 
 def _image_drop_reason(item: Any) -> str:

--- a/tests/test_feishu_images.py
+++ b/tests/test_feishu_images.py
@@ -30,6 +30,27 @@ def _descriptor(resource_type: str = "image", file_key: str = "img_v3_x"):
     )
 
 
+def _sdk_shaped_image_message():
+    """构造一条**与真实 SDK 同形**的图片消息。
+
+    ``FakeFeishuMessage`` 是给 Adapter 用的扁平视图；``_handle_message`` 拿到的是
+    SDK 原始对象（``conversation.chat_id``、``sender.open_id``、``resources``），
+    形状完全不同。用错会被准入直接拒掉，测的就不是想测的东西了。
+    """
+    return SimpleNamespace(
+        id="om_x100b68eb5c93c0a0c3debeed80c1313",
+        conversation=SimpleNamespace(chat_id="oc_allowed", chat_type="p2p"),
+        sender=SimpleNamespace(open_id="ou_owner", sender_type="user", is_bot=False),
+        mentioned_bot=False,
+        body_text="![image](img_v3_x)",
+        raw_content_type="image",
+        resources=[_descriptor()],
+        reply=None,
+        raw={},
+        create_time=None,
+    )
+
+
 def _cached(
     *,
     decision: str = "cached",
@@ -105,6 +126,54 @@ class FeishuImageAdmissionTest(unittest.TestCase):
 
         assert isinstance(result, InboundMessage)
         self.assertEqual(result.image_paths, ())
+
+    def test_markdown_placeholder_never_reaches_the_model(self) -> None:
+        """``![image](key)`` 是 SDK 的渲染产物，不是 Owner 打的字，必须摘掉。
+
+        真实事故：模型收到了图，却盯着这段占位符回"你发的是没有 artifact_id 的
+        Markdown 链接"，全程没有描述图里任何内容。图片本身是作为 ImagePart 挂上去的，
+        占位符留在正文里只会把模型带偏。
+        """
+        result = self.adapter.normalize(
+            FakeFeishuMessage(
+                raw_content_type="image",
+                body_text="![image](img_v3_0214i_babf612d)",
+                image_descriptors=(_descriptor(),),
+            )
+        )
+
+        assert isinstance(result, InboundMessage)
+        self.assertNotIn("![image]", result.text)
+        self.assertNotIn("img_v3_0214i_babf612d", result.text)
+        self.assertEqual(result.text, "请看这张图片。")
+
+    def test_caption_survives_placeholder_stripping(self) -> None:
+        """图文混排时 Owner 的说明文字必须原样保留，只摘掉占位符。"""
+        result = self.adapter.normalize(
+            FakeFeishuMessage(
+                raw_content_type="post",
+                body_text="这个报错是什么意思 ![image](img_v3_abc) 帮我看看",
+                image_descriptors=(_descriptor(),),
+            )
+        )
+
+        assert isinstance(result, InboundMessage)
+        self.assertNotIn("![image]", result.text)
+        self.assertIn("这个报错是什么意思", result.text)
+        self.assertIn("帮我看看", result.text)
+
+    def test_multiple_images_get_plural_prompt(self) -> None:
+        """多图时提示语要说得通，不能仍旧写"这张图片"。"""
+        result = self.adapter.normalize(
+            FakeFeishuMessage(
+                raw_content_type="image",
+                body_text="![image](a) ![image](b)",
+                image_descriptors=(_descriptor(file_key="a"), _descriptor(file_key="b")),
+            )
+        )
+
+        assert isinstance(result, InboundMessage)
+        self.assertEqual(result.text, "请看这些图片。")
 
     def test_text_message_still_has_no_images(self) -> None:
         """纯文字消息必须保持原行为，不受本次改动影响。"""
@@ -193,6 +262,53 @@ class FeishuImageResolutionTest(unittest.IsolatedAsyncioTestCase):
         paths = await self.transport._resolve_images("om_x", (_descriptor(),))
 
         self.assertEqual(paths, ())
+
+
+class FeishuImageFailureHonestyTest(unittest.IsolatedAsyncioTestCase):
+    """取不回图时必须让模型照实说，而不是对着不存在的图编内容。"""
+
+    def setUp(self) -> None:
+        """构造一个下载必然失败的 Transport。"""
+        self.sdk = FakeOfficialSdk()
+        self.inbound: list[InboundMessage] = []
+        self.transport = FeishuTransport(
+            FeishuConfig(
+                enabled=True,
+                account_id="default",
+                owner_open_id="ou_owner",
+                allowed_open_ids=("ou_owner",),
+            ),
+            app_id="cli_x",
+            app_secret="secret",
+            on_inbound=self._collect,
+            sdk=self.sdk,
+        )
+
+    async def _collect(self, message: InboundMessage) -> None:
+        """记录进入管线的消息。"""
+        self.inbound.append(message)
+
+    async def test_unresolved_image_tells_the_model_it_cannot_see(self) -> None:
+        """图没取回来时，正文必须明确说明，否则模型会照着"请看这张图片"编。"""
+        self.sdk.channel.resolve_error = RuntimeError("network down")
+
+        await self.transport._handle_message(_sdk_shaped_image_message())
+
+        self.assertEqual(len(self.inbound), 1)
+        message = self.inbound[0]
+        self.assertEqual(message.image_paths, ())
+        self.assertIn("没能取回", message.text)
+        self.assertIn("不要猜测", message.text)
+
+    async def test_resolved_image_adds_no_failure_notice(self) -> None:
+        """图正常取回时不得插入任何失败提示，否则模型会自我怀疑。"""
+        self.sdk.channel.cached_resources = [_cached()]
+
+        await self.transport._handle_message(_sdk_shaped_image_message())
+
+        message = self.inbound[0]
+        self.assertEqual(len(message.image_paths), 1)
+        self.assertEqual(message.text, "请看这张图片。")
 
 
 class FeishuImageObservabilityTest(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## 埋点一次命中

上线后第一条图片消息就定位了：

```
descriptor_count=1 → resolved_count=1, outcome=resolved
```

图片**已经成功下载并挂上请求**，链路本身是通的。

## 真正的问题在正文

SDK 的 image 转换器把图片消息渲染成 `![image](<file_key>)` 放进 `body_text`，而 Adapter 把这段**渲染产物**原样当成 Owner 的提问交给了模型。

于是模型同时收到「一张真图」和「一句看起来像坏掉的 Markdown 链接」，然后去分析那段链接：

> 你发的是带原始图片内容的 Markdown 链接，但依然没有 `artifact_id`，所以我的工具 `read_artifact` 无法调用

全程没有描述图里任何内容——**它盯着管道，没看图**。

## 改动

- 摘掉 `![image](key)` 占位符；图文混排时 Owner 的说明文字原样保留
- 摘完为空且确实带图时补一句中性提示；多图用「这些图片」
- 描述符存在但一张都没取回时，正文里明确写「图片没能取回，你看不到它，请如实说明，不要猜测图片内容」——否则模型会照着「请看这张图片」编。取回成功时不插入任何提示，避免模型自我怀疑

## 测试

新增的 SDK 形状假消息说明了一个此前踩过的坑：`FakeFeishuMessage` 是给 Adapter 的扁平视图，`_handle_message` 拿到的是 SDK 原始对象（`conversation.chat_id`、`sender.open_id`、`resources`），形状完全不同——用错会被准入直接拒掉，测的就不是想测的东西。

## 验证

`2118 tests, OK (skipped=4)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)