### PR TITLE
fix(turn): 上下文压缩把这一轮的图片丢了

### DIFF
--- a/src/lobster0/agent/turn.py
+++ b/src/lobster0/agent/turn.py
@@ -475,6 +475,27 @@ class TurnService:
                 disclosure=disclosure,
                 tools=self._runner.tool_schemas,
             )
+            if self._compactor is not None and self._compactor.should_compact(request):
+                if self._memory_capture is not None:
+                    self._memory_capture.flush()
+                compacted = await self._compactor.compact(session.id)
+                if compacted is not None:
+                    history = tuple(
+                        _model_message(message)
+                        for message in self._messages.list_context(session.id)
+                    )
+                    request = self._context.build(
+                        self._model,
+                        history,
+                        disclosure=disclosure,
+                        tools=self._runner.tool_schemas,
+                    )
+            # 挂图必须在压缩**之后**：压缩会用新的 history 把 request 整个重建，
+            # 挂在重建之前的图片会被无声丢弃。真实事故——图片在 Channel 层已经
+            # 下载成功（descriptor 1 → resolved 1），Owner 的会话有 972 条消息，
+            # 每一轮都触发压缩，于是模型每次都收不到图，只能说"我看不到图片"，
+            # 被追问后开始编造画面细节。
+            #
             # 图片字节只在这一刻读出来：上传时不读，纯文字轮次也不读。
             # 读失败不能让整轮挂掉——附件仍以文字摘要留在上下文里，
             # 模型可以用 read_artifact 按需读取。
@@ -494,21 +515,6 @@ class TurnService:
                     )
                 except (OSError, ValueError):
                     pass
-            if self._compactor is not None and self._compactor.should_compact(request):
-                if self._memory_capture is not None:
-                    self._memory_capture.flush()
-                compacted = await self._compactor.compact(session.id)
-                if compacted is not None:
-                    history = tuple(
-                        _model_message(message)
-                        for message in self._messages.list_context(session.id)
-                    )
-                    request = self._context.build(
-                        self._model,
-                        history,
-                        disclosure=disclosure,
-                        tools=self._runner.tool_schemas,
-                    )
             tool_context = ToolContext(
                 user_id=user_id,
                 session_id=session.id,

--- a/tests/test_channel_manager.py
+++ b/tests/test_channel_manager.py
@@ -62,6 +62,7 @@ class TrackingTurnService:
     approval_id: int | None = None
     emit_event: bool = True
     calls: list[tuple[str, str]] = field(init=False, default_factory=list)
+    image_path_calls: list[tuple] = field(init=False, default_factory=list)
     trusted_calls: list[bool] = field(init=False, default_factory=list)
     conversation_kinds: list[str] = field(init=False, default_factory=list)
     verified_identity_calls: list[bool] = field(init=False, default_factory=list)
@@ -93,6 +94,7 @@ class TrackingTurnService:
         self.trusted_calls.append(trusted_owner)
         self.conversation_kinds.append(conversation_kind)
         self.verified_identity_calls.append(identity_verified)
+        self.image_path_calls.append(image_paths)
         session = self.sessions.get_or_create(
             user_id,
             channel,
@@ -1616,6 +1618,40 @@ class ChannelManagerTest(unittest.IsolatedAsyncioTestCase):
         assert target is not None
         self.assertEqual(target.role, "assistant")
 
+    async def test_image_paths_reach_the_turn_service(self) -> None:
+        """图片必须真的穿过 Manager 到达 TurnService。
+
+        此前假 Service 收下了 image_paths 却从不记录，于是"图片能不能穿过管理器"
+        从来没有被验证过。真实症状：图在 Channel 层已经下载成功
+        （descriptor 1 → resolved 1），模型却说看不到——因为它根本没拿到。
+        """
+        service = TrackingTurnService(self.sessions, self.messages, self.turns)
+        manager = self._manager(service, queue_size=4, worker_count=1)
+        paths = ((Path("/tmp/cached.png"), "image/png"),)
+        await manager.start()
+        try:
+            await manager.receive(
+                self._message("om_img", "看看这张图", image_paths=paths)
+            )
+            await manager.wait_idle(timeout=2)
+        finally:
+            await manager.stop()
+
+        self.assertEqual(service.image_path_calls, [paths])
+
+    async def test_text_only_turn_carries_no_images(self) -> None:
+        """纯文字轮次不得凭空带上图片——否则会白白切到视觉模型。"""
+        service = TrackingTurnService(self.sessions, self.messages, self.turns)
+        manager = self._manager(service, queue_size=4, worker_count=1)
+        await manager.start()
+        try:
+            await manager.receive(self._message("om_text", "你好"))
+            await manager.wait_idle(timeout=2)
+        finally:
+            await manager.stop()
+
+        self.assertEqual(service.image_path_calls, [()])
+
     def _manager(
         self,
         service: TrackingTurnService,
@@ -1654,6 +1690,7 @@ class ChannelManagerTest(unittest.IsolatedAsyncioTestCase):
         chat_type: str = "p2p",
         external_user_id: str = "ou_owner",
         replied_to_message_id: str = "",
+        image_paths: tuple = (),
     ) -> InboundMessage:
         """创建一条标准化飞书消息。"""
         return InboundMessage(
@@ -1666,6 +1703,7 @@ class ChannelManagerTest(unittest.IsolatedAsyncioTestCase):
             chat_type=chat_type,
             message_type="text",
             text=text,
+            image_paths=image_paths,
             reply_to_message_id=message_id,
             replied_to_message_id=replied_to_message_id,
             received_at=datetime(2026, 8, 8, tzinfo=UTC),

--- a/tests/test_turn.py
+++ b/tests/test_turn.py
@@ -1684,5 +1684,63 @@ class TurnServiceTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(tool_status, "succeeded")
 
 
+class CompactionKeepsImagesTest(TurnServiceTest):
+    """上下文压缩不得把这一轮的图片丢掉。
+
+    真实事故：图片在 Channel 层已经下载成功（descriptor 1 → resolved 1），
+    但 Owner 的会话有 972 条消息，每一轮都触发压缩。压缩会用新的 history 把
+    request **整个重建**，而挂图发生在重建之前，于是图片每次都被无声丢弃。
+    模型只能说"我看不到图片"，被追问后开始编造画面细节。
+
+    链路上每一段单独看都是对的，最后一步把图扔了——这正是集成断言存在的意义。
+    """
+
+    async def test_images_survive_a_compaction_rebuild(self) -> None:
+        """压缩重建之后，请求上必须仍然带着这一轮的图片。"""
+        image = self.paths.workspace / "shot.png"
+        # 只需非空字节：读取路径不校验 PNG 结构，ImagePart 只要求非空 + 合法 MIME。
+        image.write_bytes(b"\x89PNG\r\n\x1a\n fake image bytes")
+
+        provider = FakeProvider([final_response("看到了")])
+        service = self.service(provider)
+        service._compactor = _AlwaysCompact(self.messages)
+
+        await service.handle_inbound(
+            user_id=self.owner.id,
+            channel="feishu",
+            account_id="default",
+            external_conversation_id="oc_img",
+            inbound_event_id="om_img",
+            text="看看这张图",
+            image_paths=((image, "image/png"),),
+        )
+
+        request = provider.requests[-1]
+        attached = [part for message in request.messages for part in message.images]
+        self.assertEqual(len(attached), 1, "压缩之后图片丢了")
+        self.assertEqual(attached[0].media_type, "image/png")
+
+
+class _AlwaysCompact:
+    """必定触发一次压缩重建的 Compactor 替身。"""
+
+    def __init__(self, messages) -> None:
+        self._messages = messages
+        self.compacted = False
+
+    def should_compact(self, request) -> bool:
+        """只压一次，避免与真实预算耦合。"""
+        return not self.compacted
+
+    async def compact(self, session_id: int):
+        """返回一个非 None 结果，触发 turn.py 里的 request 重建分支。"""
+        self.compacted = True
+        return self._messages.latest_compaction(session_id) or _StubCompaction()
+
+
+class _StubCompaction:
+    """只需要"不是 None"，内容不参与断言。"""
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 根因

挂图发生在压缩检查**之前**；压缩命中时会用新的 history 把 `request` **整个重建**，挂在重建之前的 `ImagePart` 随之无声消失。

Owner 那个会话有 **972 条消息**，每一轮都触发压缩，于是图片每次都被丢掉。

把挂图移到压缩重建之后即可——**顺序问题，不是逻辑问题**。

## 为什么排查了这么久

链路上每一段单独看都是对的，而且都验证过：

| 环节 | 验证结果 |
| --- | --- |
| Transport | 真实凭据实测，图片下载成本地文件（`decision=cached`，`image/jpeg`，176 KB） |
| 观测埋点 | `descriptor_count=1 → resolved_count=1, outcome=resolved` |
| Manager | 新增集成测试，`image_paths` 确实穿过管理器到达 TurnService |
| 视觉后端 | `providers` 有 `vision`，`LOBSTER0_VISION_MODEL=qwen3-vl-flash`，key 存在 |

**最后一步把图扔了，而那一步没有任何断言。** `turns` 表显示这一轮用的是 `deepseek-v4-pro` 而不是视觉模型——请求里没有图，`VisionSwitchingProvider` 自然不会切换。

## 对 Owner 的直接影响

模型收不到图，只能说「我看不到图片」。Owner 反复追问后，模型开始顺着话**编造画面细节**（"绿色紧身裤、蓝帽、粉色鞋尖"），随后又自行纠正说那是编的。

这是最坏的一种失败：它不是坏在明处，而是让人无法判断该信哪一句。

## 补上的断言

- `tests/test_turn.py`：压缩重建之后请求上必须仍带着图片。**已反向验证**——把挂图移回压缩之前，测试立刻失败。
- `tests/test_channel_manager.py`：假 Service 此前收下 `image_paths` 却**从不记录**，于是「图片能不能穿过管理器」从来没被验证过；现在记录并断言。

## 验证

`2155 tests, OK (skipped=4)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)