### PR TITLE
docs(phase8): 三端多模态归一化设计——桌面端、飞书、CLI 走同一条路

### DIFF
--- a/docs/engineering/phase-8/20260814_三端多模态归一化设计.md
+++ b/docs/engineering/phase-8/20260814_三端多模态归一化设计.md
@@ -1,0 +1,313 @@
+# 三端多模态归一化设计：桌面端、飞书、CLI 用同一条路
+
+> 文档日期：2026-08-14
+> 状态：**DESIGN**
+> 关联：`20260814_多模态输入统一设计.md`（那一份从飞书事故出发，本份补上三端归一化）
+> 触发：飞书图片连续三次静默失效之后回头看，发现根子不在飞书，在**三端各走各的路**。
+
+---
+
+## 1. 问题不是"飞书有 bug"，是"有两套媒体机制"
+
+`TurnService.handle` 的签名把问题摆在明面上：
+
+```python
+async def handle(
+    self, user_id, text, conversation_id, on_text=None, *,
+    on_event=None,
+    attachments: tuple[tuple[str, str], ...] = (),      # 桌面端：artifact_id + filename
+    image_paths: tuple[tuple[Path, str], ...] = (),     # 飞书：本地路径 + mime
+) -> TurnResult:
+```
+
+**同一个入口，并排挂着两套互不相干的媒体参数。** 往下走也是两套：
+
+| | 桌面端 | 飞书 |
+| --- | --- | --- |
+| 入口参数 | `attachments` | `image_paths` |
+| 载体 | ArtifactStore（持久、有校验） | 系统临时目录（1 小时后消失） |
+| 读取函数 | `build_image_parts` | `build_image_parts_from_paths` |
+| 内容哈希 | Store 记录的 `content_hash`，读时校验 | 当场算，不校验 |
+| 重启后 | 还在 | 丢失（`_pending_images` 只在内存） |
+| 非图片附件 | 落成 Artifact，模型可 `read_artifact` | **直接丢弃** |
+
+CLI 是第三种情况：**两套都没有**。`lobster0` 命令行没有任何附件参数，`handle` 的
+两个媒体参数在 CLI 路径上永远是空的。
+
+### 这直接导致了三次事故
+
+三次静默失效都发生在飞书那一套上，而桌面端那一套一直是好的。原因很简单：
+**桌面端那套走 ArtifactStore，有持久化、有校验、有测试；飞书那套是新拉的一条平行路径，
+每一环都得重新做一遍，于是每一环都漏了点东西。**
+
+第三次尤其说明问题——`turn.py` 里两套挂图代码紧挨着：
+
+```python
+if summaries and self._artifacts is not None:      # 桌面端
+    request = attach_images_to_request(request, build_image_parts(...))
+if image_paths:                                    # 飞书
+    request = attach_images_to_request(request, build_image_parts_from_paths(...))
+```
+
+两块都挂在压缩之前，于是**两端一起丢图**。桌面端没被发现，只是因为桌面端会话短、
+没触发压缩。同一个 bug 埋在两个地方，修的时候必须记得改两处——这本身就是设计缺陷。
+
+---
+
+## 2. 目标
+
+1. **一种媒体，一条路**：三端产出同一种中间表示，`turn.py` 只有一段挂载代码。
+2. **消息类型是一等公民**：图片、语音、语音转写、文件各自有明确的类型与行为，
+   而不是"能识别的走图片，不能识别的丢掉"。
+3. **加一个渠道 = 写一个翻译函数**，不需要碰媒体管线。
+4. **静默丢弃归零**：任何不支持的东西都要让 Owner 知道。
+
+### 非目标
+
+- 不做媒体**生成**（模型产出图片/语音），只做输入。
+- 不做实时语音通话。
+- 不在本设计里换视觉模型或 ASR 供应商——那是配置，不是架构。
+
+---
+
+## 3. 核心：三端都翻译成 `InboundMedia`
+
+```
+桌面端选文件 ─┐
+飞书发消息  ─┼─→ MediaRef ──(取回)──→ InboundMedia ──(按类型)──→ ModelPart
+CLI 传路径  ─┘   (引用，无内容)        (Artifact，持久)          (模型能吃的)
+```
+
+### 3.1 `MediaRef`：渠道给出的引用，不含内容
+
+每个渠道只负责把自己的原生结构翻译成这个：
+
+```python
+@dataclass(frozen=True, slots=True)
+class MediaRef:
+    kind: Literal["image", "audio", "file", "video", "sticker"]
+    # 渠道内的定位符：飞书是 file_key，桌面/CLI 是本地绝对路径
+    locator: str
+    filename: str | None = None
+    declared_mime: str | None = None
+    duration_ms: int | None = None   # 语音/视频
+```
+
+**三端的翻译函数：**
+
+| 渠道 | 原生结构 | 翻译 |
+| --- | --- | --- |
+| 飞书 | `ResourceDescriptor(type, file_key)` | `kind=type, locator=file_key` |
+| 桌面端 | 用户选中的本地文件路径 | `kind` 由 magic byte 判定，`locator=路径` |
+| CLI | `--attach <path>` 参数 | 同桌面端 |
+| Telegram | `file_id` | `locator=file_id` |
+| Discord | attachment URL | `locator=url` |
+
+**引用不含内容**，所以构造它零成本：判断"这条消息带没带图"不需要下载。
+准入检查（谁发的、私聊还是群聊）在这一层完成，**下载永远在准入之后**——
+否则陌生人发一张图就能让我们跑一次网络和磁盘。
+
+### 3.2 `InboundMedia`：统一落成 Artifact，与消息一起持久化
+
+取回之后，**三端一律落进 ArtifactStore**，不再有"临时目录"这条平行路径：
+
+```python
+@dataclass(frozen=True, slots=True)
+class InboundMedia:
+    artifact_id: str
+    kind: str
+    mime_type: str
+    content_hash: str
+    size: int
+    # 语音专用：转写结果与它的来源
+    transcript: str | None = None
+    transcript_engine: str | None = None
+```
+
+**为什么统一走 Artifact，而不是统一走临时路径：**
+
+- 临时目录 1 小时后消失，事后无法复查——这次排查里我一度据此错误判断"没下载过"；
+- Artifact 有内容哈希、有大小上限、有 magic byte 校验，这些飞书那条路全都没有；
+- 重启后仍在，`_pending_images` 那种"只在内存"的丢失不会再发生；
+- 模型已经有 `read_artifact` 工具，非图片附件天然可用。
+
+代价是飞书的图要多写一次磁盘（从 SDK 缓存拷进 Artifact）。**这个代价值得**：
+换来的是三端共用一套校验、一套持久化、一套测试。
+
+媒体与入站事件一起持久化，新增 `inbound_media` 表：
+
+| 列 | 说明 |
+| --- | --- |
+| `id` | 主键 |
+| `session_id` / `message_id` | 归属 |
+| `artifact_id` | 指向 ArtifactStore |
+| `kind` / `mime_type` / `size` | 类型与大小 |
+| `transcript` | 语音转写结果，可空 |
+| `transcript_engine` | 哪个引擎转的，可空 |
+| `created_at` | |
+
+### 3.3 `ModelPart`：只有模型真正能吃的东西
+
+```python
+if media.kind == "image":     → ImagePart（挂到最后一条 user 消息）
+if media.kind == "audio":     → 转写文本并入正文，音频本身不发给模型
+其余                          → 只进上下文的文字摘要，模型按需 read_artifact
+```
+
+**挂载点必须是"请求最终定型的那一刻"。** 压缩、重试、子 Agent 派发都会重建
+`request`，挂早了会被无声扫掉——这是第三次事故的直接教训，已在 #58 修复。
+
+---
+
+## 4. 消息类型：逐一定义行为
+
+### 4.1 图片
+
+| 项 | 决定 |
+| --- | --- |
+| 格式 | png / jpeg / **webp / heic**（heic 是 iPhone 默认，现在会被丢） |
+| 单张上限 | 8 MB |
+| 单轮张数 | 最多 4 张，超出的明确告知而不是静默截断 |
+| 路由 | 请求带图 → 自动切视觉模型；未配置视觉后端时**直接失败**，不回退 |
+
+**为什么不回退到文本模型**：文本模型收到图不会报错，它只会照着上下文编一个像样的
+回答，Owner 会以为它真看过。宁可失败。
+
+### 4.2 语音：转写，而不是直接喂给模型
+
+```
+语音消息 → 落 Artifact → ASR 转写 → 转写文本进入正文 → 正常文本轮次
+```
+
+**为什么不把音频直接发给多模态模型：**
+
+1. **可纠正**：转写文本会展示给 Owner。听错了你能看见、能改；直接喂音频，
+   它听岔了你完全不知道，只会觉得"它答非所问"。
+2. **可复查**：转写落库，事后能对照。
+3. **成本**：ASR 比多模态模型便宜一个量级。
+4. **可替换**：ASR 引擎是可插拔的配置，不绑死在某个模型供应商上。
+
+**转写进入正文的形态**（正文即 Owner 说的话，不加装饰）：
+
+```
+[语音 12 秒] 帮我看看昨天那个部署脚本还有没有问题
+```
+
+前缀让 Owner 一眼看出这轮来自语音——转写出错时能立刻意识到是听错了，
+而不是以为模型理解能力有问题。
+
+**转写失败**：明确回一句"这条语音没能转成文字"，**不猜内容**。与图片取不回时的
+处理一致——静默失败最终会变成可信度问题。
+
+**三端语音入口**（原文档写"桌面/CLI 语音不适用"是错的）：
+
+| 渠道 | 入口 |
+| --- | --- |
+| 飞书 | 语音消息 |
+| 桌面端 | 按住录音 → 落成本地 wav → 同一条路 |
+| CLI | `lobster0 chat --attach voice.m4a` |
+
+### 4.3 语音转文字（独立能力）
+
+转写不只服务于"发语音提问"，它本身是一个 Owner 会直接要的能力：
+把一段录音转成文字。因此 ASR 做成**独立组件**而不是语音消息处理的内部步骤：
+
+- 消息路径：语音 → 转写 → 进对话
+- 工具路径：模型可调 `transcribe_audio(artifact_id)` 转写任意已上传音频
+
+两条路共用同一个引擎、同一份配额与错误码。
+
+### 4.4 文件
+
+落成 Artifact，上下文里只放一行摘要（文件名、类型、大小），模型需要时用
+`read_artifact` 按需读取。**不把文件内容一股脑塞进上下文**——一个 2 MB 的日志
+能把整轮预算烧光。
+
+### 4.5 视频、表情包
+
+**明确告知不支持**，不静默丢弃。一句"暂不支持视频，可以把关键帧截图发给我"，
+比什么都不说强得多。
+
+---
+
+## 5. 三端归一化后的样子
+
+`TurnService.handle` 的两个媒体参数合成一个：
+
+```python
+async def handle(
+    self, user_id, text, conversation_id, on_text=None, *,
+    on_event=None,
+    media: tuple[InboundMedia, ...] = (),   # 三端唯一入口
+) -> TurnResult:
+```
+
+`turn.py` 里两段挂图代码合成一段。两个构造函数
+（`build_image_parts` / `build_image_parts_from_paths`）合成一个。
+
+### 各端要做的改动
+
+| 端 | 现状 | 改动 |
+| --- | --- | --- |
+| 桌面端 | 已走 Artifact，机制正确 | `attachments` 元组换成 `InboundMedia`；加录音入口 |
+| 飞书 | 走临时目录，平行路径 | 取回后拷进 Artifact，删掉 `_pending_images` 与 `image_paths` |
+| CLI | 完全没有 | 新增 `--attach <path>`，复用桌面端的 staging 逻辑 |
+
+**桌面端那一套是对的，飞书应该并过去，而不是反过来。**
+
+---
+
+## 6. 观测
+
+已实现的 `ChannelObserver.media` 保留并推广到三端：`descriptor → resolved` 两个计数
+加可区分的失败码。语音再加两个：`transcribe_ok` / `transcribe_failed`（含引擎与耗时）。
+
+**成功也要记。** 只记失败的话，"什么都没发生"依然无从判断——这正是前几次排查
+卡住的地方。
+
+---
+
+## 7. 落地顺序
+
+| 步骤 | 内容 | 前置 |
+| --- | --- | --- |
+| 0 | **真机验证图片链路**（#58 已修但未验证） | — |
+| 1 | 不支持的类型改为明确告知，消灭静默丢弃 | — |
+| 2 | `MediaRef` / `InboundMedia` + `inbound_media` 表（迁移 v15） | — |
+| 3 | 飞书图片并入 Artifact，删掉平行路径 | 2 |
+| 4 | 桌面端 `attachments` 迁到 `InboundMedia`，`handle` 合并参数 | 2、3 |
+| 5 | CLI `--attach` | 4 |
+| 6 | 图片格式扩到 webp/heic | 3 |
+| 7 | ASR 组件 + 语音消息 + `transcribe_audio` 工具 | 2 |
+| 8 | Telegram / Discord 翻译函数 | 4 |
+
+**步骤 0 排在最前不是形式**：地基没验证通过之前，上面每一层都是空中楼阁。
+步骤 1 单独提前，是因为它改动小、价值大——至少 Owner 能知道自己发的东西没被收到。
+
+---
+
+## 8. 测试策略
+
+延续前一份文档的四条，并强化一条最贵的教训：
+
+**分层全绿不等于端到端可用。** 第三次事故里，下载、观测、Manager 透传、视觉后端
+配置逐段验证全部通过，于是得出"链路是通的"这个错误结论——而丢图的那一步
+（压缩重建）没有任何断言。
+
+因此归一化之后必须有一条**跨越全部三端**的端到端断言：
+
+```
+三端各造一条带媒体的消息 → 走完整 handle → 断言最终 request 上带着预期的 ModelPart
+```
+
+三端共用一条路之后，这条断言才写得出来——这也是归一化本身的价值之一：
+**不是少写几行代码，是让"验证它真的能用"这件事变得可能。**
+
+---
+
+## 9. 明确不做
+
+- 不做媒体生成。
+- 不做实时语音通话。
+- 不为了"看起来支持"而把视频抽帧当图片处理——那是另一个量级的工程。
+- 不在管线里做图片内容审核；安全边界是"谁能发"，不是"发了什么"。


### PR DESCRIPTION
## 为什么还要一份

前一份设计从飞书事故出发，桌面端和 CLI 只是捎带，矩阵里甚至把「桌面/CLI」并成一列、把语音标成「不适用」。回头看，**根子不在飞书，在三端各走各的路**。

## 问题就摆在签名上

```python
async def handle(
    self, user_id, text, conversation_id, on_text=None, *,
    attachments: tuple[tuple[str, str], ...] = (),      # 桌面端：走 ArtifactStore
    image_paths: tuple[tuple[Path, str], ...] = (),     # 飞书：走系统临时目录
)
```

同一个入口，两套互不相干的媒体参数。往下是两套载体、两个构造函数、两条挂载代码。CLI 是第三种：**两套都没有**。

| | 桌面端 | 飞书 |
| --- | --- | --- |
| 载体 | ArtifactStore（持久、有校验） | 临时目录（1 小时后消失） |
| 内容哈希 | 有，读时校验 | 当场算，不校验 |
| 重启后 | 还在 | 丢失 |
| 非图片附件 | 落 Artifact，可 `read_artifact` | **直接丢弃** |

**三次静默失效全部发生在飞书那一套上**，桌面端一直是好的——因为桌面端那条路有持久化、有校验、有测试；飞书那条是新拉的平行路径，每一环都要重做一遍，于是每一环都漏了点东西。

第三次尤其说明问题：`turn.py` 里两段挂图代码紧挨着，**都挂在压缩之前，两端一起丢图**。桌面端没被发现只是因为会话短、没触发压缩。同一个 bug 埋在两个地方。

## 设计

```
桌面端选文件 ─┐
飞书发消息  ─┼─→ MediaRef ──(取回)──→ InboundMedia ──(按类型)──→ ModelPart
CLI 传路径  ─┘   (引用，无内容)        (Artifact，持久)          (模型能吃的)
```

飞书的图要多写一次磁盘。**这个代价值得**——换来三端共用一套校验、持久化与测试。桌面端那套是对的，飞书并过去，不是反过来。

逐类型定义了行为：

- **图片**：扩到 webp/heic（heic 是 iPhone 默认，现在被丢）
- **语音**：转写而非直接喂模型——可纠正、可复查、成本低一个量级、引擎可替换
- **语音转文字**：独立组件，消息路径与 `transcribe_audio` 工具路径共用
- **文件**：落 Artifact 按需读，不塞满上下文
- **视频/表情包**：明确告知不支持，不静默丢弃

修正前一份的一处错误：桌面/CLI 语音不是「不适用」——桌面端按住录音、CLI `--attach voice.m4a`，都是真实入口。

## 归一化的真正价值

三端共用一条路之后，才写得出「跨越全部三端的端到端断言」。第三次事故里逐段验证全部通过却仍然丢图，正是因为丢图那一步没有断言。

**不是少写几行代码，是让「验证它真的能用」这件事变得可能。**

## 落地顺序

步骤 0 是**真机验证图片链路**（#58 已修但未验证）——地基没验证通过之前，上面每一层都是空中楼阁。步骤 1 是消灭静默丢弃，改动小价值大。

🤖 Generated with [Claude Code](https://claude.com/claude-code)