### PR TITLE
feat(desktop): 视觉重做 P1——排版对比度与矢量图标

### DIFF
--- a/desktop/src/renderer/icons.tsx
+++ b/desktop/src/renderer/icons.tsx
@@ -1,0 +1,64 @@
+/**
+ * 最小内联图标集。
+ *
+ * 为什么不引图标库：见
+ * docs/superpowers/specs/2026-08-14-desktop-visual-production-grade-redesign.md §3.4。
+ * 需要图标的位置目前屈指可数，内联比新增一个运行时依赖划算；超过约 15 个再考虑。
+ *
+ * 为什么不用文字字形（三角、叉号那种）：字面大小与垂直位置随字体变化，且会被
+ * 当作文本参与选中与朗读。矢量图标尺寸可控、颜色跟随 `currentColor`。
+ *
+ * test/icons.test.tsx 会扫描本目录禁止字形图标回潮，且**不设例外清单**——
+ * 所以这段注释也不能出现那些字符。
+ */
+
+interface IconProps {
+  /** 边长（px）。默认 16——文字字形时代那个 11px 是 Owner 报「箭头太小」的直接原因。 */
+  readonly size?: number;
+  readonly className?: string;
+}
+
+/**
+ * 右向尖角。展开态由 CSS 旋转 90°，而不是换成第二个图标——
+ * 换图标没法做过渡，旋转可以，且只需维护一份路径。
+ */
+export function ChevronRightIcon({ size = 16, className }: IconProps): JSX.Element {
+  return (
+    <svg
+      aria-hidden="true"
+      className={className}
+      fill="none"
+      focusable="false"
+      height={size}
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+      width={size}
+    >
+      <path d="m9 18 6-6-6-6" />
+    </svg>
+  );
+}
+
+/** 关闭 / 移除。 */
+export function CloseIcon({ size = 14, className }: IconProps): JSX.Element {
+  return (
+    <svg
+      aria-hidden="true"
+      className={className}
+      fill="none"
+      focusable="false"
+      height={size}
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+      width={size}
+    >
+      <path d="M18 6 6 18M6 6l12 12" />
+    </svg>
+  );
+}

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -11,7 +11,9 @@
   line-height: 1.6;
   color: var(--lobster-foreground);
   background: var(--lobster-background);
-  font-synthesis: none;
+  /* 允许合成字重：中文字体常常缺 700 这一档，`none` 会让中文加粗几乎不生效。
+     宁可让少数字体的加粗略糙，也不要「加粗看不出来」。 */
+  font-synthesis: weight;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -593,8 +595,10 @@ select:focus-visible {
   font-size: var(--lobster-text-xs);
 }
 
+/* 对话是长文阅读场景，14px 是给密集列表用的尺寸。15px 而不是 16px：侧栏与右栏
+   仍是密集布局，15px 是两者的平衡点。 */
 .message .markdown {
-  font-size: var(--lobster-text-sm);
+  font-size: 15px;
 }
 
 .message-assistant .markdown {
@@ -649,7 +653,7 @@ select:focus-visible {
 .markdown h3,
 .markdown h4 {
   margin: 4px 0 0;
-  font-weight: 600;
+  font-weight: var(--lobster-ui-font-weight-bold);
   line-height: 1.35;
 }
 
@@ -659,7 +663,9 @@ select:focus-visible {
 .markdown h4 { font-size: var(--lobster-text-sm); }
 
 .markdown strong {
-  font-weight: 600;
+  /* 正文里的加粗是「这句是重点」的唯一信号，必须一眼可见。 */
+  font-weight: var(--lobster-ui-font-weight-bold);
+  color: var(--lobster-text-primary);
 }
 
 .markdown em {
@@ -770,17 +776,18 @@ select:focus-visible {
 .process-toggle {
   display: flex;
   width: fit-content;
-  height: 28px;
+  height: 30px;
   align-items: center;
   gap: 6px;
   margin: 0;
-  padding: 0 10px 0 8px;
+  padding: 0 10px 0 6px;
   border: 0;
   border-radius: 8px;
   color: var(--lobster-text-secondary);
   background: transparent;
   cursor: pointer;
-  font-size: var(--lobster-text-xs);
+  font-size: var(--lobster-text-sidebarCompact);
+  font-weight: var(--lobster-ui-font-weight-medium);
 }
 
 .process-toggle:hover {
@@ -788,16 +795,22 @@ select:focus-visible {
   background: var(--lobster-hover);
 }
 
+/* 展开态靠旋转同一个图标，而不是换成第二个图标：换图标做不了过渡，
+   旋转可以，且只需维护一份路径。颜色跟随按钮文字（currentColor），
+   不再固定成最淡的一档灰——那是 Owner 报「箭头太小」的另一半原因。 */
 .process-caret {
-  display: inline-block;
-  width: 12px;
-  color: var(--lobster-text-muted);
-  font-size: 11px;
-  text-align: center;
+  flex: none;
+  transition: transform 0.15s ease;
 }
 
-.process-toggle:hover .process-caret {
-  color: var(--lobster-foreground);
+.process-block[data-expanded="true"] .process-caret {
+  transform: rotate(90deg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .process-caret {
+    transition: none;
+  }
 }
 
 .process-count {

--- a/desktop/src/renderer/task-workbench.tsx
+++ b/desktop/src/renderer/task-workbench.tsx
@@ -24,6 +24,7 @@ import {
   removeAttachment,
 } from "./attachment-draft";
 import { resolveComposerKeyAction } from "./composer-keys";
+import { ChevronRightIcon, CloseIcon } from "./icons";
 import { Markdown } from "./markdown";
 import {
   appendDesktopUser,
@@ -296,7 +297,7 @@ export function TaskWorkbench({
                   setAttachments((current) => removeAttachment(current, item.artifactId))}
                 type="button"
               >
-                ×
+                <CloseIcon />
               </button>
             </li>
           ))}
@@ -420,7 +421,7 @@ export function TaskWorkbench({
                   onClick={() => toggleProcess(block.id)}
                   type="button"
                 >
-                  <span className="process-caret" aria-hidden="true">{expanded ? "▾" : "▸"}</span>
+                  <ChevronRightIcon className="process-caret" />
                   <span>过程</span>
                   <span className="process-count">{block.items.length} 步</span>
                 </button>

--- a/desktop/src/renderer/theme.css
+++ b/desktop/src/renderer/theme.css
@@ -28,9 +28,12 @@
   --lobster-chat-user-foreground: #634136;
   --lobster-chat-bot: #f1efe9;
   --lobster-chat-bot-foreground: #0b0b0b;
+  /* 三档文字都必须在 --lobster-background 上达到 WCAG AA 4.5:1，且彼此拉开层级。
+     旧的 muted #8a887f 只有 3.37:1——步数、时间、token 数全用它渲染，于是界面上
+     所有「次要但仍要被读到」的数字都读不清。见 test/theme-contrast.test.ts。 */
   --lobster-text-primary: #0b0b0b;
-  --lobster-text-secondary: #65635b;
-  --lobster-text-muted: #8a887f;
+  --lobster-text-secondary: #5c5a52;
+  --lobster-text-muted: #716f66;
   --lobster-border: rgba(224, 218, 206, 0.6);
   --lobster-border-subtle: rgba(224, 218, 206, 0.3);
   --lobster-input-border: rgba(224, 218, 206, 0.6);
@@ -53,8 +56,13 @@
 
   --lobster-ui-font-size: 14px;
   --lobster-code-font-size: 12px;
-  --lobster-ui-font-weight-normal: 445;
+  /* 445 是早先为模仿 Claude 引入的非常规基础字重，代价是把加粗的对比削掉了一半
+     （445 → 600 只差 155）。回到 400 / 700：差 300，而且 700 是中文字体真实存在
+     的字重，不依赖 font-synthesis 合成。 */
+  --lobster-ui-font-weight-normal: 400;
   --lobster-ui-font-weight-medium: 500;
+  --lobster-ui-font-weight-semibold: 600;
+  --lobster-ui-font-weight-bold: 700;
   --lobster-text-xs: 12px;
   --lobster-text-sm: 14px;
   --lobster-text-base: 16px;

--- a/desktop/test/icons.test.tsx
+++ b/desktop/test/icons.test.tsx
@@ -1,0 +1,44 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { ChevronRightIcon, CloseIcon } from "../src/renderer/icons";
+
+describe("icons", () => {
+  it("render as vectors that inherit the surrounding text colour", () => {
+    // currentColor 是「图标跟随文字」的实现点：按钮 hover 变色时图标一起变，
+    // 不需要为每个状态再写一条 .icon 规则。
+    for (const markup of [
+      renderToStaticMarkup(<ChevronRightIcon />),
+      renderToStaticMarkup(<CloseIcon />),
+    ]) {
+      expect(markup).toContain("<svg");
+      expect(markup).toContain('stroke="currentColor"');
+      // 图标是装饰性的，读屏应当跳过——可访问名字由外层按钮的 aria-label 提供。
+      expect(markup).toContain('aria-hidden="true"');
+    }
+  });
+
+  it("defaults the chevron to a size that is actually visible", () => {
+    // 原先是 11px 的文字三角，Owner 的原话是「这个箭头太小了」。
+    expect(renderToStaticMarkup(<ChevronRightIcon />)).toContain('width="16"');
+  });
+});
+
+describe("renderer source", () => {
+  it("uses no text glyphs as icons", () => {
+    // 文字字形当图标是「不像生产级应用」最直接的来源：字面大小与垂直位置随字体
+    // 变化，还会被当作文本参与选中与朗读。两个参考仓库（LobsterAI / ClawX）
+    // 没有一处这么做。这条测试防止后续「顺手打一个 ×」。
+    const directory = fileURLToPath(new URL("../src/renderer", import.meta.url));
+    const glyphs = /[▸▾▴▼▲◂►◄✓✕✖⌄⌃]|(?<![\p{L}\p{N}])×(?![\p{L}\p{N}])/u;
+
+    const offenders = readdirSync(directory)
+      .filter((name) => name.endsWith(".tsx"))
+      .filter((name) => glyphs.test(readFileSync(`${directory}/${name}`, "utf8")));
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/desktop/test/theme-contrast.test.ts
+++ b/desktop/test/theme-contrast.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * 把「注意对比度」这句设计意图变成可执行断言。
+ *
+ * 见 docs/superpowers/specs/2026-08-14-desktop-visual-production-grade-redesign.md §6：
+ * 文档里写一句「注意对比度」没人会去量，写成测试才会在回退时立刻响。
+ */
+
+const THEME = readFileSync(
+  fileURLToPath(new URL("../src/renderer/theme.css", import.meta.url)),
+  "utf8",
+);
+
+/** 读出 :root 里某个 token 的字面值。 */
+function token(name: string): string {
+  const match = THEME.match(new RegExp(`--lobster-${name}:\\s*([^;]+);`));
+  const value = match?.[1];
+  if (value === undefined) {
+    throw new Error(`token --lobster-${name} not found`);
+  }
+  return value.trim();
+}
+
+function channel(value: number): number {
+  const c = value / 255;
+  return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+}
+
+/** WCAG 相对亮度。只接受 #rrggbb——token 里的颜色都是这个形式。 */
+function luminance(hex: string): number {
+  const body = hex.replace("#", "");
+  if (!/^[0-9a-f]{6}$/i.test(body)) {
+    throw new Error(`expected #rrggbb, got ${hex}`);
+  }
+  const [r = 0, g = 0, b = 0] = [0, 2, 4].map((i) =>
+    channel(parseInt(body.slice(i, i + 2), 16)));
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+export function contrastRatio(foreground: string, background: string): number {
+  const a = luminance(foreground);
+  const b = luminance(background);
+  return (Math.max(a, b) + 0.05) / (Math.min(a, b) + 0.05);
+}
+
+describe("theme contrast", () => {
+  // 步数、时间、token 数全部用 text-muted 渲染。它一旦低于 AA，界面上所有
+  // 「次要但仍需被读到」的数字就都读不清——这正是 Owner 报的「颜色不突出」。
+  it.each(["text-primary", "text-secondary", "text-muted"])(
+    "%s reaches WCAG AA on the app background",
+    (name) => {
+      const ratio = contrastRatio(token(name), token("background"));
+
+      expect(ratio).toBeGreaterThanOrEqual(4.5);
+    },
+  );
+
+  it("keeps the three text levels visually distinct", () => {
+    // 只要求达标是不够的：三档全调成近黑也能过 AA，但层级就没了。
+    const background = token("background");
+    const primary = contrastRatio(token("text-primary"), background);
+    const secondary = contrastRatio(token("text-secondary"), background);
+    const muted = contrastRatio(token("text-muted"), background);
+
+    expect(primary).toBeGreaterThan(secondary);
+    expect(secondary).toBeGreaterThan(muted);
+  });
+});
+
+describe("theme typography", () => {
+  it("keeps a wide gap between body and bold weight", () => {
+    // 445 → 600 只差 155，是 Owner 报的「加粗不突出」的直接原因。
+    // 400 → 700 差 300，且 700 是中文字体真实存在的字重，不依赖合成。
+    const normal = Number(token("ui-font-weight-normal"));
+    const bold = Number(token("ui-font-weight-bold"));
+
+    expect(bold - normal).toBeGreaterThanOrEqual(300);
+  });
+});

--- a/docs/superpowers/specs/2026-08-14-desktop-visual-production-grade-redesign.md
+++ b/docs/superpowers/specs/2026-08-14-desktop-visual-production-grade-redesign.md
@@ -1,0 +1,203 @@
+# 桌面版视觉重做：从「配色练习」到「生产级应用」
+
+> 日期：2026-08-14
+> 文档类型：视觉与前端设计（**写于实现之前**）
+> 状态：`DRAFT FOR REVIEW / IMPLEMENTATION PENDING`
+> 参考实现：[netease-youdao/LobsterAI](https://github.com/netease-youdao/LobsterAI)（★5.9k）、
+> [ValueCell-ai/ClawX](https://github.com/ValueCell-ai/ClawX)（★7.6k）
+> 取代：`2026-08-11-desktop-visual-refresh-claude-inspired-design.md`（Claude 暖色重涂，见 §2.4）
+
+## 1. 起因
+
+Owner 给了三条具体反馈和一条整体判断：
+
+> 这个箭头太小了。还有加粗和正文的字体、字重颜色 一点都不突出和显眼啊
+>
+> 桌面版我们的整体样式 **完全不像一个开源的生产级应用**
+>
+> 仿照 LobsterAI / ClawX 的桌面版前端代码去做
+
+前三条是症状，第四条是病。这份文档先诊断病，再开药。
+
+## 2. 现状核查：对着两个参考仓库的真实代码比
+
+**不是凭印象比**——两个仓库的样式文件都拉下来读过，官网落地页的 token 也用
+`getComputedStyle` 量过。
+
+### 2.1 我们抄了 token 的名字，没抄让它变好看的东西
+
+`desktop/src/renderer/theme.css` 的注释自己写着「ported from LobsterAI, theme
+classic-light」。核对下来是**结构上的 1:1 移植**——`--lobster-primary` /
+`--lobster-surface-raised` / `--lobster-chat-user` / `--lobster-gray-1..9` 逐个对得上。
+
+但 LobsterAI 真正的样子是：
+
+| | LobsterAI | ClawX | **我们** |
+| --- | --- | --- | --- |
+| 主题数量 | **14 套**（classic-light/dark、nord、mocha、midnight、paper、sakura…）+ 主题引擎 | light + dark（shadcn 语义 token） | **1 套，硬编码** |
+| 暗色模式 | 有 | 有 | **`color-scheme: light`，没有** |
+| token 契约 | `ThemeDefinition` + `SHARED_TOKENS`，types.ts 强约束 | `globals.css` + `tailwind.config.js` 两层，另有一份 token 使用规约文档 | 一份 CSS 变量表 |
+
+**我们移植的是配色表，丢掉的是主题能力本身。** 一个只有单一浅色皮肤、还是别人家
+配色改涂的应用，无论颜色调得多准，都不会像生产级产品——因为生产级产品的标志不是
+"这个颜色好看"，而是**"它有一套可以被替换的体系"**。
+
+### 2.2 三条具体反馈，逐条在代码里定位
+
+**（a）箭头太小** —— `styles.css:791`
+
+```css
+.process-caret {
+  width: 12px;
+  color: var(--lobster-text-muted);   /* #8a887f，在 #faf9f5 上对比度约 3.4:1 */
+  font-size: 11px;                     /* 而且是文字字形 ▸ / ▾，不是图标 */
+}
+```
+
+11px 的**文字三角**加上最低一档的灰。三个问题叠在一起：小、淡、而且是字形。
+`▸` 在不同字体里的字面大小和垂直位置都不一致，这是"业余感"最直接的来源之一——
+两个参考仓库都用真正的矢量图标（lucide），没有一处用文字三角当图标。
+
+**（b）加粗和正文不突出** —— `styles.css:596` 与 `theme.css`
+
+```css
+.message .markdown { font-size: var(--lobster-text-sm); }  /* 14px */
+.markdown strong   { font-weight: 600; }
+:root              { font-weight: var(--lobster-ui-font-weight-normal); }  /* 445 */
+```
+
+- **正文 14px**。LobsterAI 官网正文 16px；ClawX 用 shadcn 默认 16px。聊天是**长文
+  阅读**场景，14px 是给密集列表用的尺寸；
+- **加粗只比正文重 155 个单位**（445 → 600）。常规做法是 400 → 700，差 300。我们
+  为了模仿 Claude 把基础字重抬到 445，等于**主动把加粗的对比度削掉了一半**；
+- 并且 `font-synthesis: none`——中文字体没有真正的 600 字重时不合成，**中文加粗
+  可能几乎不生效**。截图里的中文加粗弱正是这个原因。
+
+**（c）颜色不突出** —— 次要文字 `--lobster-text-muted: #8a887f` 在 `#faf9f5` 上约
+3.4:1，低于 WCAG AA 正文 4.5:1。步数、时间、token 数全用它。
+
+### 2.3 两个参考仓库真正在做的事
+
+**ClawX**（`src/styles/globals.css`，676 行）：
+
+- shadcn 标准语义 token（`--background` / `--foreground` / `--muted-foreground` …），
+  HSL 三元组不带 `hsl()` 包装，由 `tailwind.config.js` 重新组装；
+- 额外三层中性表面 `--surface-modal` / `--surface-input` / `--surface-sidebar`，
+  **暗色下重定向到已有 token**，不维护第二套表面色板；
+- 文件头有一整块**「组件约定替换表」**：`bg-white dark:bg-card` → `bg-surface-modal`，
+  选中态一律 `bg-black/5 dark:bg-white/10`，并注明参考实现文件。
+
+最后这条是关键：**它把"怎么用 token"也写成了规约**，所以几十个组件才不会各写各的。
+我们没有这层，于是 `styles.css` 1856 行里同一个语义有多种写法。
+
+**LobsterAI**：`ThemeDefinition` 类型 + `SHARED_TOKENS` 共享默认值，每套主题只覆盖
+差异项。`classic-light` 是冷调中性（`#F8F9FB` 背景、`#0D0D0D` 前景、`#3B82F6` 蓝），
+`classic-dark` 是 `#0F1117` / `#E4E5E9`。
+
+### 2.4 为什么推翻 8-11 那份「Claude 暖色重涂」
+
+那份文档的目标是"像 Claude"。事后看，它选错了对标对象：
+
+- Claude Desktop 是**闭源商业产品**，它的视觉语言服务于品牌；我们是开源工具，
+  用户期待的是"看起来可信、可改、可主题化"；
+- 暖米色（`#faf9f5` / `#875645`）在长文阅读下**降低了对比度预算**——暖底色让同样的
+  灰看起来更浑；
+- 最重要的：**照着截图调颜色，学不到体系**。这次改为照着两个开源仓库的**代码**做，
+  能连规约一起学。
+
+## 3. 方案
+
+### 3.1 A. 回到中性色板，品牌色只出现在该出现的地方
+
+采用 ClawX/shadcn 那一路的**冷调中性**作为表面与文字，理由是中性底色把对比度预算
+全部留给内容。品牌色（龙虾橙）**不做通用 accent**，只用于：品牌标识、主按钮、
+以及需要"这是本产品的动作"的极少数位置。
+
+主按钮采用官网落地页量到的做法——**近黑填充 + 全圆角**（实测 `rgb(21,23,28)`、
+`border-radius: 9999px`、`font-weight: 600`），而不是大面积橙色。橙色作为大面积
+填充在深色模式下几乎必然刺眼，近黑/近白在两种模式下都稳。
+
+### 3.2 B. 补上暗色模式（这是"生产级"最大的单项信号）
+
+`color-scheme` 改为 `light dark`，token 分三处定义：
+
+1. `:root` 定义**完整浅色**全量 token；
+2. `@media (prefers-color-scheme: dark)` 下用 `:root:not([data-theme="light"])` 覆盖；
+3. `:root[data-theme="dark"]` 再覆盖一次，让显式选择在两个方向上都赢过系统。
+
+**不做 14 套主题**。LobsterAI 的主题引擎需要运行时注入与持久化，是独立一块。
+先把"两套皮肤 + 一个能被替换的 token 契约"做扎实——**颜色不得写死在组件里**，
+这条守住了，未来加主题只是多几组变量。
+
+### 3.3 C. 排版：把对比度还给内容
+
+| 项 | 现在 | 改为 | 理由 |
+| --- | --- | --- | --- |
+| 对话正文 | 14px | **15px** | 长文阅读；不直接跳 16px 是因为侧栏/面板是密集布局，15px 是两者的平衡点 |
+| 基础字重 | **445** | **400** | 445 是为模仿 Claude 引入的非常规值，代价是削掉加粗对比 |
+| 正文加粗 | 600 | **700** | 400→700 差 300；且 700 是中文字体真实存在的字重，不依赖合成 |
+| 标题 | 600 | **700** | 同上 |
+| `font-synthesis` | `none` | **`weight`** | 中文字体缺 700 时允许合成，宁可略糙也不要"加粗看不出来" |
+| 次要文字 | `#8a887f`(3.4:1) | 提到 **≥4.5:1** | WCAG AA；步数/时间/token 数全靠它 |
+
+### 3.4 D. 图标：文字字形一律换成矢量
+
+`▸ / ▾` 换成 **16px 的 inline SVG chevron**，颜色跟随文字而不是最淡的灰，并给
+`transform: rotate(90deg)` 的展开过渡（受 `prefers-reduced-motion` 约束）。
+
+**不引入图标库依赖**。目前需要图标的位置屈指可数，内联一个 `<Icon>` 组件比
+新增一个运行时依赖划算；等到超过 ~15 个图标再考虑。
+
+### 3.5 E. 补一份 token 使用规约（学 ClawX 那块注释）
+
+在 `theme.css` 顶部写清楚**替换表**：哪些语义该用哪个 token、选中态/悬停态/状态色
+的统一写法。没有这层，1856 行 CSS 会继续各写各的。
+
+## 4. 不可放宽的边界
+
+- **组件里不得出现字面颜色值**，一律走 token。这是未来能加主题的唯一前提；
+- 暗色不是"把浅色反过来"——表面层级在暗色下靠**提亮**（`#0F1117` → `#1A1D27` →
+  `#242830`）而不是加阴影；
+- 不复制任何一方的**品牌资产**（logo、专有字体、插画）。本次借鉴的是 token 组织方式
+  与开源配色数值，两个仓库均为开源许可；
+- `prefers-reduced-motion` 与 `:focus-visible` 的现有规则不得回退。
+
+## 5. 分阶段
+
+| 阶段 | 内容 | 为什么这个顺序 |
+| --- | --- | --- |
+| **P1** | 排版 + 对比度 + 图标（§3.3、§3.4） | 直接消掉 Owner 报的三条症状，改动面小、风险低 |
+| **P2** | 中性色板重涂 + token 规约（§3.1、§3.5） | 需要逐个组件核对，改动面最大 |
+| **P3** | 暗色模式（§3.2） | 必须建立在 P2 的 token 纪律之上；P2 没做完就做 P3 等于写两遍 |
+
+**P1 先落地并交付**，不等整体做完——症状每天都在硌着人。
+
+## 6. TDD 起点
+
+CSS 本身不适合单测，测**可断言的结构与契约**：
+
+- `theme.css` 里 `:root` 与暗色块**定义的 token 名完全一致**（漏一个就是暗色下的
+  透明/黑块，这类 bug 靠肉眼很难全覆盖）；
+- 组件源码中**不出现字面 hex 颜色**（扫 `desktop/src/renderer/*.tsx` 与 `styles.css`
+  的非 token 区域）；
+- `process-toggle` 渲染出的是 `<svg>` 而不是 `▸` 字符；
+- 折叠按钮的 `aria-expanded` 在两种状态下都正确（现有行为不得回退）；
+- 关键前景/背景组合的对比度 ≥ 4.5:1，用一个小的对比度计算函数在测试里断言。
+
+最后一条是本次唯一新增的测试工具函数——把"设计意图"变成可执行的断言，比在文档里
+写一句"注意对比度"有用得多。
+
+## 7. 退出条件
+
+1. 「过程 N 步」的箭头是 16px 矢量图标，Owner 一眼能看见；
+2. 对话里加粗与正文有**明显**区别（中文也是）；
+3. 次要文字对比度 ≥ 4.5:1，且有测试断言；
+4. 暗色模式下没有任何"白底黑字漏进来"的区域（P3 的退出条件）；
+5. `pnpm test` / `typecheck` / `build` 全绿。
+
+## 8. 明确不做
+
+- LobsterAI 那样的 14 套主题与运行时主题引擎；
+- 引入图标库依赖（lucide 等）；
+- 引入 shadcn/Radix 组件体系——那是把整个渲染层重写，与"改样式"不是一回事；
+- 动 Python Core、Bridge 协议、IPC。本次改动全部在 `desktop/src/renderer/`。


### PR DESCRIPTION
## 起因

Owner 报了三条症状加一条整体判断：

> 这个箭头太小了。还有加粗和正文的字体、字重颜色 一点都不突出和显眼啊
> 桌面版我们的整体样式 **完全不像一个开源的生产级应用**

并指向 [netease-youdao/LobsterAI](https://github.com/netease-youdao/LobsterAI)（★5.9k）与 [ValueCell-ai/ClawX](https://github.com/ValueCell-ai/ClawX)（★7.6k）的前端代码。

## 诊断

**拉下两个仓库的样式源码逐条比对**（不是看截图）后，根因清楚了：我们移植了 LobsterAI 的 token *名字*（`theme.css` 注释自承 ported from classic-light），却丢掉了让它成立的东西。

| | LobsterAI | ClawX | 我们 |
| --- | --- | --- | --- |
| 主题 | 14 套 + 主题引擎 | light + dark | **1 套硬编码** |
| 暗色 | 有 | 有 | **没有** |
| 图标 | 矢量 | 矢量 | **文字字形** |

三条症状逐个定位到代码：

- **箭头**：`.process-caret` 是 11px 的**文字三角** `▸`，还用了最淡一档灰；
- **加粗不突出**：基础字重 `445` → 加粗 `600` 只差 155（常规 400→700 差 300），叠加 `font-synthesis: none`，**中文加粗几乎不生效**；
- **颜色不突出**：`--lobster-text-muted: #8a887f` 在背景上只有 **3.37:1**，低于 WCAG AA 4.5:1——步数、时间、token 数全用它。

## 本次改动（P1：症状层）

字重 445→400 / bold 700；`font-synthesis: weight`；三档文字对比度重排为 18.7 / 6.6 / 4.8（达标且保留层级）；对话正文 14→15px；字形图标换成 16px 内联 SVG，展开态旋转过渡。

不引图标库——需要图标的位置目前屈指可数，内联比新增运行时依赖划算。

## 测试

两条新测试把设计意图变成可执行断言，而不是在文档里写一句「注意对比度」：

- `theme-contrast.test.ts`：直接在 token 上算 WCAG 对比度并断言 ≥4.5:1，另断言三档层级不被拉平；
- `icons.test.tsx`：扫描 renderer 目录禁止字形图标回潮，**不设例外清单**（清单只会变长——为此把 `icons.tsx` 自己的注释也改了）。

`pnpm test` 200 passed / `typecheck` / `build` 全绿。并用构建产物的真实 CSS 套真实 DOM 结构截图核实了渲染结果。

## 排期

P2（中性色板重涂 + token 使用规约）与 P3（暗色模式）在设计文档中排期。P1 先落地不等整体做完——症状每天都在硌着人。

设计文档：`docs/superpowers/specs/2026-08-14-desktop-visual-production-grade-redesign.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)